### PR TITLE
Add tests for libsass issue 942

### DIFF
--- a/spec/libsass-todo-issues/issue_942/expected.compact.css
+++ b/spec/libsass-todo-issues/issue_942/expected.compact.css
@@ -1,0 +1,3 @@
+.foo .bar { color: #F00; }
+
+div { content: "foobar"; }

--- a/spec/libsass-todo-issues/issue_942/expected.compressed.css
+++ b/spec/libsass-todo-issues/issue_942/expected.compressed.css
@@ -1,0 +1,1 @@
+.foo .bar{color:#F00}div{content:"foobar"}

--- a/spec/libsass-todo-issues/issue_942/expected.expanded.css
+++ b/spec/libsass-todo-issues/issue_942/expected.expanded.css
@@ -1,0 +1,7 @@
+.foo .bar {
+  color: #F00;
+}
+
+div {
+  content: "foobar";
+}

--- a/spec/libsass-todo-issues/issue_942/expected_output.css
+++ b/spec/libsass-todo-issues/issue_942/expected_output.css
@@ -1,0 +1,5 @@
+.foo .bar {
+  color: #F00; }
+
+div {
+  content: "foobar"; }

--- a/spec/libsass-todo-issues/issue_942/input.scss
+++ b/spec/libsass-todo-issues/issue_942/input.scss
@@ -1,0 +1,11 @@
+$v: ".foo \
+.bar";
+
+#{$v} {
+	color: #F00;
+}
+
+div {
+	content: "foo\
+bar";
+}


### PR DESCRIPTION
https://github.com/sass/libsass/issues/942

Note that there's a big difference between Sass 3.2 and 3.4 behaviour in this case. 3.2 will error on the multi-line string variable, and incorrectly compile the content into `"foo\ bar"`.