### PR TITLE
Activate specs for correctly bubbling directives

### DIFF
--- a/spec/libsass-closed-issues/issue_828/expected_output.css
+++ b/spec/libsass-closed-issues/issue_828/expected_output.css
@@ -1,0 +1,9 @@
+@media (foo: bar), (bar: baz) {
+  .foo {
+    foo: bar; } }
+  @media (foo: bar) and (foo: bar), (bar: baz) and (foo: bar) {
+    .foo {
+      bar: baz; } }
+@media (foo: bar), (bar: baz) {
+    .foo .bar {
+      baz: bam; } }

--- a/spec/libsass-closed-issues/issue_828/input.scss
+++ b/spec/libsass-closed-issues/issue_828/input.scss
@@ -1,0 +1,14 @@
+.foo {
+    @media (foo: bar), (bar: baz) {
+        foo: bar;
+
+        @media (foo: bar) {
+            bar: baz;
+        }
+
+        .bar {
+            baz: bam;
+        }
+    }
+ }
+


### PR DESCRIPTION
This PR adds and activates specs for correctly bubbling directives (https://github.com/sass/libsass/issues/829).