### PR TITLE
Activate specs for not operator in media queries

### DIFF
--- a/spec/libsass-closed-issues/issue_485/expected_output.css
+++ b/spec/libsass-closed-issues/issue_485/expected_output.css
@@ -1,0 +1,6 @@
+@media not all and (monochrome) {
+  foo: bar; }
+@media not screen and (color), print and (color) {
+  foo: bar; }
+@media (false), print and (color) {
+  foo: bar; }

--- a/spec/libsass-closed-issues/issue_485/input.scss
+++ b/spec/libsass-closed-issues/issue_485/input.scss
@@ -1,0 +1,3 @@
+@media not all and (monochrome) { foo: bar; }
+@media not screen and (color), print and (color) { foo: bar; }
+@media (not (screen and (color))), print and (color) { foo: bar; }


### PR DESCRIPTION
This PR activates specs for `not` operator in media queries (https://github.com/sass/libsass/issues/485).
