### PR TITLE
Activate specs for issue 659

### DIFF
--- a/spec/libsass-closed-issues/issue_659/sass-script/expected_output.css
+++ b/spec/libsass-closed-issues/issue_659/sass-script/expected_output.css
@@ -1,0 +1,3 @@
+baz {
+  baz: !important;
+}

--- a/spec/libsass-closed-issues/issue_659/sass-script/input.scss
+++ b/spec/libsass-closed-issues/issue_659/sass-script/input.scss
@@ -1,0 +1,21 @@
+$foo: null;
+
+@mixin bar() {
+   bar: $foo;
+}
+
+@mixin baz() {
+   baz: $foo !important;
+}
+
+foo {
+  baz: $foo;
+}
+
+bar {
+  @include bar;
+}
+
+baz {
+  @include baz;
+}

--- a/spec/libsass-closed-issues/issue_659/static/expected_output.css
+++ b/spec/libsass-closed-issues/issue_659/static/expected_output.css
@@ -1,0 +1,11 @@
+bam {
+  bam: null; }
+
+foo {
+  foo: null; }
+
+bar {
+  bar: null; }
+
+baz {
+  baz: null !important; }

--- a/spec/libsass-closed-issues/issue_659/static/input.scss
+++ b/spec/libsass-closed-issues/issue_659/static/input.scss
@@ -1,0 +1,26 @@
+
+%bam { bam: null; }
+
+@mixin bar() {
+   bar: null;
+}
+
+@mixin baz() {
+   baz: null !important;
+}
+
+foo {
+  foo: null;
+}
+
+bar {
+  @include bar;
+}
+
+baz {
+  @include baz;
+}
+
+bam {
+  @extend %bam;
+}


### PR DESCRIPTION
This PR adds specs for ensuring empty blocks aren't outputted (https://github.com/sass/libsass/issues/659).
