### PR TITLE
Activate spec for at-error feature test

### DIFF
--- a/spec/libsass/at-error/feature-test/expected.compact.css
+++ b/spec/libsass/at-error/feature-test/expected.compact.css
@@ -1,0 +1,1 @@
+div { feature: true; }

--- a/spec/libsass/at-error/feature-test/expected.compressed.css
+++ b/spec/libsass/at-error/feature-test/expected.compressed.css
@@ -1,0 +1,1 @@
+div{feature:true}

--- a/spec/libsass/at-error/feature-test/expected.expanded.css
+++ b/spec/libsass/at-error/feature-test/expected.expanded.css
@@ -1,0 +1,3 @@
+div {
+  feature: true;
+}

--- a/spec/libsass/at-error/feature-test/expected_output.css
+++ b/spec/libsass/at-error/feature-test/expected_output.css
@@ -1,0 +1,2 @@
+div {
+  feature: true; }

--- a/spec/libsass/at-error/feature-test/input.scss
+++ b/spec/libsass/at-error/feature-test/input.scss
@@ -1,0 +1,5 @@
+@if feature-exists(at-error) {
+  div {
+    feature: true;
+  }
+}


### PR DESCRIPTION
This PR adds specs for the `at-root` feature check.