### PR TITLE
Fix spec for underscore normalisation

### DIFF
--- a/spec/libsass-closed-issues/issue_877/input.scss
+++ b/spec/libsass-closed-issues/issue_877/input.scss
@@ -14,14 +14,6 @@
   mixin: true;
 }
 
-@mixin -test1() {
-  mixin: true;
-}
-
-@mixin _test2() {
-  mixin: true;
-}
-
 @mixin -test2() {
   mixin: true;
 }
@@ -31,8 +23,6 @@
 }
 
 $-test1: true;
-$_test1: true;
-$-test2: true;
 $_test2: true;
 $test: true;
 


### PR DESCRIPTION
This PR fixes the spec for underscore normalisation https://github.com/sass/libsass/issues/877 so that it's actually testing the desired behaviour. 