### PR TITLE
Return an exception message to stderr

### DIFF
--- a/lib/sass_spec/engine_adapter.rb
+++ b/lib/sass_spec/engine_adapter.rb
@@ -72,9 +72,9 @@ class SassEngineAdapter < EngineAdapter
         css_output = Sass.compile_file(sass_filename.to_s, :style => style.to_sym)
         [css_output, captured_stderr.to_s, 0]
       rescue Sass::SyntaxError => e
-        [Sass::SyntaxError.exception_to_css(e), captured_stderr.string, 1]
+        ["", "Error: " + e.message.to_s, 1]
       rescue => e
-        [Sass::SyntaxError.exception_to_css(e), captured_stderr.string, 2]
+        ["", e.to_s, 2]
       end
     ensure
       $stderr = real_stderr


### PR DESCRIPTION
Fully-formatted exception as CSS with
a backtrace is useless to have useful
comparison against known errors we
might want to test against.

This is also inconsistent with regards
to other engines invoked via the command-line
(sassc, Ruby sass CLI) - since in that
case the exception is printed on
the standard output.

Therefore return empty string on
the standard output and only an
error message (without backtrace) to stderr.

Fixes: #497 (to some extent)