### PR TITLE
Activate specs for correctly handling negative values in lists

### DIFF
--- a/spec/libsass-closed-issues/issue_828/expected_output.css
+++ b/spec/libsass-closed-issues/issue_828/expected_output.css
@@ -1,0 +1,9 @@
+foo {
+  box-shadow: inset -1.5em 0 1.5em -0.75em rgba(0, 0, 0, 0.25);
+  box-shadow: inset -1.5em 0 0.75em rgba(0, 0, 0, 0.25);
+  box-shadow: inset -1.5em 0 1.5em- 0.75em rgba(0, 0, 0, 0.25);
+  box-shadow: inset -1.5em 0 0.75em rgba(0, 0, 0, 0.25);
+  box-shadow: inset -1.5em 0 1.5em -0.75em rgba(0, 0, 0, 0.25);
+  box-shadow: inset -1.5em 0 0.75em rgba(0, 0, 0, 0.25);
+  box-shadow: inset -1.5em 0 1.5em- 0.75em rgba(0, 0, 0, 0.25);
+  box-shadow: inset -1.5em 0 1.5em- 0.75em rgba(0, 0, 0, 0.25); }

--- a/spec/libsass-closed-issues/issue_828/input.scss
+++ b/spec/libsass-closed-issues/issue_828/input.scss
@@ -1,0 +1,10 @@
+foo {
+  box-shadow: inset -1.5em 0 1.5em -0.75em rgba(0, 0, 0, 0.25);
+  box-shadow: inset -1.5em 0 1.5em - 0.75em rgba(0, 0, 0, 0.25);
+  box-shadow: inset -1.5em 0 1.5em- 0.75em rgba(0, 0, 0, 0.25);
+  box-shadow: inset -1.5em 0 1.5em-0.75em rgba(0, 0, 0, 0.25);
+  box-shadow: inset -1.5em 0 1.5em -.75em rgba(0, 0, 0, .25);
+  box-shadow: inset -1.5em 0 1.5em - .75em rgba(0, 0, 0, .25);
+  box-shadow: inset -1.5em 0 1.5em- .75em rgba(0, 0, 0, .25);
+  box-shadow: inset -1.5em 0 1.5em-.75em rgba(0, 0, 0, .25);
+}


### PR DESCRIPTION
This PR adds and activates specs for correctly handling negative values in lists (https://github.com/sass/libsass/issues/828).