### PR TITLE
Add missing error specs

### DIFF
--- a/spec/colors/basic/error
+++ b/spec/colors/basic/error
@@ -1,0 +1,6 @@
+DEPRECATION WARNING: Passing red, a non-string value, to unquote()
+will be an error in future versions of Sass.
+        on line 8 of /sass/sass-spec/spec/colors/basic/input.scss
+DEPRECATION WARNING: Passing 0xf00, a non-string value, to unquote()
+will be an error in future versions of Sass.
+        on line 9 of /sass/sass-spec/spec/colors/basic/input.scss

--- a/spec/libsass-closed-issues/issue_1106/error
+++ b/spec/libsass-closed-issues/issue_1106/error
@@ -1,0 +1,6 @@
+DEPRECATION WARNING: Passing null, a non-string value, to unquote()
+will be an error in future versions of Sass.
+        on line 7 of /sass/sass-spec/spec/libsass-closed-issues/issue_1106/input.scss
+DEPRECATION WARNING: Passing null, a non-string value, to unquote()
+will be an error in future versions of Sass.
+        on line 13 of /sass/sass-spec/spec/libsass-closed-issues/issue_1106/input.scss

--- a/spec/libsass-closed-issues/issue_1124/error
+++ b/spec/libsass-closed-issues/issue_1124/error
@@ -1,0 +1,6 @@
+DEPRECATION WARNING: Passing null, a non-string value, to unquote()
+will be an error in future versions of Sass.
+        on line 17 of /sass/sass-spec/spec/libsass-closed-issues/issue_1124/input.scss
+DEPRECATION WARNING: Passing null, a non-string value, to unquote()
+will be an error in future versions of Sass.
+        on line 19 of /sass/sass-spec/spec/libsass-closed-issues/issue_1124/input.scss

--- a/spec/libsass-closed-issues/issue_1240/error
+++ b/spec/libsass-closed-issues/issue_1240/error
@@ -1,0 +1,4 @@
+/sass/sass-spec/spec/libsass-closed-issues/issue_1240/input.scss:5 DEBUG: 1
+/sass/sass-spec/spec/libsass-closed-issues/issue_1240/input.scss:6 DEBUG: 2, 3
+/sass/sass-spec/spec/libsass-closed-issues/issue_1240/input.scss:7 DEBUG: 1 (2, 3)
+/sass/sass-spec/spec/libsass-closed-issues/issue_1240/input.scss:8 DEBUG: 1 (2, 3)

--- a/spec/libsass-closed-issues/issue_1243/debug/error
+++ b/spec/libsass-closed-issues/issue_1243/debug/error
@@ -1,0 +1,1 @@
+/sass/sass-spec/spec/libsass-closed-issues/issue_1243/debug/input.scss:1 DEBUG: foo

--- a/spec/libsass-closed-issues/issue_1258/error
+++ b/spec/libsass-closed-issues/issue_1258/error
@@ -1,0 +1,3 @@
+DEPRECATION WARNING: Passing "(-webkit-min-device-pixel-ratio: 2)", "(min-resolution: 192dpi)", a non-string value, to unquote()
+will be an error in future versions of Sass.
+        on line 6 of /sass/sass-spec/spec/libsass-closed-issues/issue_1258/input.scss

--- a/spec/libsass-closed-issues/issue_1291/error
+++ b/spec/libsass-closed-issues/issue_1291/error
@@ -1,0 +1,8 @@
+DEPRECATION WARNING: Passing 3, a non-string value, to unquote()
+will be an error in future versions of Sass.
+        on line 2 of /sass/sass-spec/spec/libsass-closed-issues/issue_1291/input.scss, in `spec1'
+        from line 16 of /sass/sass-spec/spec/libsass-closed-issues/issue_1291/input.scss
+DEPRECATION WARNING: Passing 5, a non-string value, to unquote()
+will be an error in future versions of Sass.
+        on line 7 of /sass/sass-spec/spec/libsass-closed-issues/issue_1291/input.scss, in `spec2'
+        from line 18 of /sass/sass-spec/spec/libsass-closed-issues/issue_1291/input.scss

--- a/spec/libsass-closed-issues/issue_1331/error
+++ b/spec/libsass-closed-issues/issue_1331/error
@@ -1,0 +1,5 @@
+/sass/sass-spec/spec/libsass-closed-issues/issue_1331/input.scss:3 DEBUG: (foo: 1px, null: 2px, false: 3px, true: 4px)
+/sass/sass-spec/spec/libsass-closed-issues/issue_1331/input.scss:4 DEBUG: 1px
+/sass/sass-spec/spec/libsass-closed-issues/issue_1331/input.scss:5 DEBUG: 2px
+/sass/sass-spec/spec/libsass-closed-issues/issue_1331/input.scss:6 DEBUG: 3px
+/sass/sass-spec/spec/libsass-closed-issues/issue_1331/input.scss:7 DEBUG: 4px

