### PR TITLE
Activate specs for issue 740

### DIFF
--- a/spec/libsass-closed-issues/issue_740/expected_output.css
+++ b/spec/libsass-closed-issues/issue_740/expected_output.css
@@ -1,0 +1,3 @@
+foo {
+  foo: #fff;
+  bar: #000; }

--- a/spec/libsass-closed-issues/issue_740/input.scss
+++ b/spec/libsass-closed-issues/issue_740/input.scss
@@ -1,0 +1,9 @@
+$foo: null;
+$foo: #fff !default;
+$bar: #000;
+$bar: #f00 !default;
+
+foo {
+  foo: $foo;
+  bar: $bar;
+}


### PR DESCRIPTION
This PR activates specs for allow guarded assignments to override `null` values (https://github.com/sass/libsass/issues/740).
