### PR TITLE
Add specs for issue 702

### DIFF
--- a/spec/libsass-closed-issues/issue_702/expected_output.css
+++ b/spec/libsass-closed-issues/issue_702/expected_output.css
@@ -1,0 +1,7 @@
+.foo {
+  content: true;
+  content: false;
+  content: false;
+  content: false;
+  content: false;
+}

--- a/spec/libsass-closed-issues/issue_702/input.scss
+++ b/spec/libsass-closed-issues/issue_702/input.scss
@@ -1,0 +1,7 @@
+.foo {
+  content: function-exists("feature-exists");
+  content: feature-exists("global-variable-shadowing");
+  content: feature-exists("extend-selector-pseudoclass");
+  content: feature-exists("units-level-3");
+  content: feature-exists("at-error");
+}


### PR DESCRIPTION
This PR adds and activates specs for `feature-exists` (https://github.com/sass/libsass/issues/702) in preparation for https://github.com/sass/libsass/pull/709.
