### PR TITLE
Add specs for issue 820

### DIFF
--- a/spec/libsass-todo-issues/issue_820/expected_output.css
+++ b/spec/libsass-todo-issues/issue_820/expected_output.css
@@ -1,0 +1,4 @@
+@charset "UTF-8";
+/*!  Force output of above line by adding a unicode character. ♫ */
+html, body {
+  height: 100%; }

--- a/spec/libsass-todo-issues/issue_820/input.scss
+++ b/spec/libsass-todo-issues/issue_820/input.scss
@@ -1,0 +1,4 @@
+@charset "UTF-8";
+/*!  Force output of above line by adding a unicode character. ♫ */
+html, body {
+  height: 100%; }


### PR DESCRIPTION
This PR adds specs for `@charset` not being inserted when utf-8 chars appear in comments before code (https://github.com/sass/libsass/issues/820).