### PR TITLE
Test for error output

### DIFF
--- a/lib/sass_spec/cli.rb
+++ b/lib/sass_spec/cli.rb
@@ -69,7 +69,7 @@ Make sure the command you provide prints to stdout.
       end
 
       opts.on("-s", "--skip", "Skip tests that fail to exit successfully") do
-        options[:skip] = true
+        # Note: --skip is no longer necessary as this is now the default behavior, since we test for errors
       end
 
       opts.on("--nuke", "Write a new expected_output for every test from whichever engine we are using") do

--- a/lib/sass_spec/engine_adapter.rb
+++ b/lib/sass_spec/engine_adapter.rb
@@ -68,10 +68,11 @@ class SassEngineAdapter < EngineAdapter
     require 'sass'
     begin
       captured_stderr = StringIO.new
+      # Does not work as expected when tests are run in parallel
       real_stderr, $stderr = $stderr, captured_stderr
       begin
         css_output = Sass.compile_file(sass_filename.to_s, :style => style.to_sym)
-        [css_output, captured_stderr.to_s, 0]
+        [css_output, captured_stderr.string, 0]
       rescue Sass::SyntaxError => e
         ["", "Error: " + e.message.to_s, 1]
       rescue => e

--- a/lib/sass_spec/runner.rb
+++ b/lib/sass_spec/runner.rb
@@ -39,14 +39,22 @@ class SassSpec::Runner
       glob = File.join(@options[:spec_directory], "**", input_file)
       Dir.glob(glob) do |filename|
         input = Pathname.new(filename)
+        folder = File.dirname(filename)
+        expected_stderr_file_path = File.join(folder, "error")
+        expected_status_file_path = File.join(folder, "status")
         @options[:output_styles].each do |output_style|
-          folder = File.dirname(filename)
           output_file_name = @options["#{output_style}_output_file".to_sym]
-          expected_file_path = File.join(folder, output_file_name + ".css")
+          expected_stdout_file_path = File.join(folder, output_file_name + ".css")
           clean_file_name = File.join(folder, output_file_name + ".clean")
-          if File.file?(expected_file_path) && !File.file?(expected_file_path.sub(/\.css$/, ".skip")) && filename.include?(@options[:filter])
+          if ( File.file?(expected_stdout_file_path) ) &&
+             !File.file?(expected_stdout_file_path.sub(/\.css$/, ".skip")) &&
+             filename.include?(@options[:filter]) 
             clean = File.file?(clean_file_name)
-            cases.push SassSpec::TestCase.new(input.realpath(), expected_file_path, output_style, clean, @options)
+            cases.push SassSpec::TestCase.new(input.realpath(),
+              expected_stdout_file_path,
+              expected_stderr_file_path,
+              expected_status_file_path,
+              output_style, clean, @options)
           end
         end
       end

--- a/lib/sass_spec/test.rb
+++ b/lib/sass_spec/test.rb
@@ -38,7 +38,6 @@ end
 
 # Holder to put and run test cases
 class SassSpec::Test < Minitest::Test
-  parallelize_me!
   def self.create_tests(test_cases, options = {})
     test_cases[0..options[:limit]].each do |test_case|
       define_method('test__' << test_case.output_style + "_" + test_case.name) do

--- a/lib/sass_spec/test.rb
+++ b/lib/sass_spec/test.rb
@@ -6,32 +6,58 @@ def run_spec_test(test_case, options = {})
   end
 
   assert File.exists?(test_case.input_path), "Input #{test_case.input_path} file does not exist"
-  assert File.exists?(test_case.expected_path), "Expected #{test_case.expected_path} file does not exist"
 
   output, clean_output, error, status = test_case.output
 
-  if status != 0 && !options[:unexpected_pass]
-    msg = "Command `#{options[:engine_adapter]}` did not complete:\n\n#{error}"
-
-    raise msg
-  end
-
-
-  if options[:unexpected_pass] && test_case.todo? && (test_case.expected == clean_output)
-    raise "#{test_case.input_path} passed a test we expected it to fail"
-  end
-
   if options[:nuke]
+    if status != 0
+      File.open(test_case.status_path, "w+") do |f|
+        f.write(status)
+        f.close
+      end
+    end
+
+    if error.length > 0
+      File.open(test_case.error_path, "w+") do |f|
+        f.write(error)
+        f.close
+      end
+    end
+
     File.open(test_case.expected_path, "w+") do |f|
       f.write(output)
       f.close
     end
   end
 
-  if test_case.todo? && options[:unexpected_pass]
-    assert test_case.expected != clean_output, "Marked as todo and passed"
-  elsif !test_case.todo? || !options[:skip_todo]
+  assert File.exists?(test_case.expected_path), "Expected #{test_case.expected_path} file does not exist"
+
+  begin
+    if test_case.should_fail?
+       # XXX Ruby returns 65 etc. SassC returns 1
+       refute_equal status, 0, "Test case should fail, but it did not"
+    else
+       assert_equal status, 0, "Command `#{options[:engine_adapter]}` did not complete:\n\n#{error}"
+    end
     assert_equal test_case.expected, clean_output, "Expected did not match output"
+    if test_case.verify_stderr?
+      # Compare only first line of error output (we can't compare stacktraces etc.)
+      error_msg = error.each_line.next.rstrip
+      expected_error_msg = test_case.expected_error.each_line.next.rstrip
+      assert_equal expected_error_msg, error_msg, "Expected did not match error"
+    end
+  rescue Minitest::Assertion
+    if test_case.todo? && options[:unexpected_pass]
+      pass
+    else
+      raise
+    end
+  else
+    if test_case.todo? && options[:unexpected_pass]
+      raise "#{test_case.input_path} passed a test we expected it to fail"
+    else
+      pass
+    end
   end
 end
 

--- a/lib/sass_spec/test.rb
+++ b/lib/sass_spec/test.rb
@@ -13,12 +13,7 @@ def run_spec_test(test_case, options = {})
   if status != 0 && !options[:unexpected_pass]
     msg = "Command `#{options[:engine_adapter]}` did not complete:\n\n#{error}"
 
-    if options[:skip]
-      raise msg
-    end
-
-    puts msg
-    exit 4
+    raise msg
   end
 
 


### PR DESCRIPTION
Enable testing for error output
and sass compiler failures.
 
If files "error" and "status" are existing
in the test directory, do expect errors
and test against them.

Errors returned by the Sass engines are
now treated as test failures, not errors.

Also create error and status files with --nuke.
An error will be reported in this case anyway.

**Important** Now the tests cannot be ran in parallel,
because we need to capture standard error reliably.

Should fix: https://github.com/sass/sass-spec/issues/136 https://github.com/sass/sass-spec/pull/133