### PR TITLE
Re-add specs for list_separator

### DIFF
--- a/spec/libsass-todo-issues/issue_506/expected_output.css
+++ b/spec/libsass-todo-issues/issue_506/expected_output.css
@@ -1,0 +1,5 @@
+div {
+  _list-space: space;
+  _list-comma: comma;
+  _single-item: space;
+}

--- a/spec/libsass-todo-issues/issue_506/input.scss
+++ b/spec/libsass-todo-issues/issue_506/input.scss
@@ -1,0 +1,9 @@
+$list: foo bar baz;
+$list--comma: foo, bar, baz;
+$single: foo;
+
+div {
+  _list-space: list-separator($list);
+  _list-comma: list-separator($list--comma);
+  _single-item: list-separator($single);
+}


### PR DESCRIPTION
Re-add list_separator specs (in the correct folder) which were inadvertently deleted in 66b721972424e9f03cf4135e635f166fea929b5a
