### PR TITLE
Update the @media hoisting specs to cater for interpolants also

### DIFF
--- a/spec/libsass-closed-issues/issue_185/hoisting/expected_output.css
+++ b/spec/libsass-closed-issues/issue_185/hoisting/expected_output.css
@@ -5,3 +5,7 @@
   @media only screen and (min-width: 1337px) {
     .foo {
       content: baz; } }
+
+@media (min-width: 0) and (max-width: 599px) and (min-width: 0) and (max-width: 599px), (min-width: 600px) and (max-width: 899px) and (min-width: 0) and (max-width: 599px) {
+  .foo {
+    content: bar; } }

--- a/spec/libsass-closed-issues/issue_185/hoisting/input.scss
+++ b/spec/libsass-closed-issues/issue_185/hoisting/input.scss
@@ -9,3 +9,13 @@
     content: foo;
   }
 }
+
+$foo: "(min-width: 0) and (max-width: 599px),  (min-width: 600px) and (max-width: 899px)";
+@media #{$foo} {
+  $bar: "(min-width: 0) and (max-width: 599px)";
+  @media #{$bar} {
+    .foo {
+      content: bar;
+    }
+  }
+}


### PR DESCRIPTION
This PR updates the `@media` hoisting specs to cater for interpolants also.