### PR TITLE
Fix weird UTF-8 characters in the length spec

### DIFF
--- a/spec/libsass/length/input.scss
+++ b/spec/libsass/length/input.scss
@@ -4,13 +4,13 @@ div {
   foo: length(true);
   foo: length(false);
 
-  foo: length("protégé");
-  foo: length(protégé);
+  foo: length("protÃ©gÃ©");
+  foo: length(protÃ©gÃ©);
   foo: length("");
   foo: length("hello there");
-  foo: length("Façade");
-  foo: length("Tromsø");
-  foo: length("Ãlso");
+  foo: length("FaÃ§ade");
+  foo: length("TromsÃ¸");
+  foo: length("Ãƒlso");
 
   foo: length((foo: foo, bar: bar));
   foo: length((foo, bar, baz, bang));


### PR DESCRIPTION
This PR fixes a spec that causes the Ruby Sass process to crash due to weird UTF-8 characters.

Originally mentioned in https://github.com/sass/sass-spec/issues/361.