### PR TITLE
Normalise path to spec in error message to `/sass/sass-spec/...`

### DIFF
--- a/spec/libsass-closed-issues/issue_1093/argument/function/error
+++ b/spec/libsass-closed-issues/issue_1093/argument/function/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "...ction foo($bar:": expected expression (e.g. 1px, bold), was "#{}) {"
-        on line 1 of /home/saper/sw/libsass/sass-spec/spec/libsass-todo-issues/issue_1093/argument/function/input.scss
+        on line 1 of /sass/sass-spec/spec/libsass-closed-issues/issue_1093/argument/function/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1093/argument/mixin/error
+++ b/spec/libsass-closed-issues/issue_1093/argument/mixin/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "@mixin foo($bar:": expected expression (e.g. 1px, bold), was "#{}) {"
-        on line 1 of /home/saper/sw/libsass/sass-spec/spec/libsass-todo-issues/issue_1093/argument/mixin/input.scss
+        on line 1 of /sass/sass-spec/spec/libsass-closed-issues/issue_1093/argument/mixin/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1093/assignment/error
+++ b/spec/libsass-closed-issues/issue_1093/assignment/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "$foo: #{": expected expression (e.g. 1px, bold), was "};"
-        on line 1 of /home/saper/sw/libsass/sass-spec/spec/libsass-todo-issues/issue_1093/assignment/input.scss
+        on line 1 of /sass/sass-spec/spec/libsass-closed-issues/issue_1093/assignment/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1093/parameter/function/error
+++ b/spec/libsass-closed-issues/issue_1093/parameter/function/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "$foo: foo(#{": expected expression (e.g. 1px, bold), was "});"
-        on line 5 of /home/saper/sw/libsass/sass-spec/spec/libsass-todo-issues/issue_1093/parameter/function/input.scss
+        on line 5 of /sass/sass-spec/spec/libsass-closed-issues/issue_1093/parameter/function/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1093/parameter/mixin/error
+++ b/spec/libsass-closed-issues/issue_1093/parameter/mixin/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "  @include foo(#{": expected expression (e.g. 1px, bold), was "});"
-        on line 6 of /home/saper/sw/libsass/sass-spec/spec/libsass-todo-issues/issue_1093/parameter/mixin/input.scss
+        on line 6 of /sass/sass-spec/spec/libsass-closed-issues/issue_1093/parameter/mixin/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1093/property/error
+++ b/spec/libsass-closed-issues/issue_1093/property/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "  bar: #{": expected expression (e.g. 1px, bold), was "};"
-        on line 2 of /home/saper/sw/libsass/sass-spec/spec/libsass-todo-issues/issue_1093/property/input.scss
+        on line 2 of /sass/sass-spec/spec/libsass-closed-issues/issue_1093/property/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1355/error
+++ b/spec/libsass-closed-issues/issue_1355/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "  @return": expected expression (e.g. 1px, bold), was ";"
-        on line 2 of /home/saper/sw/libsass/sass-spec/spec/libsass-todo-issues/issue_1355/input.scss
+        on line 2 of /sass/sass-spec/spec/libsass-closed-issues/issue_1355/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1418/dynamic/error
+++ b/spec/libsass-closed-issues/issue_1418/dynamic/error
@@ -1,3 +1,3 @@
 Error: Function missing doesn't support keyword arguments
-        on line 2 of /home/saper/sw/libsass/sass-spec/spec/libsass-todo-issues/issue_1418/dynamic/input.scss
+        on line 2 of /sass/sass-spec/spec/libsass-closed-issues/issue_1418/dynamic/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1418/static/error
+++ b/spec/libsass-closed-issues/issue_1418/static/error
@@ -1,3 +1,3 @@
 Error: Function missing doesn't support keyword arguments
