### PR TITLE
Made test name more obviously reflect directory structure.

### DIFF
--- a/lib/sass_spec/test.rb
+++ b/lib/sass_spec/test.rb
@@ -30,7 +30,7 @@ class SassSpec::Test < Minitest::Test
   parallelize_me!
   def self.create_tests(test_cases, options = {})
     test_cases.each do |test_case|
-      define_method('test_' + test_case.name) do
+      define_method('test__' << test_case.name) do
         run_spec_test(test_case, options)
       end
     end

--- a/lib/sass_spec/test_case.rb
+++ b/lib/sass_spec/test_case.rb
@@ -8,7 +8,7 @@ class SassSpec::TestCase
   end
 
   def name
-    @input_path.dirname.to_s.sub(Dir.pwd + "/", "").gsub('/', '_')
+    @input_path.dirname.to_s.sub(Dir.pwd + "/", "")
   end
 
   def input_path


### PR DESCRIPTION
This changes test output from

```
SassSpec::Test#test_spec_basic_56_global_variable_exists
```

to

```
SassSpec::Test#test__spec/basic/56_global_variable_exists
```

To newcomers, this makes it easier to determine where to find the files for failing tests.
