### PR TITLE
ExecutableEngineAdapter should return numeric status

### DIFF
--- a/lib/sass_spec/engine_adapter.rb
+++ b/lib/sass_spec/engine_adapter.rb
@@ -45,7 +45,8 @@ class ExecutableEngineAdapater < EngineAdapter
 
 
   def compile(sass_filename, style)
-    Open3.capture3("#{@command} -t #{style} #{sass_filename}")
+    stdout, stderr, status = Open3.capture3("#{@command} -t #{style} #{sass_filename}")
+    [stdout, stderr, status.exitstatus]
   end
 end
 


### PR DESCRIPTION
ExecutableEngineAdapter and SassEngineAdapter
should consistently return numeric exit code
from the compiler.

Fixes https://github.com/sass/sass-spec/issues/495 (partially)