### PR TITLE
Activate specs handling comments in propsets

### DIFF
--- a/spec/libsass-closed-issues/issue_890/expected_output.css
+++ b/spec/libsass-closed-issues/issue_890/expected_output.css
@@ -1,0 +1,2 @@
+.foo {
+  border-right: 10px solid; }

--- a/spec/libsass-closed-issues/issue_890/input.scss
+++ b/spec/libsass-closed-issues/issue_890/input.scss
@@ -1,0 +1,5 @@
+.foo {
+  border: {
+    right: 10px solid /*here is a comment*/;
+  }
+}


### PR DESCRIPTION
This PR activates specs handling comments in propsets (https://github.com/sass/libsass/issues/890).