### PR TITLE
Update and deactivate spec for issue 439

### DIFF
--- a/spec/libsass-closed-issues/issue_439/expected_output.css
+++ b/spec/libsass-closed-issues/issue_439/expected_output.css
@@ -1,2 +1,0 @@
-ul > li:nth-child(odd) {
-  background: #ccc; }

--- a/spec/libsass-closed-issues/issue_439/input.scss
+++ b/spec/libsass-closed-issues/issue_439/input.scss
@@ -1,9 +1,0 @@
-@mixin odd( $selector, $n) {
-    $local-uniq: unique_id();
-    #{$selector}:nth-child(odd) { @content }
-    %#{$local-uniq} { @content; }
-}
-
-ul > {
-  @include odd( li, 5 ) { background: #ccc;  }
-}

--- a/spec/libsass-todo-issues/issue_439/expected_output.css
+++ b/spec/libsass-todo-issues/issue_439/expected_output.css
@@ -1,0 +1,2 @@
+ul > li:first-child + li + li {
+  background: #ccc; }

--- a/spec/libsass-todo-issues/issue_439/input.scss
+++ b/spec/libsass-todo-issues/issue_439/input.scss
@@ -1,0 +1,12 @@
+@mixin odd( $selector, $n) {
+  $selector: "& + " + $selector + " + " + $selector;
+  $placeholder: unique_id();
+  %#{$placeholder} { @content; }
+  #{$selector}:first-child {
+    #{$selector} { @extend %#{$placeholder}; }
+  }
+}
+
+ul > {
+  @include odd( li, 5 ) { background: #ccc;  }
+}


### PR DESCRIPTION
This PR updates the spec for https://github.com/sass/libsass/issues/439 to reflect the issue at hand.

The update issue fails as expected, and is hence moved back to todo-issues.