### PR TITLE
Fix method missing exception

### DIFF
--- a/lib/sass_spec/test.rb
+++ b/lib/sass_spec/test.rb
@@ -34,7 +34,7 @@ def run_spec_test(test_case, options = {})
   end
 
   if test_case.todo? && options[:unexpected_pass]
-    assert_not_equal test_case.expected, clean_output, "Marked as todo and passed"
+    assert test_case.expected != clean_output, "Marked as todo and passed"
   elsif !test_case.todo? || !options[:skip_todo]
     assert_equal test_case.expected, clean_output, "Expected did not match output"
   end


### PR DESCRIPTION
This PR fix a method missing exception for the undefined `asset_not_equal` when using the `--unexpected-pass` flag.