### PR TITLE
Add and activate specs for random()

### DIFF
--- a/spec/libsass-closed-issues/issue_657/default/expected_output.css
+++ b/spec/libsass-closed-issues/issue_657/default/expected_output.css
@@ -1,0 +1,4 @@
+foo {
+  is-defined: true;
+  is-number: true;
+  is-within-range: true; }

--- a/spec/libsass-closed-issues/issue_657/default/input.scss
+++ b/spec/libsass-closed-issues/issue_657/default/input.scss
@@ -1,0 +1,16 @@
+
+foo {
+    $num: random();
+    $is-number: type-of($num) == number;
+    $is-within-range: $num >= 0 and $num < 1;
+
+    @for $i from 1 through 1000 {
+      $num: random();
+      $is-number: $is-number and type-of($num) == number;
+      $is-within-range: $is-within-range and $num >= 0 and $num < 1;
+    }
+
+    is-defined: $num != "random()";
+    is-number: $is-number;
+    is-within-range: $is-within-range;
+}

--- a/spec/libsass-closed-issues/issue_657/limit/expected_output.css
+++ b/spec/libsass-closed-issues/issue_657/limit/expected_output.css
@@ -1,0 +1,4 @@
+foo {
+  is-defined: true;
+  is-digit: true;
+  is-within-range: true; }

--- a/spec/libsass-closed-issues/issue_657/limit/input.scss
+++ b/spec/libsass-closed-issues/issue_657/limit/input.scss
@@ -1,0 +1,17 @@
+
+foo {
+  $limit: 10;
+  $num: random($limit);
+  $is-digit: type-of($num) == number and floor($num) == $num;
+  $is-within-range: $num >= 1 and $num <= $limit;
+
+  @for $i from 1 through 1000 {
+    $num: random($limit);
+    $is-digit: $is-digit and type-of($num) == number and floor($num) == $num;
+    $is-within-range: $is-within-range and $num >= 1 and $num <= $limit;
+  }
+
+  is-defined: $num != "random(10)";
+  is-digit: $is-digit;
+  is-within-range: $is-within-range;
+}


### PR DESCRIPTION
This PR implements a naive spec for `random` testing the elements of the function we can reliably determine.

Whilst writing this spec I uncovered an issue in the Ruby sass implementation https://github.com/sass/sass/issues/1548. I'm not merging this until I've heard from back about this issue.
