### PR TITLE
Test for list-separator

### DIFF
--- a/spec/libsass/list-separator/expected_output.css
+++ b/spec/libsass/list-separator/expected_output.css
@@ -1,0 +1,5 @@
+div {
+  _list-space: space;
+  _list-comma: comma;
+  _single-item: space;
+}

--- a/spec/libsass/list-separator/input.scss
+++ b/spec/libsass/list-separator/input.scss
@@ -1,0 +1,9 @@
+$list: foo bar baz;
+$list--comma: foo, bar, baz;
+$single: foo;
+
+div {
+  _list-space: list-separator($list);
+  _list-comma: list-separator($list--comma);
+  _single-item: list-separator($single);
+}


### PR DESCRIPTION
The `list-separator` function is needed in order for [Breakpoint](https://github.com/at-import/breakpoint) to work, amongst others
