### PR TITLE
add test for libsass issue 736 [fixed]

### DIFF
--- a/spec/libsass-todo-issues/issue_736/expected_output.css
+++ b/spec/libsass-todo-issues/issue_736/expected_output.css
@@ -1,0 +1,4 @@
+.test {
+  out: 'nothing found';
+  out: 'nothing found';
+  out: 'found true'; }

--- a/spec/libsass-todo-issues/issue_736/input.scss
+++ b/spec/libsass-todo-issues/issue_736/input.scss
@@ -1,0 +1,17 @@
+// libsass issue 736:  @return does not cause function exit
+// https://github.com/sass/libsass/issues/736
+
+@function contains-true($list) {
+  @each $bool in $list {
+    @if $bool {
+      @return 'found true';
+    }
+  }
+  @return 'nothing found';
+}
+
+.test {
+  out: contains-true(true false false);
+  out: contains-true(false true false);
+  out: contains-true(false false true);
+}


### PR DESCRIPTION
This is a test for the issue of the `@return` directive failing to exit a function
http://github.com/sass/libsass/issues/736