--- a/spec/libsass-closed-issues/issue_1336/error
+++ b/spec/libsass-closed-issues/issue_1336/error
@@ -1,0 +1,1 @@
+/sass/sass-spec/spec/libsass-closed-issues/issue_1336/input.scss:1 DEBUG: null

--- a/spec/libsass-closed-issues/issue_1578/error.todo
+++ b/spec/libsass-closed-issues/issue_1578/error.todo
@@ -1,0 +1,2 @@
+WARNING on line 4 of /sass/sass-spec/spec/libsass-closed-issues/issue_1578/input.sass:
+This selector doesn't have any properties and will not be rendered.

--- a/spec/libsass-closed-issues/issue_308/error.todo
+++ b/spec/libsass-closed-issues/issue_308/error.todo
@@ -1,0 +1,6 @@
+WARNING on line 7, column 2 of /sass/sass-spec/spec/libsass-closed-issues/issue_308/input.scss:
+You probably don't mean to use the color value `orange' in interpolation here.
+It may end up represented as #ffa500, which will likely produce invalid CSS.
+Always quote color names when using them as strings (for example, "orange").
+If you really want to use the color value here, use `"" + $var'.
+

--- a/spec/libsass-closed-issues/issue_674/error
+++ b/spec/libsass-closed-issues/issue_674/error
@@ -1,0 +1,4 @@
+DEPRECATION WARNING on line 5 of /sass/sass-spec/spec/libsass-closed-issues/issue_674/input.scss:
+Naming a function "url" is disallowed and will be an error in future versions of Sass.
+This name conflicts with an existing CSS function with special parse rules.
+

--- a/spec/libsass-todo-issues/issue_1096/error
+++ b/spec/libsass-todo-issues/issue_1096/error
@@ -1,0 +1,4 @@
+DEPRECATION WARNING on line 3, column 13 of /sass/sass-spec/spec/libsass-todo-issues/issue_1096/input.scss:
+Unescaped multiline strings are deprecated and will be removed in a future version of Sass.
+To include a newline in a string, use "\a" or "\a " as in CSS.
+

--- a/spec/libsass-todo-tests/color-functions/opacity/opacity/error
+++ b/spec/libsass-todo-tests/color-functions/opacity/opacity/error
@@ -1,0 +1,303 @@
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 0 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 1 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 2 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 3 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 4 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 5 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 6 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 7 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 8 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 9 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 10 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 11 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 12 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 13 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 14 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 15 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 16 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 17 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 18 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 19 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 20 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 21 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 22 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 23 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 24 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 25 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 26 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 27 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 28 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 29 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 30 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 31 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 32 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 33 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 34 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 35 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 36 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 37 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 38 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 39 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 40 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 41 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 42 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 43 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 44 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 45 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 46 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 47 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 48 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 49 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 50 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 51 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 52 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 53 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 54 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 55 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 56 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 57 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 58 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 59 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 60 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 61 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 62 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 63 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 64 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 65 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 66 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 67 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 68 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 69 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 70 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 71 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 72 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 73 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 74 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 75 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 76 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 77 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 78 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 79 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 80 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 81 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 82 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 83 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 84 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 85 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 86 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 87 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 88 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 89 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 90 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 91 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 92 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 93 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 94 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 95 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 96 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 97 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 98 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 99 instead.
+
+DEPRECATION WARNING: Passing a percentage as the alpha value to rgba() will be
+interpreted differently in future versions of Sass. For now, use 100 instead.
+

--- a/spec/libsass-todo-tests/extend-tests/200_test_extend_with_subject_transfers_subject_to_extender/error
+++ b/spec/libsass-todo-tests/extend-tests/200_test_extend_with_subject_transfers_subject_to_extender/error
@@ -1,0 +1,5 @@
+DEPRECATION WARNING on line 1, column 1:
+The subject selector operator "!" is deprecated and will be removed in a future release.
+This operator has been replaced by ":has()" in the CSS spec.
+For example: foo bar:has(baz)
+

--- a/spec/libsass-todo-tests/extend-tests/201_test_extend_with_subject_transfers_subject_to_extender/error
+++ b/spec/libsass-todo-tests/extend-tests/201_test_extend_with_subject_transfers_subject_to_extender/error
@@ -1,0 +1,5 @@
+DEPRECATION WARNING on line 1, column 1:
+The subject selector operator "!" is deprecated and will be removed in a future release.
+This operator has been replaced by ":has()" in the CSS spec.
+For example: foo.x bar.y:has(baz.z)
+

--- a/spec/libsass-todo-tests/extend-tests/202_test_extend_with_subject_retains_subject_on_target/error
+++ b/spec/libsass-todo-tests/extend-tests/202_test_extend_with_subject_retains_subject_on_target/error
@@ -1,0 +1,5 @@
+DEPRECATION WARNING on line 1, column 1:
+The subject selector operator "!" is deprecated and will be removed in a future release.
+This operator has been replaced by ":has()" in the CSS spec.
+For example: .foo:has(.bar)
+

--- a/spec/libsass-todo-tests/extend-tests/203_test_extend_with_subject_transfers_subject_to_target/error
+++ b/spec/libsass-todo-tests/extend-tests/203_test_extend_with_subject_transfers_subject_to_target/error
@@ -1,0 +1,5 @@
+DEPRECATION WARNING on line 1, column 1:
+The subject selector operator "!" is deprecated and will be removed in a future release.
+This operator has been replaced by ":has()" in the CSS spec.
+For example: .bip .bap
+

--- a/spec/libsass-todo-tests/extend-tests/204_test_extend_with_subject_retains_subject_on_extender/error
+++ b/spec/libsass-todo-tests/extend-tests/204_test_extend_with_subject_retains_subject_on_extender/error
@@ -1,0 +1,5 @@
+DEPRECATION WARNING on line 1, column 1:
+The subject selector operator "!" is deprecated and will be removed in a future release.
+This operator has been replaced by ":has()" in the CSS spec.
+For example: .bip:has(.bap)
+

--- a/spec/libsass-todo-tests/extend-tests/205_test_extend_with_subject_fails_with_conflicting_subject/error
+++ b/spec/libsass-todo-tests/extend-tests/205_test_extend_with_subject_fails_with_conflicting_subject/error
@@ -1,0 +1,10 @@
+DEPRECATION WARNING on line 1, column 1:
+The subject selector operator "!" is deprecated and will be removed in a future release.
+This operator has been replaced by ":has()" in the CSS spec.
+For example: x:has(.bar)
+
+DEPRECATION WARNING on line 1, column 1:
+The subject selector operator "!" is deprecated and will be removed in a future release.
+This operator has been replaced by ":has()" in the CSS spec.
+For example: y:has(.bap)
+

--- a/spec/libsass-todo-tests/libsass/delayed/error
+++ b/spec/libsass-todo-tests/libsass/delayed/error
@@ -1,0 +1,6 @@
+WARNING: 2/3
+         on line 21 of /sass/sass-spec/spec/libsass-todo-tests/libsass/delayed/input.scss
+
+WARNING: blah blah
+         on line 31 of /sass/sass-spec/spec/libsass-todo-tests/libsass/delayed/input.scss
+

--- a/spec/libsass-todo-tests/libsass/propsets/error
+++ b/spec/libsass-todo-tests/libsass/propsets/error
@@ -1,0 +1,3 @@
+WARNING: 5
+         on line 28 of /sass/sass-spec/spec/libsass-todo-tests/libsass/propsets/input.scss
+

--- a/spec/libsass-todo-tests/scss-tests/046_test_parent_selector_with_subject/error
+++ b/spec/libsass-todo-tests/scss-tests/046_test_parent_selector_with_subject/error
@@ -1,0 +1,10 @@
+DEPRECATION WARNING on line 1, column 1:
+The subject selector operator "!" is deprecated and will be removed in a future release.
+This operator has been replaced by ":has()" in the CSS spec.
+For example: bar &.baz:has(.bip)
+
+DEPRECATION WARNING on line 1, column 1:
+The subject selector operator "!" is deprecated and will be removed in a future release.
+This operator has been replaced by ":has()" in the CSS spec.
+For example: bar &.baz:has(.bip)
+

--- a/spec/libsass-todo-tests/scss-tests/118_test_parent_selector_with_parent_and_subject/error
+++ b/spec/libsass-todo-tests/scss-tests/118_test_parent_selector_with_parent_and_subject/error
@@ -1,0 +1,5 @@
+DEPRECATION WARNING on line 3, column 1 of /sass/sass-spec/spec/libsass-todo-tests/scss-tests/118_test_parent_selector_with_parent_and_subject/input.scss:
+The subject selector operator "!" is deprecated and will be removed in a future release.
+This operator has been replaced by ":has()" in the CSS spec.
+For example: bar &.baz:has(.bip)
+

--- a/spec/libsass/unquote/error
+++ b/spec/libsass/unquote/error
@@ -1,0 +1,3 @@
+DEPRECATION WARNING: Passing 24, a non-string value, to unquote()
+will be an error in future versions of Sass.
+        on line 6 of /sass/sass-spec/spec/libsass/unquote/input.scss

--- a/spec/libsass/var-args/error
+++ b/spec/libsass/var-args/error
@@ -1,0 +1,6 @@
+WARNING: Mixin bar takes 3 arguments but 5 were passed.
+        on line 35 of /sass/sass-spec/spec/libsass/var-args/input.scss
+This will be an error in future versions of Sass.
+WARNING: Mixin bar takes 3 arguments but 4 were passed.
+        on line 37 of /sass/sass-spec/spec/libsass/var-args/input.scss
+This will be an error in future versions of Sass.

--- a/spec/misc/warn-directive/error
+++ b/spec/misc/warn-directive/error
@@ -1,0 +1,3 @@
+WARNING: Don't crash the ambulance, whatever you do
+         on line 2 of /sass/sass-spec/spec/misc/warn-directive/input.scss
+


### PR DESCRIPTION
This PR adds missing error messages for specs that we're regenerated after error spec support was added.