-        on line 2 of /home/saper/sw/libsass/sass-spec/spec/libsass-todo-issues/issue_1418/static/input.scss
+        on line 2 of /sass/sass-spec/spec/libsass-closed-issues/issue_1418/static/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1432/is-superselector/error
+++ b/spec/libsass-closed-issues/issue_1432/is-superselector/error
@@ -1,4 +1,4 @@
 Error: $sub: null is not a valid selector: it must be a string,
        a list of strings, or a list of lists of strings for `is-superselector'
-        on line 1 of /home/saper/sw/libsass/sass-spec/spec/libsass-closed-issues/issue_1432/is-superselector/input.scss
+        on line 1 of /sass/sass-spec/spec/libsass-closed-issues/issue_1432/is-superselector/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1432/selector-append/error
+++ b/spec/libsass-closed-issues/issue_1432/selector-append/error
@@ -1,4 +1,4 @@
 Error: $selectors: null is not a valid selector: it must be a string,
        a list of strings, or a list of lists of strings for `selector-append'
-        on line 1 of /home/saper/sw/libsass/sass-spec/spec/libsass-closed-issues/issue_1432/selector-append/input.scss
+        on line 1 of /sass/sass-spec/spec/libsass-closed-issues/issue_1432/selector-append/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1432/selector-extend/error
+++ b/spec/libsass-closed-issues/issue_1432/selector-extend/error
@@ -1,4 +1,4 @@
 Error: $extender: null is not a valid selector: it must be a string,
        a list of strings, or a list of lists of strings for `selector-extend'
-        on line 1 of /home/saper/sw/libsass/sass-spec/spec/libsass-closed-issues/issue_1432/selector-extend/input.scss
+        on line 1 of /sass/sass-spec/spec/libsass-closed-issues/issue_1432/selector-extend/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1432/selector-nest/error
+++ b/spec/libsass-closed-issues/issue_1432/selector-nest/error
@@ -1,4 +1,4 @@
 Error: $selectors: null is not a valid selector: it must be a string,
        a list of strings, or a list of lists of strings for `selector-nest'
-        on line 1 of /home/saper/sw/libsass/sass-spec/spec/libsass-closed-issues/issue_1432/selector-nest/input.scss
+        on line 1 of /sass/sass-spec/spec/libsass-closed-issues/issue_1432/selector-nest/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1432/selector-parse/error
+++ b/spec/libsass-closed-issues/issue_1432/selector-parse/error
@@ -1,4 +1,4 @@
 Error: $selector: null is not a valid selector: it must be a string,
        a list of strings, or a list of lists of strings for `selector-parse'
-        on line 1 of /home/saper/sw/libsass/sass-spec/spec/libsass-closed-issues/issue_1432/selector-parse/input.scss
+        on line 1 of /sass/sass-spec/spec/libsass-closed-issues/issue_1432/selector-parse/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1432/selector-replace/error
+++ b/spec/libsass-closed-issues/issue_1432/selector-replace/error
@@ -1,4 +1,4 @@
 Error: $replacement: null is not a valid selector: it must be a string,
        a list of strings, or a list of lists of strings for `selector-replace'
-        on line 1 of /home/saper/sw/libsass/sass-spec/spec/libsass-closed-issues/issue_1432/selector-replace/input.scss
+        on line 1 of /sass/sass-spec/spec/libsass-closed-issues/issue_1432/selector-replace/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1432/selector-unify/error
+++ b/spec/libsass-closed-issues/issue_1432/selector-unify/error
@@ -1,4 +1,4 @@
 Error: $selector2: null is not a valid selector: it must be a string,
        a list of strings, or a list of lists of strings for `selector-unify'
-        on line 1 of /home/saper/sw/libsass/sass-spec/spec/libsass-closed-issues/issue_1432/selector-unify/input.scss
+        on line 1 of /sass/sass-spec/spec/libsass-closed-issues/issue_1432/selector-unify/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1432/simple-selectors/error
+++ b/spec/libsass-closed-issues/issue_1432/simple-selectors/error
@@ -1,3 +1,3 @@
 Error: $selector: null is not a string for `simple-selectors'
