### PR TITLE
Revert "Add missing todo spec tests for issue 1219"

### DIFF
--- a/spec/libsass-todo-issues/issue_1219/expected.compact.css
+++ b/spec/libsass-todo-issues/issue_1219/expected.compact.css
@@ -1,2 +1,0 @@
-/* one.css */
-@media screen and (min-width: 0\0) { .bar { width: 12px; } }

--- a/spec/libsass-todo-issues/issue_1219/expected.compressed.css
+++ b/spec/libsass-todo-issues/issue_1219/expected.compressed.css
@@ -1,1 +1,0 @@
-@media screen and (min-width: 0\0){.bar{width:12px}}

--- a/spec/libsass-todo-issues/issue_1219/expected.expanded.css
+++ b/spec/libsass-todo-issues/issue_1219/expected.expanded.css
@@ -1,6 +1,0 @@
-/* one.css */
-@media screen and (min-width: 0\0) {
-  .bar {
-    width: 12px;
-  }
-}

--- a/spec/libsass-todo-issues/issue_1219/expected_output.css
+++ b/spec/libsass-todo-issues/issue_1219/expected_output.css
@@ -1,4 +1,0 @@
-/* one.css */
-@media screen and (min-width: 0\0) {
-  .bar {
-    width: 12px; } }

--- a/spec/libsass-todo-issues/issue_1219/input.scss
+++ b/spec/libsass-todo-issues/issue_1219/input.scss
@@ -1,6 +1,0 @@
-/* one.css */
-@media screen and (min-width:0\0) {
-    .bar {
-        width: 12px;
-    }
-}


### PR DESCRIPTION
Reverts sass/sass-spec#410

https://github.com/sass/libsass/issues/1219 is testing an error condition, as such this spec should not pass by design.