### PR TITLE
Add spec for issue 823

### DIFF
--- a/spec/libsass-todo-issues/issue_823/expected_output.css
+++ b/spec/libsass-todo-issues/issue_823/expected_output.css
@@ -1,0 +1,2 @@
+p > .red, p > a > .red {
+  color: #F00; }

--- a/spec/libsass-todo-issues/issue_823/input.scss
+++ b/spec/libsass-todo-issues/issue_823/input.scss
@@ -1,0 +1,17 @@
+%test {
+  > {
+    .red {
+      color: #F00;
+    }
+  }
+}
+
+p {
+  @extend %test;
+
+  > {
+    a {
+      @extend %test;
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a spec for a regression in `@extends` https://github.com/sass/libsass/issues/823.