### PR TITLE
Added test for placeholders inside media queries

### DIFF
--- a/spec/libsass/placeholder-mediaquery/expected_output.css
+++ b/spec/libsass/placeholder-mediaquery/expected_output.css
@@ -1,0 +1,3 @@
+@media screen and (min-width: 300px) {
+  bar {
+    max-width: 80%; } }

--- a/spec/libsass/placeholder-mediaquery/input.scss
+++ b/spec/libsass/placeholder-mediaquery/input.scss
@@ -1,0 +1,9 @@
+%foo {
+	@media screen and (min-width: 300px) {
+		max-width: 80%;
+	}
+}
+
+bar {
+	@extend %foo;
+}


### PR DESCRIPTION
Related to hcatlin/libsass#316

This adds tests that pass in SASS 3.3.1/3.2.15 but fail in libsass. Wasn't sure if I should put them in `spec/libsass` or `spec/todo` so went with `spec/libsass`, feel free to let me know if you want them changed.
