### PR TITLE
Activate specs for issue 817

### DIFF
--- a/spec/libsass-closed-issues/issue_817/expected_output.css
+++ b/spec/libsass-closed-issues/issue_817/expected_output.css
@@ -1,0 +1,7 @@
+foo {
+  foo: url("foo/bar.baz");
+  foo: url("foo/bar.baz");
+  foo: url(foo/bar.baz);
+  foo: foo("foo/bar.baz", "bar", 55);
+  foo: foo("foo/bar.baz", "bar", 55);
+  foo: foo("foo/bar.baz", bar, 55); }

--- a/spec/libsass-closed-issues/issue_817/input.scss
+++ b/spec/libsass-closed-issues/issue_817/input.scss
@@ -1,0 +1,7 @@
+foo {
+  foo: url('foo/bar.baz');
+  foo: url("foo/bar.baz");
+  foo: url(foo/bar.baz);
+  foo: foo('foo/bar.baz', "bar", 55);
+  foo: foo("foo/bar.baz", 'bar', 55);
+  foo: foo("foo/bar.baz", bar, 55); }


### PR DESCRIPTION
This PR adds and activates specs for normalising string function arguments to double quotes (https://github.com/sass/libsass/issues/817).