### PR TITLE
Activate specs for issue 815

### DIFF
--- a/spec/libsass-closed-issues/issue_815/expected_output.css
+++ b/spec/libsass-closed-issues/issue_815/expected_output.css
@@ -1,0 +1,3 @@
+foo {
+  foo: "ba";
+  bar: "r"; }

--- a/spec/libsass-closed-issues/issue_815/input.scss
+++ b/spec/libsass-closed-issues/issue_815/input.scss
@@ -1,0 +1,4 @@
+foo {
+  foo: str-slice("bar", 1, 2);
+  bar: str-slice("bar", 3);
+}


### PR DESCRIPTION
This PR activates specs for a regression in `str-slice` when `$end-at` is omitted (https://github.com/sass/libsass/issues/815).