### PR TITLE
Add test for nested media query logical combination

### DIFF
--- a/spec/libsass-todo-issues/issue_185/expected_output.css
+++ b/spec/libsass-todo-issues/issue_185/expected_output.css
@@ -1,0 +1,6 @@
+@media screen and (min-width: 20em) {
+  .foo {
+    bar: baz; } }
+@media only screen and (min-width: 20em) and (max-width: 40em) {
+  .bim {
+    bam: boom; } }

--- a/spec/libsass-todo-issues/issue_185/input.scss
+++ b/spec/libsass-todo-issues/issue_185/input.scss
@@ -1,0 +1,17 @@
+@media screen {
+  @media (min-width: 20em) {
+    .foo {
+      bar: baz;
+    }
+    @media only screen and (max-width: 40em) {
+      .bim {
+        bam: boom;
+      }
+    }
+    @media print {
+      .biz {
+        blag: blog;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Nesting media queries combines queries in a manner similar to nesting selectors, but with some logical evaluation of the parameters. 

In the test example the repetition of `screen` is taken in to account, while the logically conflicting `print` declaration is left out, and `min-width`/`max-width` queries are combined with `and`.

https://github.com/sass/libsass/issues/185
