### PR TITLE
Add specs for issue 883

### DIFF
--- a/spec/libsass-todo-issues/issue_883/expected_output.css
+++ b/spec/libsass-todo-issues/issue_883/expected_output.css
@@ -1,0 +1,6 @@
+@foo {
+  div {
+    font: a; } }
+@bar {
+  div {
+    color: b; } }

--- a/spec/libsass-todo-issues/issue_883/input.scss
+++ b/spec/libsass-todo-issues/issue_883/input.scss
@@ -1,0 +1,8 @@
+div {
+  @foo {
+    font: a;
+  }
+  @bar {
+    color: b;
+  }
+}


### PR DESCRIPTION
This PR adds spec for the incorrect bubbling of at-rule properties https://github.com/sass/libsass/issues/883.