### PR TITLE
Add specs for @-moz-document support

### DIFF
--- a/spec/libsass-todo-tests/libsass/moz-document/basic/expected.compact.css
+++ b/spec/libsass-todo-tests/libsass/moz-document/basic/expected.compact.css
@@ -1,0 +1,4 @@
+@-moz-document url(sass-lang.com),
+               url-prefix(http://sass-lang.com/docs),
+               domain(sass-lang.com),
+               regexp("https:.*") { .foo { a: b; } }

--- a/spec/libsass-todo-tests/libsass/moz-document/basic/expected.compressed.css
+++ b/spec/libsass-todo-tests/libsass/moz-document/basic/expected.compressed.css
@@ -1,0 +1,4 @@
+@-moz-document url(sass-lang.com),
+               url-prefix(http://sass-lang.com/docs),
+               domain(sass-lang.com),
+               regexp("https:.*"){.foo{a:b}}

--- a/spec/libsass-todo-tests/libsass/moz-document/basic/expected.expanded.css
+++ b/spec/libsass-todo-tests/libsass/moz-document/basic/expected.expanded.css
@@ -1,0 +1,8 @@
+@-moz-document url(sass-lang.com),
+               url-prefix(http://sass-lang.com/docs),
+               domain(sass-lang.com),
+               regexp("https:.*") {
+  .foo {
+    a: b;
+  }
+}

--- a/spec/libsass-todo-tests/libsass/moz-document/basic/expected_output.css
+++ b/spec/libsass-todo-tests/libsass/moz-document/basic/expected_output.css
@@ -1,0 +1,6 @@
+@-moz-document url(sass-lang.com),
+               url-prefix(http://sass-lang.com/docs),
+               domain(sass-lang.com),
+               regexp("https:.*") {
+  .foo {
+    a: b; } }

--- a/spec/libsass-todo-tests/libsass/moz-document/basic/input.scss
+++ b/spec/libsass-todo-tests/libsass/moz-document/basic/input.scss
@@ -1,0 +1,6 @@
+@-moz-document url(sass-lang.com),
+               url-prefix(http://sass-lang.com/docs),
+               domain(sass-lang.com),
+               regexp("https:.*") {
+  .foo { a: b; }
+}

--- a/spec/libsass-todo-tests/libsass/moz-document/interpolated/expected.compact.css
+++ b/spec/libsass-todo-tests/libsass/moz-document/interpolated/expected.compact.css
@@ -1,0 +1,4 @@
+@-moz-document url(http://sass-lang.com/),
+               url-prefix(http://sass-lang.com/docs),
+               domain(sass-lang.com),
+               domain("sass-lang.com") { .foo { a: b; } }

--- a/spec/libsass-todo-tests/libsass/moz-document/interpolated/expected.compressed.css
+++ b/spec/libsass-todo-tests/libsass/moz-document/interpolated/expected.compressed.css
@@ -1,0 +1,4 @@
+@-moz-document url(http://sass-lang.com/),
+               url-prefix(http://sass-lang.com/docs),
+               domain(sass-lang.com),
+               domain("sass-lang.com"){.foo{a:b}}

--- a/spec/libsass-todo-tests/libsass/moz-document/interpolated/expected.expanded.css
+++ b/spec/libsass-todo-tests/libsass/moz-document/interpolated/expected.expanded.css
@@ -1,0 +1,8 @@
+@-moz-document url(http://sass-lang.com/),
+               url-prefix(http://sass-lang.com/docs),
+               domain(sass-lang.com),
+               domain("sass-lang.com") {
+  .foo {
+    a: b;
+  }
+}

--- a/spec/libsass-todo-tests/libsass/moz-document/interpolated/expected_output.css
+++ b/spec/libsass-todo-tests/libsass/moz-document/interpolated/expected_output.css
@@ -1,0 +1,6 @@
+@-moz-document url(http://sass-lang.com/),
+               url-prefix(http://sass-lang.com/docs),
+               domain(sass-lang.com),
+               domain("sass-lang.com") {
+  .foo {
+    a: b; } }

--- a/spec/libsass-todo-tests/libsass/moz-document/interpolated/input.scss
+++ b/spec/libsass-todo-tests/libsass/moz-document/interpolated/input.scss
@@ -1,0 +1,7 @@
+$domain: "sass-lang.com";
+@-moz-document url(http://#{$domain}/),
+               url-prefix(http://#{$domain}/docs),
+               domain(#{$domain}),
+               #{domain($domain)} {
+  .foo { a: b; }
+}


### PR DESCRIPTION
This PR adds spec coverage for `@-moz-document`.

https://developer.mozilla.org/en-US/docs/Web/CSS/@document

Related https://github.com/sass/sass-spec/tree/master/spec/libsass-todo-tests/scss-tests/127_test_moz_document_interpolation