### PR TITLE
Activate specs for handling comments in function definitions

### DIFF
--- a/spec/libsass-closed-issues/issue_646/expected_output.css
+++ b/spec/libsass-closed-issues/issue_646/expected_output.css
@@ -1,0 +1,2 @@
+foo {
+  foo: true; }

--- a/spec/libsass-closed-issues/issue_646/input.scss
+++ b/spec/libsass-closed-issues/issue_646/input.scss
@@ -1,0 +1,8 @@
+@function foo() {
+  /* $bar: 1; */
+ @return true;
+}
+
+foo {
+  foo: foo();
+}


### PR DESCRIPTION
This PR activates specs for handling comments in function definitions (https://github.com/sass/libsass/issues/646).