### PR TITLE
Add tests for not expression. 

### DIFF
--- a/spec/libsass-todo-issues/issue_680/expected_output.css
+++ b/spec/libsass-todo-issues/issue_680/expected_output.css
@@ -1,0 +1,9 @@
+.test {
+  debug: "truthy";
+  debug: "falsey";
+  debug: "falsey";
+  debug: "truthy";
+  debug: "truthy";
+  debug: "truthy";
+  debug: "truthy";
+  debug: "truthy"; }

--- a/spec/libsass-todo-issues/issue_680/input.scss
+++ b/spec/libsass-todo-issues/issue_680/input.scss
@@ -1,0 +1,20 @@
+// problem: not expression is currently returning false on values other than true, false or null
+
+@function truthyfalsey($bool: null) {
+  @if not $bool {
+    @return 'falsey';
+  } @else {
+    @return 'truthy';
+  }
+}
+
+.test {
+  debug: truthyfalsey(true); // expect truthy
+  debug: truthyfalsey(false); // expect falsey
+  debug: truthyfalsey(); // expect falsey (default arg is null)
+  debug: truthyfalsey(5); // expect truthy
+  debug: truthyfalsey(string); // expect truthy
+  debug: truthyfalsey((alpha: 1, bravo: 2)); // expect truthy
+  debug: truthyfalsey(this is a list); // expect truthy
+  debug: truthyfalsey('true'); // expect truthy
+}


### PR DESCRIPTION
The not expression is currently incorrect in evaluating non-boolean data types.

Issue/PR: http://github.com/sass/libsass/pull/680