-        on line 1 of /home/saper/sw/libsass/sass-spec/spec/libsass-closed-issues/issue_1432/simple-selectors/input.scss
+        on line 1 of /sass/sass-spec/spec/libsass-closed-issues/issue_1432/simple-selectors/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1484/error
+++ b/spec/libsass-closed-issues/issue_1484/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "div {": expected "}", was ""
-        on line 2 of /home/saper/sw/libsass/sass-spec/spec/libsass-todo-issues/issue_1484/input.scss
+        on line 2 of /sass/sass-spec/spec/libsass-closed-issues/issue_1484/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1487/error
+++ b/spec/libsass-closed-issues/issue_1487/error
@@ -1,4 +1,4 @@
 Error: Mixin "foo" does not accept a content block.
-        on line 6 of /home/saper/sw/libsass/sass-spec/spec/libsass-todo-issues/issue_1487/input.scss, in `foo'
-        from line 6 of /home/saper/sw/libsass/sass-spec/spec/libsass-todo-issues/issue_1487/input.scss
+        on line 6 of /sass/sass-spec/spec/libsass-closed-issues/issue_1487/input.scss, in `foo'
+        from line 6 of /sass/sass-spec/spec/libsass-closed-issues/issue_1487/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1569/error
+++ b/spec/libsass-closed-issues/issue_1569/error
@@ -1,3 +1,3 @@
 Error: Base-level rules cannot contain the parent-selector-referencing character '&'.
-        on line 2 of /home/saper/sw/libsass/sass-spec/spec/libsass-ok-issues/issue_1569/input.scss
+        on line 2 of /sass/sass-spec/spec/libsass-closed-issues/issue_1569/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1577/error
+++ b/spec/libsass-closed-issues/issue_1577/error
@@ -1,3 +1,3 @@
 Error: Incompatible units: 'px' and '%'.
-        on line 3 of /Users/michael/Projects/Sass/sass-spec/spec/libsass-closed-issues/issue_1577/input.scss
+        on line 3 of /sass/sass-spec/spec/libsass-closed-issues/issue_1577/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1658/error
+++ b/spec/libsass-closed-issues/issue_1658/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS: @else must come after @if
-        on line 1 of /Users/michael/Projects/Sass/sass-spec/spec/libsass-closed-issues/issue_1658/input.scss
+        on line 1 of /sass/sass-spec/spec/libsass-closed-issues/issue_1658/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_698/error
+++ b/spec/libsass-closed-issues/issue_698/error
@@ -1,3 +1,3 @@
 Error: Invalid null operation: ""foo" plus null".
-        on line 2 of /home/saper/sw/libsass/sass-spec/spec/libsass-todo-issues/issue_698/input.scss
+        on line 2 of /sass/sass-spec/spec/libsass-closed-issues/issue_698/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_712/error
+++ b/spec/libsass-closed-issues/issue_712/error
@@ -1,5 +1,5 @@
 Error: You may not @extend an outer selector from within @media.
        You may only @extend selectors within the same directive.
-       From "@extend .foo" on line 7 of /home/saper/sw/libsass/sass-spec/spec/libsass-todo-issues/issue_712/input.scss.
-        on line 1 of /home/saper/sw/libsass/sass-spec/spec/libsass-todo-issues/issue_712/input.scss
+       From "@extend .foo" on line 7 of /sass/sass-spec/spec/libsass-closed-issues/issue_712/input.scss.
+        on line 1 of /sass/sass-spec/spec/libsass-closed-issues/issue_712/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_713/and/error
+++ b/spec/libsass-closed-issues/issue_713/and/error
@@ -1,3 +1,3 @@
 Error: Invalid function name "and".
-        on line  of /home/saper/sw/libsass/sass-spec/spec/libsass-closed-issues/issue_713/and/input.scss
+        on line  of /sass/sass-spec/spec/libsass-closed-issues/issue_713/and/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_713/not/error
+++ b/spec/libsass-closed-issues/issue_713/not/error
@@ -1,3 +1,3 @@
 Error: Invalid function name "not".
