### PR TITLE
Add specs for \ in identifiers

### DIFF
--- a/spec/libsass-closed-issues/issue_602/expected_output.css
+++ b/spec/libsass-closed-issues/issue_602/expected_output.css
@@ -1,0 +1,14 @@
+#foo.\bar {
+  color: red; }
+
+#foo.b\ar {
+  color: red; }
+
+#foo\.bar {
+  color: red; }
+
+#foo\bar {
+  color: red; }
+
+#fo\o.bar {
+  color: red; }

--- a/spec/libsass-closed-issues/issue_602/input.scss
+++ b/spec/libsass-closed-issues/issue_602/input.scss
@@ -1,0 +1,19 @@
+#foo.\bar {
+  color: red;
+}
+
+#foo.b\ar {
+  color: red;
+}
+
+#foo\.bar {
+  color: red;
+}
+
+#foo\bar {
+  color: red;
+}
+
+#fo\o.bar {
+  color: red;
+}


### PR DESCRIPTION
This PR adds specs for asserting we correctly handle `\` in identifiers. Addressed https://github.com/sass/libsass/issues/602.
