### PR TITLE
Remove invalid specs for non-standard compact function

### DIFF
--- a/spec/libsass-todo-tests/libsass/compact/expected.compact.css
+++ b/spec/libsass-todo-tests/libsass/compact/expected.compact.css
@@ -1,1 +1,0 @@
-div { content: compact(yellow, false, false, false, false); content: string; content: 1; }

--- a/spec/libsass-todo-tests/libsass/compact/expected.compressed.css
+++ b/spec/libsass-todo-tests/libsass/compact/expected.compressed.css
@@ -1,1 +1,0 @@
-div{content:compact(#ff0, false, false, false, false);content:string;content:1}

--- a/spec/libsass-todo-tests/libsass/compact/expected.expanded.css
+++ b/spec/libsass-todo-tests/libsass/compact/expected.expanded.css
@@ -1,5 +1,0 @@
-div {
-  content: compact(yellow, false, false, false, false);
-  content: string;
-  content: 1;
-}

--- a/spec/libsass-todo-tests/libsass/compact/expected_output.css
+++ b/spec/libsass-todo-tests/libsass/compact/expected_output.css
@@ -1,4 +1,0 @@
-div {
-  content: compact(yellow, false, false, false, false);
-  content: string;
-  content: 1; }

--- a/spec/libsass-todo-tests/libsass/compact/input.scss
+++ b/spec/libsass-todo-tests/libsass/compact/input.scss
@@ -1,5 +1,0 @@
-div {
-  content: compact(yellow, false, false, false, false);
-  content: type-of(compact(yellow, false, false, false, false));
-  content: length(type-of(compact(yellow, false, false, false, false)));
-}

--- a/spec/libsass-todo-tests/libsass/eq/expected.compact.css
+++ b/spec/libsass-todo-tests/libsass/eq/expected.compact.css
@@ -1,1 +1,1 @@
-div { foo: true; foo: true; foo: a b false b c; foo: false; foo: false; }
+div { foo: true; foo: true; foo: a b false b c; }

--- a/spec/libsass-todo-tests/libsass/eq/expected.compressed.css
+++ b/spec/libsass-todo-tests/libsass/eq/expected.compressed.css
@@ -1,1 +1,1 @@
-div{foo:true;foo:true;foo:a b false b c;foo:false;foo:false}
+div{foo:true;foo:true;foo:a b false b c}

--- a/spec/libsass-todo-tests/libsass/eq/expected.expanded.css
+++ b/spec/libsass-todo-tests/libsass/eq/expected.expanded.css
@@ -2,6 +2,4 @@ div {
   foo: true;
   foo: true;
   foo: a b false b c;
-  foo: false;
-  foo: false;
 }

--- a/spec/libsass-todo-tests/libsass/eq/expected_output.css
+++ b/spec/libsass-todo-tests/libsass/eq/expected_output.css
@@ -1,6 +1,4 @@
 div {
   foo: true;
   foo: true;
-  foo: a b false b c;
-  foo: false;
-  foo: false; }
+  foo: a b false b c; }

--- a/spec/libsass-todo-tests/libsass/eq/input.scss
+++ b/spec/libsass-todo-tests/libsass/eq/input.scss
@@ -2,6 +2,4 @@ div {
   foo: center == "center";
   foo: (a b c) == (a b c);
   foo: a b c == a b c;
-  foo: compact(1 2 false 4) == compact(1 2 4);
-  foo: compact(1 2 4) == compact(1 2 4, false);
 }


### PR DESCRIPTION
This PR removes or updates specs that incorrect reference the non-standard `compact` function.