### PR TITLE
Remove error file from non-error spec

### DIFF
--- a/spec/misc/warn-directive/error
+++ b/spec/misc/warn-directive/error
@@ -1,3 +1,0 @@
-WARNING: Don't crash the ambulance, whatever you do
-         on line 2 of /home/saper/sw/libsass/sass-spec/spec/misc/warn-directive/input.scss
-


### PR DESCRIPTION
This PR removes an `error` file from a non-error spec. This file causes node-sass' spec suite to fail.