### PR TITLE
Add spec for PR 1774

### DIFF
--- a/lib/sass_spec/runner.rb
+++ b/lib/sass_spec/runner.rb
@@ -10,6 +10,22 @@ class SassSpec::Runner
     @options = options
   end
 
+  def get_files(path, arr, key)
+    entries = Dir.entries(path, {:encoding=>"UTF-8"})
+    entries.each do |entry|
+      next if entry == '.' || entry == '..'
+
+      entry_path = File.join(Dir.pwd, path, entry)
+
+      if File.directory? entry_path
+        get_files(File.join(path, entry), arr, key)
+      else
+        arr << entry_path if entry == key
+      end
+    end
+    arr  
+  end
+
   def run
     unless @options[:silent] || @options[:tap]
       puts "Recursively searching under directory '#{@options[:spec_directory]}' for test files to test '#{@options[:engine_adapter]}' with."
@@ -36,8 +52,7 @@ class SassSpec::Runner
   def _get_cases
     cases = []
     @options[:input_files].each do |input_file|
-      glob = File.join(@options[:spec_directory], "**", input_file)
-      Dir.glob(glob) do |filename|
+      get_files(@options[:spec_directory], [], input_file).each do |filename|
         input = Pathname.new(filename)
         folder = File.dirname(filename)
         expected_stderr_file_path = File.join(folder, "error")

--- a/spec/libsass/Sáss-UŢF8/expected.compact.css
+++ b/spec/libsass/Sáss-UŢF8/expected.compact.css
@@ -1,0 +1,1 @@
+span.utf8-in-path { margin: auto; }

--- a/spec/libsass/Sáss-UŢF8/expected.compressed.css
+++ b/spec/libsass/Sáss-UŢF8/expected.compressed.css
@@ -1,0 +1,1 @@
+span.utf8-in-path{margin:auto}

--- a/spec/libsass/Sáss-UŢF8/expected.expanded.css
+++ b/spec/libsass/Sáss-UŢF8/expected.expanded.css
@@ -1,0 +1,3 @@
+span.utf8-in-path {
+  margin: auto;
+}

--- a/spec/libsass/Sáss-UŢF8/expected_output.css
+++ b/spec/libsass/Sáss-UŢF8/expected_output.css
@@ -1,0 +1,2 @@
+span.utf8-in-path {
+  margin: auto; }

--- a/spec/libsass/Sáss-UŢF8/input.scss
+++ b/spec/libsass/Sáss-UŢF8/input.scss
@@ -1,0 +1,3 @@
+span.utf8-in-path {
+  margin: auto;
+}


### PR DESCRIPTION
* The `runner.rb` file change fixes the file enumeration issue in Ruby+Windows+Unicode scenario. (@xzyfer, as discussed on Slack)
* The test is added for sassc and future command executors to test this spec against Windows. The actual issue sass/libsass#1774 is untestable via spec, since in order to test that particular case, our `cwd` should have multibyte std::string. We can probably test that scenario via `libsass/appveyor.yml` separately.

Test for: sass/sassc#156.
Depends on: sass/sassc#156 and sass/libsass#1774.