### PR TITLE
Respect the --ignore-todo flag

### DIFF
--- a/lib/sass_spec/test.rb
+++ b/lib/sass_spec/test.rb
@@ -33,10 +33,10 @@ def run_spec_test(test_case, options = {})
     end
   end
 
-  if !test_case.todo?
-    assert_equal test_case.expected, clean_output, "Expected did not match output"
-  elsif options[:unexpected_pass]
+  if test_case.todo? && options[:unexpected_pass]
     assert_not_equal test_case.expected, clean_output, "Marked as todo and passed"
+  elsif !test_case.todo? || !options[:skip_todo]
+    assert_equal test_case.expected, clean_output, "Expected did not match output"
   end
 end
 


### PR DESCRIPTION
This PR fixes a big with sass-spec which causes it to falsely report todo specs as passing. This has resulted in some recent Libsass regressions, and incorrectly closed bugs.

/cc @mgreter 