### PR TITLE
Fix specs for the random function

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     minitest (5.2.0)
-    sass (3.4.9)
+    sass (3.4.13)
 
 PLATFORMS
   ruby

--- a/spec/libsass-closed-issues/issue_657/default/expected.compact.css
+++ b/spec/libsass-closed-issues/issue_657/default/expected.compact.css
@@ -1,1 +1,1 @@
-foo { is-defined: true; is-number: true; is-within-range: true; }
+foo { is-defined: true; is-number: true; is-within-range: true; is-random: true; }

--- a/spec/libsass-closed-issues/issue_657/default/expected.compressed.css
+++ b/spec/libsass-closed-issues/issue_657/default/expected.compressed.css
@@ -1,1 +1,1 @@
-foo{is-defined:true;is-number:true;is-within-range:true}
+foo{is-defined:true;is-number:true;is-within-range:true;is-random:true}

--- a/spec/libsass-closed-issues/issue_657/default/expected.expanded.css
+++ b/spec/libsass-closed-issues/issue_657/default/expected.expanded.css
@@ -2,4 +2,5 @@ foo {
   is-defined: true;
   is-number: true;
   is-within-range: true;
+  is-random: true;
 }

--- a/spec/libsass-closed-issues/issue_657/default/expected_output.css
+++ b/spec/libsass-closed-issues/issue_657/default/expected_output.css
@@ -1,4 +1,5 @@
 foo {
   is-defined: true;
   is-number: true;
-  is-within-range: true; }
+  is-within-range: true;
+  is-random: true; }

--- a/spec/libsass-closed-issues/issue_657/default/input.scss
+++ b/spec/libsass-closed-issues/issue_657/default/input.scss
@@ -1,16 +1,22 @@
+$values: ();
 
 foo {
     $num: random();
     $is-number: type-of($num) == number;
     $is-within-range: $num >= 0 and $num < 1;
+    $is-random: index($values, $num) == null;
+    $values: append($values, $num);
 
     @for $i from 1 through 1000 {
       $num: random();
       $is-number: $is-number and type-of($num) == number;
       $is-within-range: $is-within-range and $num >= 0 and $num < 1;
+      $is-random: $is-random and index($values, $num) == null;
+      $values: append($values, $num);
     }
 
     is-defined: $num != "random()";
     is-number: $is-number;
     is-within-range: $is-within-range;
+    is-random: $is-random;
 }

--- a/spec/libsass-closed-issues/issue_657/limit/expected.compact.css
+++ b/spec/libsass-closed-issues/issue_657/limit/expected.compact.css
@@ -1,1 +1,1 @@
-foo { is-defined: true; is-digit: true; is-within-range: true; }
+foo { is-defined: true; is-digit: true; is-within-range: true; is-random: false; }

--- a/spec/libsass-closed-issues/issue_657/limit/expected.compressed.css
+++ b/spec/libsass-closed-issues/issue_657/limit/expected.compressed.css
@@ -1,1 +1,1 @@
-foo{is-defined:true;is-digit:true;is-within-range:true}
+foo{is-defined:true;is-digit:true;is-within-range:true;is-random:false}

--- a/spec/libsass-closed-issues/issue_657/limit/expected.expanded.css
+++ b/spec/libsass-closed-issues/issue_657/limit/expected.expanded.css
@@ -2,4 +2,5 @@ foo {
   is-defined: true;
   is-digit: true;
   is-within-range: true;
+  is-random: false;
 }

--- a/spec/libsass-closed-issues/issue_657/limit/expected_output.css
+++ b/spec/libsass-closed-issues/issue_657/limit/expected_output.css
@@ -1,4 +1,5 @@
 foo {
   is-defined: true;
   is-digit: true;
-  is-within-range: true; }
+  is-within-range: true;
+  is-random: false; }

--- a/spec/libsass-closed-issues/issue_657/limit/input.scss
+++ b/spec/libsass-closed-issues/issue_657/limit/input.scss
@@ -1,17 +1,23 @@
+$values: ();
+$limit: 10;
 
 foo {
-  $limit: 10;
   $num: random($limit);
   $is-digit: type-of($num) == number and floor($num) == $num;
   $is-within-range: $num >= 1 and $num <= $limit;
+  $is-random: index($values, $num) == null;
+  $values: append($values, $num);
 
   @for $i from 1 through 1000 {
     $num: random($limit);
     $is-digit: $is-digit and type-of($num) == number and floor($num) == $num;
     $is-within-range: $is-within-range and $num >= 1 and $num <= $limit;
+    $is-random: $is-random and index($values, $num) == null;
+    $values: append($values, $num);
   }
 
   is-defined: $num != "random(10)";
   is-digit: $is-digit;
   is-within-range: $is-within-range;
+    is-random: $is-random;
 }

--- a/spec/number-functions/random/expected.compact.css
+++ b/spec/number-functions/random/expected.compact.css
@@ -1,0 +1,1 @@
+foo { foo: true; foo: true; foo: true; foo: true; foo: true; foo: true; }

--- a/spec/number-functions/random/expected.compressed.css
+++ b/spec/number-functions/random/expected.compressed.css
@@ -1,0 +1,1 @@
+foo{foo:true;foo:true;foo:true;foo:true;foo:true;foo:true}

--- a/spec/number-functions/random/expected.expanded.css
+++ b/spec/number-functions/random/expected.expanded.css
@@ -1,0 +1,8 @@
+foo {
+  foo: true;
+  foo: true;
+  foo: true;
+  foo: true;
+  foo: true;
+  foo: true;
+}

--- a/spec/number-functions/random/expected_output.css
+++ b/spec/number-functions/random/expected_output.css
@@ -1,0 +1,7 @@
+foo {
+  foo: true;
+  foo: true;
+  foo: true;
+  foo: true;
+  foo: true;
+  foo: true; }

--- a/spec/number-functions/random/input.scss
+++ b/spec/number-functions/random/input.scss
@@ -1,0 +1,10 @@
+foo {
+  $number: random();
+  foo: $number >= 0 and $number <= 1;
+  $number: random(1.0);
+  foo: $number >= 0 and $number <= 1;
+  foo: random(1) == 1;
+  foo: type-of(random()) == number;
+  foo: type-of(random(1)) == number;
+  foo: type-of(random(1.0)) == number;
+}


### PR DESCRIPTION
This PR fixes specs for the  `random` function, primarily adding an assertion that it is infact somewhat random.

I've also update the Ruby dep to 3.4.13 to fix an issue with Ruby's `random` - http://sass-lang.com/documentation/file.SASS_CHANGELOG.html#3413_26_february_2015