### PR TITLE
Activates specs for issue 760

### DIFF
--- a/spec/libsass-closed-issues/issue_760/expected_output.css
+++ b/spec/libsass-closed-issues/issue_760/expected_output.css
@@ -1,0 +1,3 @@
+foo {
+  quoted: "a";
+  unquoted: a; }

--- a/spec/libsass-closed-issues/issue_760/input.scss
+++ b/spec/libsass-closed-issues/issue_760/input.scss
@@ -1,0 +1,4 @@
+foo {
+  quoted: str-slice("abcd", 1, 0);
+  unquoted: str-slice(abcd, 1, 0);
+}


### PR DESCRIPTION
This PR activates the specs for an edge case with `str-slice` where `$start-at: 1 && $end-at: 0` https://github.com/sass/libsass/issues/760
