### PR TITLE
add tests for CSS native filter functions

### DIFF
--- a/spec/libsass/filter-functions/expected_output.css
+++ b/spec/libsass/filter-functions/expected_output.css
@@ -1,0 +1,5 @@
+div {
+  hoo: grayscale(0.3) grayscale(200%);
+  moo: opacity(0.3) opacity(200%);
+  poo: invert(0.3) invert(200%);
+  goo: saturate(0.3) saturate(200%); }

--- a/spec/libsass/filter-functions/input.scss
+++ b/spec/libsass/filter-functions/input.scss
@@ -1,0 +1,6 @@
+div {
+  hoo: grayscale(0.3) grayscale(200%);
+  moo: opacity(0.3) opacity(200%);
+  poo: invert(0.3) invert(200%);
+  goo: saturate(0.3) saturate(200%);
+}


### PR DESCRIPTION
Add tests to verify that attempts to use native CSS filter functions,
like `grayscale(20%)`, are properly passed through to CSS unchanged,
rather than interpreted as the Sass function `grayscale` that operates
on colors.

Fixes compatibility with Ruby Sass.

Original issue reported in sass/libsass#151. These tests pass with
sass/libsass#467.
