### PR TITLE
Add specs for issue 535

### DIFF
--- a/spec/libsass-todo-issues/issue_535/expected_output.css
+++ b/spec/libsass-todo-issues/issue_535/expected_output.css
@@ -1,0 +1,2 @@
+.test {
+  margin-left: -541; }

--- a/spec/libsass-todo-issues/issue_535/input.scss
+++ b/spec/libsass-todo-issues/issue_535/input.scss
@@ -1,0 +1,5 @@
+$width: 10;
+
+.test {
+  margin-left: - 54 * $width - 1;
+}


### PR DESCRIPTION
This PR add spec for https://github.com/sass/libsass/issues/535.

Libsass doesn't correctly parse `- 54` as `-54`.
