### PR TITLE
Activate specs for issue 763

### DIFF
--- a/spec/libsass-closed-issues/issue_763/expected_output.css
+++ b/spec/libsass-closed-issues/issue_763/expected_output.css
@@ -1,0 +1,8 @@
+foo {
+  a: "a";
+  b: "a";
+  c: a;
+  d: "Xabcd";
+  e: "Xabcd";
+  f: "Xabcd";
+  g: "Xabcd"; }

--- a/spec/libsass-closed-issues/issue_763/input.scss
+++ b/spec/libsass-closed-issues/issue_763/input.scss
@@ -1,0 +1,10 @@
+foo {
+  a: str-slice("abcd", 1, 1);
+  b: str-slice('abcd', 1, 1);
+  c: str-slice(abcd, 1, 1);
+
+  d: str-insert("abcd", "X", 1);
+  e: str-insert("abcd", 'X', 1);
+  f: str-insert('abcd', "X", 1);
+  g: str-insert('abcd', 'X', 1);
+}


### PR DESCRIPTION
This PR activates specs for normalising quotes to double quote for str-slice and str-insert https://github.com/sass/libsass/issues/763
