### PR TITLE
Implement --generate format option

### DIFF
--- a/lib/sass_spec/cli.rb
+++ b/lib/sass_spec/cli.rb
@@ -7,6 +7,7 @@ module SassSpec::CLI
     options = {
       engine_adapter: SassEngineAdapter.new("sass"),
       spec_directory: "spec",
+      generate: [],
       tap: false,
       skip: false,
       verbose: false,
@@ -54,6 +55,18 @@ Make sure the command you provide prints to stdout.
 
       opts.on("-c", "--command COMMAND", "Sets a specific binary to run (defaults to '#{options[:engine_adapter]}')") do |v|
         options[:engine_adapter] = ExecutableEngineAdapater.new(v)
+      end
+
+      opts.on("-g", "--generate format", "Run test and generate output files for the specified format or \"all\"") do |v|
+        if v == "all"
+          options[:generate].replace(options[:output_styles])
+        else
+          if options[:output_styles].include?(v)
+            options[:generate] << v
+          else
+            raise "--generate needs a valid output format #{options[:output_styles]} or \"all\""
+          end
+        end
       end
 
       opts.on("--ignore-todo", "Skip any folder named 'todo'") do

--- a/lib/sass_spec/runner.rb
+++ b/lib/sass_spec/runner.rb
@@ -46,7 +46,8 @@ class SassSpec::Runner
           output_file_name = @options["#{output_style}_output_file".to_sym]
           expected_stdout_file_path = File.join(folder, output_file_name + ".css")
           clean_file_name = File.join(folder, output_file_name + ".clean")
-          if ( File.file?(expected_stdout_file_path) ) &&
+          if ( File.file?(expected_stdout_file_path) ||
+               @options[:generate].include?(output_style) ) &&
              !File.file?(expected_stdout_file_path.sub(/\.css$/, ".skip")) &&
              filename.include?(@options[:filter]) 
             clean = File.file?(clean_file_name)
@@ -54,7 +55,9 @@ class SassSpec::Runner
               expected_stdout_file_path,
               expected_stderr_file_path,
               expected_status_file_path,
-              output_style, clean, @options)
+              output_style, clean, 
+              @options[:generate].include?(output_style),
+              @options)
           end
         end
       end

--- a/lib/sass_spec/test.rb
+++ b/lib/sass_spec/test.rb
@@ -9,7 +9,7 @@ def run_spec_test(test_case, options = {})
 
   output, clean_output, error, status = test_case.output
 
-  if options[:nuke]
+  if test_case.overwrite?
     if status != 0
       File.open(test_case.status_path, "w+") do |f|
         f.write(status)

--- a/lib/sass_spec/test_case.rb
+++ b/lib/sass_spec/test_case.rb
@@ -1,6 +1,6 @@
 # This represents a specific test case.
 class SassSpec::TestCase
-  def initialize(input_scss, expected_css, error_file, status_file, style, clean, options = {})
+  def initialize(input_scss, expected_css, error_file, status_file, style, clean, gen, options = {})
     @input_path = input_scss
     @expected_path = expected_css
     @error_path = error_file
@@ -8,6 +8,7 @@ class SassSpec::TestCase
     @output_style = style
     @clean_test = clean
     @options = options
+    @generate = gen
 
     # Probe filesystem once and cache the results
     @should_fail = File.file?(@status_path)
@@ -52,6 +53,10 @@ class SassSpec::TestCase
 
   def todo?
     @input_path.to_s.include? "todo"
+  end
+
+  def overwrite?
+    @generate || @options[:nuke]
   end
 
   def output


### PR DESCRIPTION
With --generate format (or "all") it is possible to run a test case and
generate status, error and up to 4 output files.