### PR TITLE
Activate specs for issue 803

### DIFF
--- a/spec/libsass-closed-issues/issue_803/expected_output.css
+++ b/spec/libsass-closed-issues/issue_803/expected_output.css
@@ -1,0 +1,3 @@
+@media (min-width: 0) and (max-width: 599px), (min-width: 600px) and (max-width: 899px) {
+  .foo {
+    content: bar; } }

--- a/spec/libsass-closed-issues/issue_803/input.scss
+++ b/spec/libsass-closed-issues/issue_803/input.scss
@@ -1,0 +1,7 @@
+
+$query-string: "(min-width: 0) and (max-width: 599px),  (min-width: 600px) and (max-width: 899px)";
+@media #{$query-string} {
+  .foo {
+    content: bar;
+  }
+}


### PR DESCRIPTION
This PR activates specs for correctly rendered media queries with interpolants (https://github.com/sass/libsass/issues/803).