### PR TITLE
Add specs for issue 549

### DIFF
--- a/spec/libsass-todo-issues/issue_549/expected_output.css
+++ b/spec/libsass-todo-issues/issue_549/expected_output.css
@@ -1,0 +1,2 @@
+foo {
+  filter: foo(opacity=1000); }

--- a/spec/libsass-todo-issues/issue_549/input.scss
+++ b/spec/libsass-todo-issues/issue_549/input.scss
@@ -1,0 +1,5 @@
+$value: 10;
+
+foo {
+  filter: foo(opacity=$value*100);
+}


### PR DESCRIPTION
This PR adds specs for https://github.com/sass/libsass/issues/549.

Libsass doesn't correctly parse the arrhythmic in function arguments.
