### PR TITLE
Update the spec for libsass#512

### DIFF
--- a/spec/libsass-todo-issues/issue_512/expected_output.css
+++ b/spec/libsass-todo-issues/issue_512/expected_output.css
@@ -1,2 +1,3 @@
 .css {
-  debug: 1; }
+  debug: 1;
+  debug: foo; }

--- a/spec/libsass-todo-issues/issue_512/input.scss
+++ b/spec/libsass-todo-issues/issue_512/input.scss
@@ -1,5 +1,8 @@
 $list: a b c;
 .css {
   debug: index($list, a);
-  debug: index($list, 2);
+
+  @if type-of(index($list, 2)) == "null" {
+    debug: foo;
+  }
 }


### PR DESCRIPTION
This PR updates the spec for issue 512. The current spec is correct for ruby sass 3.4 but it doesn't account for existing issues with libsass' treatment of null https://github.com/sass/libsass/issues/113

This is another weird edge case that we need a better way of addressing - relevant issue https://github.com/sass/sass-spec/issues/82
