### PR TITLE
Add specs for issue 472

### DIFF
--- a/spec/libsass-todo-issues/issue_472/expected_output.css
+++ b/spec/libsass-todo-issues/issue_472/expected_output.css
@@ -1,0 +1,5 @@
+div {
+  display: block; }
+@keyframes {
+  from {
+    foo: bar; } }

--- a/spec/libsass-todo-issues/issue_472/input.scss
+++ b/spec/libsass-todo-issues/issue_472/input.scss
@@ -1,0 +1,8 @@
+div {
+  display: block;
+  @keyframes {
+    from {
+      foo: bar;
+    }
+  }
+}


### PR DESCRIPTION
This PR adds specs for the correct bubbling behaviour of `@keyframes` (https://github.com/sass/libsass/issues/472).