### PR TITLE
Create expected_output.css

### DIFF
--- a/spec/maps/keywords/expected_output.css
+++ b/spec/maps/keywords/expected_output.css
@@ -1,0 +1,3 @@
+does-it-work {
+  answer: "Yep";
+}


### PR DESCRIPTION
When passing non-keyword arguments to keyword( $args ) the expected result is an empty map  "( )" – like when no arguments are passed – Throws:   "Error: basic_string::basic_string"
