### PR TITLE
Add specs for issue 873

### DIFF
--- a/spec/libsass-todo-issues/issue_873/expected_output.css
+++ b/spec/libsass-todo-issues/issue_873/expected_output.css
@@ -1,0 +1,7 @@
+foo {
+  foo: notification;
+  foo: notification;
+  foo: notification;
+  foo: "notification";
+  foo: notification;
+  foo: notification; }

--- a/spec/libsass-todo-issues/issue_873/input.scss
+++ b/spec/libsass-todo-issues/issue_873/input.scss
@@ -1,0 +1,15 @@
+$quoted: "notification";
+$unquoted: notification;
+
+@function func($var) {
+  @return $var;
+}
+
+foo {
+  foo: func(notification);
+  foo: #{notification};
+  foo: #{$quoted};
+  foo: $quoted;
+  foo: #{$unquoted};
+  foo: $unquoted;
+}


### PR DESCRIPTION
This PR adds specs for the incorrect parsing of `not` https://github.com/sass/libsass/issues/873.