### PR TITLE
Add specs for Sass features

### DIFF
--- a/spec/libsass/features/at-error/expected.compact.css
+++ b/spec/libsass/features/at-error/expected.compact.css
@@ -1,0 +1,1 @@
+foo { foo: true; }

--- a/spec/libsass/features/at-error/expected.compressed.css
+++ b/spec/libsass/features/at-error/expected.compressed.css
@@ -1,0 +1,1 @@
+foo{foo:true}

--- a/spec/libsass/features/at-error/expected.expanded.css
+++ b/spec/libsass/features/at-error/expected.expanded.css
@@ -1,0 +1,3 @@
+foo {
+  foo: true;
+}

--- a/spec/libsass/features/at-error/expected_output.css
+++ b/spec/libsass/features/at-error/expected_output.css
@@ -1,0 +1,2 @@
+foo {
+  foo: true; }

--- a/spec/libsass/features/at-error/input.scss
+++ b/spec/libsass/features/at-error/input.scss
@@ -1,0 +1,3 @@
+foo {
+  foo: feature-exists('at-error');
+}

--- a/spec/libsass/features/extend-selector-pseudoclass/expected.compact.css
+++ b/spec/libsass/features/extend-selector-pseudoclass/expected.compact.css
@@ -1,0 +1,1 @@
+foo { foo: true; }

--- a/spec/libsass/features/extend-selector-pseudoclass/expected.compressed.css
+++ b/spec/libsass/features/extend-selector-pseudoclass/expected.compressed.css
@@ -1,0 +1,1 @@
+foo{foo:true}

--- a/spec/libsass/features/extend-selector-pseudoclass/expected.expanded.css
+++ b/spec/libsass/features/extend-selector-pseudoclass/expected.expanded.css
@@ -1,0 +1,3 @@
+foo {
+  foo: true;
+}

--- a/spec/libsass/features/extend-selector-pseudoclass/expected_output.css
+++ b/spec/libsass/features/extend-selector-pseudoclass/expected_output.css
@@ -1,0 +1,2 @@
+foo {
+  foo: true; }

--- a/spec/libsass/features/extend-selector-pseudoclass/input.scss
+++ b/spec/libsass/features/extend-selector-pseudoclass/input.scss
@@ -1,0 +1,3 @@
+foo {
+  foo: feature-exists('extend-selector-pseudoclass');
+}

--- a/spec/libsass/features/global-variable-shadowing/expected.compact.css
+++ b/spec/libsass/features/global-variable-shadowing/expected.compact.css
@@ -1,0 +1,1 @@
+foo { foo: true; }

--- a/spec/libsass/features/global-variable-shadowing/expected.compressed.css
+++ b/spec/libsass/features/global-variable-shadowing/expected.compressed.css
@@ -1,0 +1,1 @@
+foo{foo:true}

--- a/spec/libsass/features/global-variable-shadowing/expected.expanded.css
+++ b/spec/libsass/features/global-variable-shadowing/expected.expanded.css
@@ -1,0 +1,3 @@
+foo {
+  foo: true;
+}

--- a/spec/libsass/features/global-variable-shadowing/expected_output.css
+++ b/spec/libsass/features/global-variable-shadowing/expected_output.css
@@ -1,0 +1,2 @@
+foo {
+  foo: true; }

--- a/spec/libsass/features/global-variable-shadowing/input.scss
+++ b/spec/libsass/features/global-variable-shadowing/input.scss
@@ -1,0 +1,3 @@
+foo {
+  foo: feature-exists('global-variable-shadowing');
+}

--- a/spec/libsass/features/units-level-3/expected.compact.css
+++ b/spec/libsass/features/units-level-3/expected.compact.css
@@ -1,0 +1,1 @@
+foo { foo: true; }

--- a/spec/libsass/features/units-level-3/expected.compressed.css
+++ b/spec/libsass/features/units-level-3/expected.compressed.css
@@ -1,0 +1,1 @@
+foo{foo:true}

--- a/spec/libsass/features/units-level-3/expected.expanded.css
+++ b/spec/libsass/features/units-level-3/expected.expanded.css
@@ -1,0 +1,3 @@
+foo {
+  foo: true;
+}

--- a/spec/libsass/features/units-level-3/expected_output.css
+++ b/spec/libsass/features/units-level-3/expected_output.css
@@ -1,0 +1,2 @@
+foo {
+  foo: true; }

--- a/spec/libsass/features/units-level-3/input.scss
+++ b/spec/libsass/features/units-level-3/input.scss
@@ -1,0 +1,3 @@
+foo {
+  foo: feature-exists('units-level-3');
+}


### PR DESCRIPTION
This PR adds specs to assert we implement all defined [Sass features](https://github.com/sass/sass/blob/7a2cb14d5812cd809def8d7c5b5802a92677569b/lib/sass/features.rb#L10-L15).