### PR TITLE
Output Sass version from executable before running tests.

### DIFF
--- a/lib/sass_spec/runner.rb
+++ b/lib/sass_spec/runner.rb
@@ -13,6 +13,9 @@ class SassSpec::Runner
   def run
     unless @options[:silent]
       puts "Recursively searching under directory '#{@options[:spec_directory]}' for test files to test '#{@options[:sass_executable]}' with."
+
+      stdout, stderr, status = Open3.capture3("#{@options[:sass_executable]} -v")
+      puts stdout
     end
 
     test_cases = _get_cases


### PR DESCRIPTION
It will help to know with certainty the version of the executable you're running. 'sass' may resolve to a different bin than you expect, or you may just want confirmation that 'bundle exec sass' is working for you.

Currently, sassc does not appear to have a `-v` flag, so that's something that will have to be added.
