### PR TITLE
Adding test for nested placeholder

### DIFF
--- a/spec/libsass/placeholder-nested/expected_output.css
+++ b/spec/libsass/placeholder-nested/expected_output.css
@@ -1,0 +1,4 @@
+.foo {
+  width: 100px; }
+  .foo .bar {
+    height: 100px; }

--- a/spec/libsass/placeholder-nested/input.scss
+++ b/spec/libsass/placeholder-nested/input.scss
@@ -1,0 +1,13 @@
+%x {
+  width: 100px;
+
+  %y {
+    height: 100px;
+  }
+}
+
+.foo {
+  @extend %x;
+
+  .bar { @extend %y }
+}


### PR DESCRIPTION
Although support for basic placeholders exists in libsass it fails when it comes to nested placeholders. I thought I'd add the test for that.
