### PR TITLE
Update spec for feature-exists for sass compat

### DIFF
--- a/spec/libsass-closed-issues/issue_702/expected_output.css
+++ b/spec/libsass-closed-issues/issue_702/expected_output.css
@@ -1,7 +1,4 @@
 .foo {
   content: true;
   content: false;
-  content: false;
-  content: false;
-  content: false;
 }

--- a/spec/libsass-closed-issues/issue_702/input.scss
+++ b/spec/libsass-closed-issues/issue_702/input.scss
@@ -1,7 +1,4 @@
 .foo {
   content: function-exists("feature-exists");
-  content: feature-exists("global-variable-shadowing");
-  content: feature-exists("extend-selector-pseudoclass");
-  content: feature-exists("units-level-3");
-  content: feature-exists("at-error");
+  content: feature-exists("foo");
 }


### PR DESCRIPTION
This PR updates the spec for `feature-exists` because it's not compatible with Ruby sass and goes against our goal of being the one true spec suite.

 Originally pointed out by @HugoGiraudel in https://github.com/sass/sass-spec/pull/161#issuecomment-66697922
