### PR TITLE
Update specs for issue 442 to better address the issue

### DIFF
--- a/spec/libsass-todo-issues/issue_442/expected_output.css
+++ b/spec/libsass-todo-issues/issue_442/expected_output.css
@@ -1,2 +1,4 @@
-.test {
-  margin: 10rem; }
+foo {
+  a: 10rem;
+  a: 10rem;
+  a: false; }

--- a/spec/libsass-todo-issues/issue_442/input.scss
+++ b/spec/libsass-todo-issues/issue_442/input.scss
@@ -1,7 +1,8 @@
-@function measure-margin($scale, $measure, $unit) {
-  @return ($measure/$scale)#{$unit};
-}
+$lhs: (100/10)#{rem};
+$rhs: 10rem;
 
-.test {
-  margin: measure-margin(10, 100, rem);
+foo {
+  a: $lhs;
+  a: $rhs;
+  a: $lhs == $rhs;
 }


### PR DESCRIPTION
This PR updates the specs for https://github.com/sass/libsass/issues/442 to better represent the issue at hand. This update also means the spec is longer whites space sensitive (https://github.com/sass/sass-spec/issues/131) and fails as expected.
