### PR TITLE
exit with failure code when minitest fails

### DIFF
--- a/lib/sass_spec/runner.rb
+++ b/lib/sass_spec/runner.rb
@@ -23,7 +23,7 @@ class SassSpec::Runner
       minioptions.push '--verbose'
     end
 
-    Minitest.run(minioptions)
+    exit Minitest.run(minioptions)
   end
 
   def _get_cases


### PR DESCRIPTION
This is causing Travis to report false positives. Ahh!

See: sass/libsass#468.
