### PR TITLE
Remove unnecessary space after comma in compressed output

### DIFF
--- a/spec/libsass-todo-issues/issue_1214/expected.compressed.css
+++ b/spec/libsass-todo-issues/issue_1214/expected.compressed.css
@@ -1,1 +1,1 @@
-@keyframes $animation-name{0%, 20%, 50%, 80%, 100%{transform:translateY(0)}40%{transform:translateY(-30px)}60%{transform:translateY(-15px)}}
+@keyframes $animation-name{0%,20%,50%,80%,100%{transform:translateY(0)}40%{transform:translateY(-30px)}60%{transform:translateY(-15px)}}

--- a/spec/libsass-todo-issues/issue_1263/expected.compressed.css
+++ b/spec/libsass-todo-issues/issue_1263/expected.compressed.css
@@ -1,1 +1,1 @@
-foo{@ap ply;;@apply (--bar);;@apply (  --bar  );;@ap ply   (   --bar , --foo  );}
+foo{@ap ply;@apply (--bar);@apply (  --bar  );@ap ply   (   --bar , --foo  )}

--- a/spec/libsass-todo-tests/38_expressions_in_at_directives/expected.compressed.css
+++ b/spec/libsass-todo-tests/38_expressions_in_at_directives/expected.compressed.css
@@ -1,1 +1,1 @@
-@foo $x $y, hux{bar{whatever:whatever}}
+@foo $x $y,hux{bar{whatever:whatever}}


### PR DESCRIPTION
Change expected output to match libsass output, which is more correct in this case than ruby sass output (probably/somewhat related to https://github.com/sass/sass/issues/1296, discussed in https://github.com/sass/libsass/pull/1249).