### PR TITLE
Add specs for issue 548

### DIFF
--- a/spec/libsass-todo-issues/issue_548/expected_output.css
+++ b/spec/libsass-todo-issues/issue_548/expected_output.css
@@ -1,0 +1,6 @@
+.parent-sel-value {
+  font-family: .parent-sel-value; }
+  .parent-sel-value .parent-sel-interpolation {
+    font-family: .parent-sel-value .parent-sel-interpolation; }
+    .parent-sel-value .parent-sel-interpolation .parent-sel-value-concat {
+      font-family: "Current parent: .parent-sel-value .parent-sel-interpolation .parent-sel-value-concat"; }

--- a/spec/libsass-todo-issues/issue_548/input.scss
+++ b/spec/libsass-todo-issues/issue_548/input.scss
@@ -1,0 +1,9 @@
+.parent-sel-value {
+  font-family: &;
+  .parent-sel-interpolation {
+    font-family: #{&};
+     .parent-sel-value-concat {
+        font-family: "Current parent: " + &;
+     }
+  }
+}


### PR DESCRIPTION
This PR add specs for https://github.com/sass/libsass/issues/548.

Libsass doesn't support `&` SassScript selector added in ruby sass 3.4.
