### PR TITLE
Add and activate specs for issue 652

### DIFF
--- a/spec/libsass-closed-issues/issue_652/expected_output.css
+++ b/spec/libsass-closed-issues/issue_652/expected_output.css
@@ -1,0 +1,4 @@
+a {
+  name: true;
+  func: true;
+  hex: true; }

--- a/spec/libsass-closed-issues/issue_652/input.scss
+++ b/spec/libsass-closed-issues/issue_652/input.scss
@@ -1,0 +1,11 @@
+$map: (
+    purple: foo,
+    rgba(1,2,3,1): bar,
+    #ffffff: baz,
+);
+
+a {
+  name: map-get($map, purple) == foo;
+  func: map-get($map, rgba(1,2,3,1)) == bar;
+  hex: map-get($map, #ffffff) == baz;
+}


### PR DESCRIPTION
This PR adds and activates specs for colours as map keys (https://github.com/sass/libsass/issues/652) in preparation for https://github.com/sass/libsass/pull/695.
