### PR TITLE
Add specs for issue 610

### DIFF
--- a/spec/libsass-todo-issues/issue_610/expected_output.css
+++ b/spec/libsass-todo-issues/issue_610/expected_output.css
@@ -1,0 +1,47 @@
+foo {
+  a: a;
+  b: b;
+  c: c;
+  d: d; }
+
+foo {
+  a: a;
+  b: b;
+  c: c;
+  d: d; }
+
+foo {
+  a: a;
+  b: b;
+  c: c;
+  d: d; }
+
+foo {
+  a: a;
+  b: b;
+  c: c;
+  d: d; }
+
+foo {
+  a: a;
+  b: b;
+  c: c;
+  d: d; }
+
+foo {
+  a: a;
+  b: b;
+  c: c;
+  d: d; }
+
+foo {
+  a: a;
+  b: b;
+  c: c;
+  d: d; }
+
+foo {
+  a: a;
+  b: b;
+  c: c;
+  d: d; }

--- a/spec/libsass-todo-issues/issue_610/input.scss
+++ b/spec/libsass-todo-issues/issue_610/input.scss
@@ -1,0 +1,38 @@
+@mixin vararg-test($a, $b, $c, $d) {
+  a: $a;
+  b: $b;
+  c: $c;
+  d: $d;
+}
+
+foo {
+  @include vararg-test(a, b, c, d);
+}
+
+foo {
+  @include vararg-test(a b c d...);
+}
+
+foo {
+  @include vararg-test((a b c d)...);
+}
+
+foo {
+  @include vararg-test((a, b, c, d)...);
+}
+
+foo {
+  @include vararg-test((a: a, b: b, c: c, d: d)...);
+}
+
+foo {
+  @include vararg-test(a b..., (c: c, d: d)...);
+}
+
+foo {
+  @include vararg-test(a, b c..., (d: d)...);
+}
+
+foo {
+  @include vararg-test($c: c, (a: a, b: b, d: d)...);
+}


### PR DESCRIPTION
This PR add specs for supporting varargs and keyword arguments in a single call. Address https://github.com/sass/libsass/issues/610.
