### PR TITLE
Activate specs for issue 759

### DIFF
--- a/spec/libsass-closed-issues/issue_759/expected_output.css
+++ b/spec/libsass-closed-issues/issue_759/expected_output.css
@@ -1,0 +1,6 @@
+foo {
+  a: 10px;
+  b: 20px;
+  c: 30px;
+  d: 40px;
+  e: 50px; }

--- a/spec/libsass-closed-issues/issue_759/input.scss
+++ b/spec/libsass-closed-issues/issue_759/input.scss
@@ -1,0 +1,13 @@
+$a: 10px !global !default;
+$b: 20px !default !global;
+$c: 30px !default !default !default !global !global !global;
+$d: 40px !global !global !global !default !default !default;
+$e: 50px !global !default !global !default !global !default;
+
+foo {
+  a: $a;
+  b: $b;
+  c: $c;
+  d: $d;
+  e: $e;
+}


### PR DESCRIPTION
This PR activates the spec for correctly parsing `!default`s and `!global`s in assignments (https://github.com/sass/libsass/issues/759).
