### PR TITLE
Add tap output reporter to spec runner

### DIFF
--- a/lib/sass_spec/cli.rb
+++ b/lib/sass_spec/cli.rb
@@ -6,6 +6,7 @@ module SassSpec::CLI
     options = {
       sass_executable: "sass",
       spec_directory: "spec",
+      tap: false,
       skip: false,
       verbose: false,
       filter: "",
@@ -39,6 +40,10 @@ Make sure the command you provide prints to stdout.
 
       opts.on("-v", "--verbose", "Run verbosely") do
         options[:verbose] = true
+      end
+
+      opts.on("-t", "--tap", "Output TAP compatible report") do
+        options[:tap] = true
       end
 
       opts.on("-c", "--command COMMAND", "Sets a specific binary to run (defaults to '#{options[:sass_executable]}')") do |v|

--- a/lib/sass_spec/runner.rb
+++ b/lib/sass_spec/runner.rb
@@ -11,9 +11,8 @@ class SassSpec::Runner
   end
 
   def run
-    unless @options[:silent]
+    unless @options[:silent] || @options[:tap]
       puts "Recursively searching under directory '#{@options[:spec_directory]}' for test files to test '#{@options[:sass_executable]}' with."
-
       stdout, stderr, status = Open3.capture3("#{@options[:sass_executable]} -v")
       puts stdout
     end
@@ -24,6 +23,11 @@ class SassSpec::Runner
     minioptions = []
     if @options[:verbose]
       minioptions.push '--verbose'
+    end
+
+    if @options[:tap]
+      require 'minitap'
+      Minitest.reporter = Minitap::TapY
     end
 
     exit Minitest.run(minioptions)


### PR DESCRIPTION
Adds a command line option to trigger tap compatible reports.
This is related to https://github.com/sass/libsass/pull/169
Alternative to https://github.com/sass/sass-spec/pull/3
