### PR TITLE
Fix the spec for index to match ruby sass 3.3 behaviour

### DIFF
--- a/spec/scss/index/expected_output.css
+++ b/spec/scss/index/expected_output.css
@@ -1,4 +1,4 @@
 div {
   foo: 2;
-  bar: false;
+  bar: null;
   baz: 3; }


### PR DESCRIPTION
This PR updates the spec for `index` to match the ruby sass 3.3 behaviour.
