### PR TITLE
Fix broken spec for issue 1060

### DIFF
--- a/spec/libsass-closed-issues/issue_1060/input.scss
+++ b/spec/libsass-closed-issues/issue_1060/input.scss
@@ -3,7 +3,7 @@ foo {
     foo: true;
   } @elseif true {
     foo: false;
-  } @else true {
+  } @else {
     foo: false;
   }
 
@@ -11,7 +11,7 @@ foo {
     bar: true;
   } @else if true {
     bar: false;
-  } @else true {
+  } @else {
     bar: false;
   }
 }


### PR DESCRIPTION
This PR fixes a broken spec for `@else` introduce (by me) in https://github.com/sass/sass-spec/pull/306.