### PR TITLE
Add and activate specs for issue 738

### DIFF
--- a/spec/libsass-closed-issues/issue_738/expected_output.css
+++ b/spec/libsass-closed-issues/issue_738/expected_output.css
@@ -1,0 +1,4 @@
+.foo--bar {
+  color: red; }
+.foo--1bar {
+  color: blue; }

--- a/spec/libsass-closed-issues/issue_738/input.scss
+++ b/spec/libsass-closed-issues/issue_738/input.scss
@@ -1,0 +1,4 @@
+.foo {
+  &--bar { color: red; }
+  &--1bar { color: blue;}
+}


### PR DESCRIPTION
This PR adds specs for the correct treatment of BEM style selectors (https://github.com/sass/libsass/issues/738).
