### PR TITLE
Add more saturation/desaturation tests

### DIFF
--- a/spec/colors/expected_output.css
+++ b/spec/colors/expected_output.css
@@ -11,5 +11,10 @@ p {
   color: #990000;
   color: black;
   color: white;
+  color: #a38f8f;
+  color: black;
+  color: white;
   color: #999999;
-  color: black; }
+  color: black;
+  color: #f20d0d;
+  color: #910808; }

--- a/spec/colors/input.scss
+++ b/spec/colors/input.scss
@@ -10,7 +10,12 @@ p {
   color: saturate(#f00, 10%);
   color: saturate(#900, 10%);
   color: saturate(#000, 10%);
+  color: saturate(#fff, 10%);
+  color: saturate(#999, 10%);
+  color: saturate(#000, 10%);
   color: desaturate(#fff, 10%);
   color: desaturate(#999, 10%);
   color: desaturate(#000, 10%);
+  color: desaturate(#f00, 10%);
+  color: desaturate(#900, 10%);
 }


### PR DESCRIPTION
Included some not-so-edge cases. Expected values checked with ruby sass 3.4 and 3.2. Related to https://github.com/sass/libsass/pull/865

Note the odd behaviour of `saturate()` on grey colours.