-        on line  of /home/saper/sw/libsass/sass-spec/spec/libsass-closed-issues/issue_713/not/input.scss
+        on line  of /sass/sass-spec/spec/libsass-closed-issues/issue_713/not/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_713/or/error
+++ b/spec/libsass-closed-issues/issue_713/or/error
@@ -1,3 +1,3 @@
 Error: Invalid function name "or".
-        on line  of /home/saper/sw/libsass/sass-spec/spec/libsass-closed-issues/issue_713/or/input.scss
+        on line  of /sass/sass-spec/spec/libsass-closed-issues/issue_713/or/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_945/error
+++ b/spec/libsass-closed-issues/issue_945/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "  d:": expected expression (e.g. 1px, bold), was "}"
-        on line 4 of /home/saper/sw/libsass/sass-spec/spec/libsass-todo-issues/issue_945/input.scss
+        on line 4 of /sass/sass-spec/spec/libsass-closed-issues/issue_945/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-issues/issue_1187/error
+++ b/spec/libsass-todo-issues/issue_1187/error
@@ -1,3 +1,3 @@
 Error: Duplicate key "foo" in map ($a: 1, $b: 2).
-        on line 3 of /home/saper/sw/libsass/sass-spec/spec/libsass-todo-issues/issue_1187/input.scss
+        on line 3 of /sass/sass-spec/spec/libsass-todo-issues/issue_1187/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-issues/issue_1266/error
+++ b/spec/libsass-todo-issues/issue_1266/error
@@ -1,3 +1,3 @@
 Error: "blah" is not a number for `min'
-        on line 2 of /home/saper/sw/libsass/sass-spec/spec/libsass-closed-issues/issue_1266/input.scss
+        on line 2 of /sass/sass-spec/spec/libsass-todo-issues/issue_1266/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-issues/issue_1452/error
+++ b/spec/libsass-todo-issues/issue_1452/error
@@ -1,3 +1,3 @@
 Error: () isn't a valid CSS value.
-        on line 2 of /home/saper/sw/libsass/sass-spec/spec/libsass-todo-issues/issue_1452/input.scss
+        on line 2 of /sass/sass-spec/spec/libsass-todo-issues/issue_1452/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-issues/issue_1537/error
+++ b/spec/libsass-todo-issues/issue_1537/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "  a: 1, two": expected ":", was ", 3,"
-        on line 2 of /home/saper/sw/libsass/sass-spec/spec/libsass-todo-issues/issue_1537/input.scss
+        on line 2 of /sass/sass-spec/spec/libsass-todo-issues/issue_1537/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-issues/issue_1550/each_embedded/error
+++ b/spec/libsass-todo-issues/issue_1550/each_embedded/error
@@ -1,3 +1,3 @@
 Error: Functions may not be defined within control directives or other mixins.
-        on line 2 of /home/saper/sw/libsass/sass-spec/spec/libsass-todo-issues/issue_1550/each_embedded/input.scss
+        on line 2 of /sass/sass-spec/spec/libsass-todo-issues/issue_1550/each_embedded/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-issues/issue_1550/for_embedded/error
+++ b/spec/libsass-todo-issues/issue_1550/for_embedded/error
@@ -1,3 +1,3 @@
 Error: Functions may not be defined within control directives or other mixins.
-        on line 2 of /home/saper/sw/libsass/sass-spec/spec/libsass-todo-issues/issue_1550/for_embedded/input.scss
+        on line 2 of /sass/sass-spec/spec/libsass-todo-issues/issue_1550/for_embedded/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-issues/issue_1550/if_embedded/error
+++ b/spec/libsass-todo-issues/issue_1550/if_embedded/error
@@ -1,3 +1,3 @@
 Error: Functions may not be defined within control directives or other mixins.
-        on line 2 of /home/saper/sw/libsass/sass-spec/spec/libsass-todo-issues/issue_1550/if_embedded/input.scss
+        on line 2 of /sass/sass-spec/spec/libsass-todo-issues/issue_1550/if_embedded/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-issues/issue_1550/mixin_embedded/error
+++ b/spec/libsass-todo-issues/issue_1550/mixin_embedded/error
@@ -1,3 +1,3 @@
 Error: Functions may not be defined within control directives or other mixins.
-        on line 2 of /home/saper/sw/libsass/sass-spec/spec/libsass-todo-issues/issue_1550/mixin_embedded/input.scss
+        on line 2 of /sass/sass-spec/spec/libsass-todo-issues/issue_1550/mixin_embedded/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-issues/issue_1550/while_embedded/error
+++ b/spec/libsass-todo-issues/issue_1550/while_embedded/error
@@ -1,3 +1,3 @@
 Error: Functions may not be defined within control directives or other mixins.
-        on line 3 of /home/saper/sw/libsass/sass-spec/spec/libsass-todo-issues/issue_1550/while_embedded/input.scss
+        on line 3 of /sass/sass-spec/spec/libsass-todo-issues/issue_1550/while_embedded/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-issues/issue_1585/error
+++ b/spec/libsass-todo-issues/issue_1585/error
@@ -1,3 +1,3 @@
 Error: Properties are only allowed within rules, directives, mixin includes, or other properties.
-        on line 7 of /home/saper/sw/libsass/sass-spec/spec/libsass-todo-issues/issue_1585/input.scss
+        on line 7 of /sass/sass-spec/spec/libsass-todo-issues/issue_1585/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-issues/issue_871/error
+++ b/spec/libsass-todo-issues/issue_871/error
@@ -1,5 +1,5 @@
 Error: ".bar" failed to @extend ".foo".
        The selector ".foo" was not found.
        Use "@extend .foo !optional" if the extend should be able to fail.
-        on line 2 of /home/saper/sw/libsass/sass-spec/spec/libsass-todo-issues/issue_871/input.scss
+        on line 2 of /sass/sass-spec/spec/libsass-todo-issues/issue_871/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-tests/maps/duplicate-keys/error
+++ b/spec/libsass-todo-tests/maps/duplicate-keys/error
@@ -1,3 +1,3 @@
 Error: Duplicate key "eta" in map (eta: 5, eta: 6).
-        on line 5 of /home/saper/sw/libsass/sass-spec/spec/maps/duplicate-keys-todo/input.scss
+        on line 5 of /sass/sass-spec/spec/libsass-todo-tests/maps/duplicate-keys/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-tests/parent-selector/missing/error
+++ b/spec/libsass-todo-tests/parent-selector/missing/error
@@ -1,5 +1,5 @@
 Error: Base-level rules cannot contain the parent-selector-referencing character '&'.
-        on line 30 of /home/saper/sw/libsass/sass-spec/spec/libsass-todo-tests/parent-selector/missing/input.scss, in `@content'
-        from line 22 of /home/saper/sw/libsass/sass-spec/spec/libsass-todo-tests/parent-selector/missing/input.scss, in `grid-media-query'
-        from line 29 of /home/saper/sw/libsass/sass-spec/spec/libsass-todo-tests/parent-selector/missing/input.scss
+        on line 30 of /sass/sass-spec/spec/libsass-todo-tests/parent-selector/missing/input.scss, in `@content'
+        from line 22 of /sass/sass-spec/spec/libsass-todo-tests/parent-selector/missing/input.scss, in `grid-media-query'
+        from line 29 of /sass/sass-spec/spec/libsass-todo-tests/parent-selector/missing/input.scss
   Use --trace for backtrace.

--- a/spec/misc/error-directive/error
+++ b/spec/misc/error-directive/error
@@ -1,3 +1,3 @@
 Error: Buckle your seatbelt Dorothy, 'cause Kansas is going bye-bye
-        on line 1 of /home/saper/sw/libsass/sass-spec/spec/misc/error-directive/input.scss
+        on line 1 of /sass/sass-spec/spec/misc/error-directive/input.scss
   Use --trace for backtrace.


### PR DESCRIPTION
The diffs caused by difference in paths when nuking test is slowing
down my figuring out a Sass 3.4.19 upgrade path. We should probably
do something like default in sass-spec but this was the fastest
solution to my current problem.