### PR TITLE
Add specs for nth with maps

### DIFF
--- a/spec/libsass-closed-issues/issue_643/expected_output.css
+++ b/spec/libsass-closed-issues/issue_643/expected_output.css
@@ -1,0 +1,2 @@
+foo {
+  a: bar baz; }

--- a/spec/libsass-closed-issues/issue_643/input.scss
+++ b/spec/libsass-closed-issues/issue_643/input.scss
@@ -1,0 +1,5 @@
+$map: (foo: bar, bar: baz);
+
+foo {
+  a: nth($map, 2);
+}


### PR DESCRIPTION
This PR add specs for `nth` with maps (https://github.com/sass/libsass/issues/643).
