### PR TITLE
Add spec for functions as map keys

### DIFF
--- a/spec/libsass-todo-issues/issue_555/expected_output.css
+++ b/spec/libsass-todo-issues/issue_555/expected_output.css
@@ -1,0 +1,3 @@
+a {
+  foo: baz;
+  bob: bam; }

--- a/spec/libsass-todo-issues/issue_555/input.scss
+++ b/spec/libsass-todo-issues/issue_555/input.scss
@@ -1,0 +1,14 @@
+
+@function hello($name) {
+    @return $name;
+}
+
+$foo: (
+  bar() : baz ,
+  hello("bob") : bam,
+);
+
+a {
+  foo: map-get($foo, "bar()");
+  foo: map-get($foo, "bob");
+}


### PR DESCRIPTION
This PR add spec for functions as map keys as reported in https://github.com/sass/libsass/issues/555
