### PR TITLE
Add specs for issue 487

### DIFF
--- a/spec/libsass-todo-issues/issue_487/expected_output.css
+++ b/spec/libsass-todo-issues/issue_487/expected_output.css
@@ -1,0 +1,9 @@
+
+[flex] {
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+  -moz-box-flex: 1;
+  -moz-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}

--- a/spec/libsass-todo-issues/issue_487/input.scss
+++ b/spec/libsass-todo-issues/issue_487/input.scss
@@ -1,0 +1,13 @@
+
+@mixin flex($grow: 1, $shrink: null, $basis: null) {
+  -webkit-box-flex: $grow;
+  -webkit-flex: $grow $shrink $basis;
+  -moz-box-flex: $grow;
+  -moz-flex: $grow $shrink $basis;
+  -ms-flex: $grow $shrink $basis;
+  flex: $grow $shrink $basis;
+}
+
+[flex] {
+  @include flex;
+}


### PR DESCRIPTION
This PR adds specs for https://github.com/sass/libsass/issues/487

This issue is only relevant for compressed output modes. IMHO this is relevant to the conversation in https://github.com/sass/sass-spec/issues/82.
