### PR TITLE
Support tests with indented syntax

### DIFF
--- a/lib/sass_spec/cli.rb
+++ b/lib/sass_spec/cli.rb
@@ -17,7 +17,7 @@ module SassSpec::CLI
 
       # Constants
       output_styles: ["nested", "compressed", "expanded", "compact"],
-      input_file: 'input.scss',
+      input_files: ["input.scss", "input.sass"],
       nested_output_file: 'expected_output',
       compressed_output_file: 'expected.compressed',
       expanded_output_file: 'expected.expanded',

--- a/lib/sass_spec/runner.rb
+++ b/lib/sass_spec/runner.rb
@@ -35,17 +35,19 @@ class SassSpec::Runner
 
   def _get_cases
     cases = []
-    glob = File.join(@options[:spec_directory], "**", "#{@options[:input_file]}")
-    Dir.glob(glob) do |filename|
-      input = Pathname.new(filename)
-      @options[:output_styles].each do |output_style|
-        folder = File.dirname(filename)
-        output_file_name = @options["#{output_style}_output_file".to_sym]
-        expected_file_path = File.join(folder, output_file_name + ".css")
-        clean_file_name = File.join(folder, output_file_name + ".clean")
-        if File.file?(expected_file_path) && !File.file?(expected_file_path.sub(/\.css$/, ".skip")) && filename.include?(@options[:filter])
-          clean = File.file?(clean_file_name)
-          cases.push SassSpec::TestCase.new(input.realpath(), expected_file_path, output_style, clean, @options)
+    @options[:input_files].each do |input_file|
+      glob = File.join(@options[:spec_directory], "**", input_file)
+      Dir.glob(glob) do |filename|
+        input = Pathname.new(filename)
+        @options[:output_styles].each do |output_style|
+          folder = File.dirname(filename)
+          output_file_name = @options["#{output_style}_output_file".to_sym]
+          expected_file_path = File.join(folder, output_file_name + ".css")
+          clean_file_name = File.join(folder, output_file_name + ".clean")
+          if File.file?(expected_file_path) && !File.file?(expected_file_path.sub(/\.css$/, ".skip")) && filename.include?(@options[:filter])
+            clean = File.file?(clean_file_name)
+            cases.push SassSpec::TestCase.new(input.realpath(), expected_file_path, output_style, clean, @options)
+          end
         end
       end
     end

--- a/spec/sass/basic/input.scss
+++ b/spec/sass/basic/input.scss
@@ -1,1 +1,0 @@
-@import "input.sass";

--- a/spec/sass/imported/expected.compact.css
+++ b/spec/sass/imported/expected.compact.css
@@ -1,0 +1,2 @@
+div a { color: red; }
+div li { color: green; }

--- a/spec/sass/imported/expected.compressed.css
+++ b/spec/sass/imported/expected.compressed.css
@@ -1,0 +1,1 @@
+div a{color:red}div li{color:green}

--- a/spec/sass/imported/expected.expanded.css
+++ b/spec/sass/imported/expected.expanded.css
@@ -1,0 +1,6 @@
+div a {
+  color: red;
+}
+div li {
+  color: green;
+}

--- a/spec/sass/imported/expected_output.css
+++ b/spec/sass/imported/expected_output.css
@@ -1,0 +1,4 @@
+div a {
+  color: red; }
+div li {
+  color: green; }

--- a/spec/sass/imported/imported.sass
+++ b/spec/sass/imported/imported.sass
@@ -1,0 +1,5 @@
+div
+	a
+		color: red
+	li
+		color: green

--- a/spec/sass/imported/input.scss
+++ b/spec/sass/imported/input.scss
@@ -1,0 +1,1 @@
+@import "imported.sass";


### PR DESCRIPTION
Now input.scss and input.sass are
reconignized as valid input names.

Fixes: https://github.com/sass/sass-spec/issues/247