### PR TITLE
Add and activate specs for unique-id()

### DIFF
--- a/spec/libsass-closed-issues/issue_636/expected_output.scss
+++ b/spec/libsass-closed-issues/issue_636/expected_output.scss
@@ -1,0 +1,5 @@
+foo {
+  is-defined: true;
+  is-string: true;
+  starts-with-character: true;
+  is-unique: true; }

--- a/spec/libsass-closed-issues/issue_636/input.scss
+++ b/spec/libsass-closed-issues/issue_636/input.scss
@@ -1,0 +1,19 @@
+
+foo {
+    $id: unique-id();
+    $is-string: type-of($id) == string;
+    $starts-with-character: str_slice($id, 0, 1) == "u";
+    $is-unique: $id != unique-id();
+
+    @for $i from 1 through 1000 {
+        $id: unique-id();
+        $is-string: $is-string and type-of($id) == string;
+        $starts-with-character: $starts-with-character and str_slice($id, 0, 1) == "u";
+        $is-unique: $is-unique and $id != unique-id();
+    }
+
+    is-defined: $id != "unique-id()";
+    is-string: $is-string;
+    starts-with-character: $starts-with-character;
+    is-unique: $is-unique;
+}


### PR DESCRIPTION
This PR implements a naive spec for `unique-id` testing the elements of the function we can reliably determine.
