### PR TITLE
Fix typo in specs for issue 1124

### DIFF
--- a/spec/libsass-todo-issues/issue_1124/input.scss
+++ b/spec/libsass-todo-issues/issue_1124/input.scss
@@ -2,12 +2,12 @@ $foo: null;
 
 @mixin bar($bar:null) {
   aa: type-of($bar);
-  ab: type-of(unqote($bar));
+  ab: type-of(unqoute($bar));
 }
 
 @mixin baz($baz) {
   ba: type-of($baz);
-  bb: type-of(unqote($baz));
+  bb: type-of(unqoute($baz));
 }
 
 foo {


### PR DESCRIPTION
This PR fixes a typo in the spec for https://github.com/sass/libsass/issues/1124