### PR TITLE
Tweak YellowGreen line in color-names to simplify test

### DIFF
--- a/spec/libsass/color-names/input.scss
+++ b/spec/libsass/color-names/input.scss
@@ -139,5 +139,5 @@ colors {
   White:   #FFFFFF + 0;
   WhiteSmoke:  #F5F5F5 + 0;
   Yellow:  #FFFF00 + 0;
-  YellowGreen:   #9ACD32
+  YellowGreen:   #9ACD32 + 0;
 }


### PR DESCRIPTION
The YellowGreen line in the color-names test differed from all the other name tests in that it doesn't perform a mathematical operation; this means this line isn't neutral on whether hex codes should be left as-is or converted to colour names if processed without any needed changes (tested in other tests).  Adding the + 0 keeps the test neutral by ensuring conversion always occurs.

(This allows https://github.com/hcatlin/libsass/pull/172 to still function on the YellowGreen line, matching otherwise-expected behaviour and deferring late/early processing until https://github.com/nex3/sass/issues/363 is actioned and covered by other tests)
