### PR TITLE
Add path cleaning for error spec tests

### DIFF
--- a/lib/sass_spec/test.rb
+++ b/lib/sass_spec/test.rb
@@ -76,7 +76,16 @@ def run_spec_test(test_case, options = {})
 end
 
 def _clean_debug_path(error)
-  error.sub(/^.*?(input.scss:\d+ DEBUG:)/, '\1')
+  pwd = Dir.pwd
+  url = pwd.gsub(/\\/, '\/')
+  error.gsub(/^.*?(input.scss:\d+ DEBUG:)/, '\1')
+       .gsub(/[ 	]+/, " ")
+       .gsub(/#{Regexp.quote(url)}\//, "/sass/sass-spec/")
+       .gsub(/#{Regexp.quote(pwd)}\//, "/sass/sass-spec/")
+       .gsub(/(?:\/todo_|_todo\/)/, "/")
+       .gsub(/\/libsass\-[a-z]+\-test\//, "/")
+       .gsub(/\/libsass\-[a-z]+\-issue/, "/libsass-issue")
+       .strip
 end
 
 

--- a/lib/sass_spec/test_case.rb
+++ b/lib/sass_spec/test_case.rb
@@ -84,7 +84,7 @@ class SassSpec::TestCase
   end
 
   def expected_error
-    @expected_error = File.read(@error_path, :encoding => "utf-8")
+    @expected_error = _clean_error(File.read(@error_path, :encoding => "utf-8"))
   end
 
   def expected_status
@@ -113,6 +113,20 @@ class SassSpec::TestCase
        .gsub(/ *\} */, " }\n")
        .gsub(/;(?:\s*;)+/m, ";")
        .gsub(/;\r?\n }/m, " }")
+       .strip
+  end
+
+  def _clean_error(err)
+    pwd = Dir.pwd
+    url = pwd.gsub(/\\/, '/')
+    err = err.force_encoding('iso-8859-1').encode('utf-8')
+    err.gsub(/^.*?(input.scss:\d+ DEBUG:)/, '\1')
+       .gsub(/[ 	]+/, " ")
+       .gsub(/#{Regexp.quote(url)}\//, "/sass/sass-spec/")
+       .gsub(/#{Regexp.quote(pwd)}\//, "/sass/sass-spec/")
+       .gsub(/(?:\/todo_|_todo\/)/, "/")
+       .gsub(/\/libsass\-[a-z]+\-test\//, "/")
+       .gsub(/\/libsass\-[a-z]+\-issue/, "/libsass-issue")
        .strip
   end
 


### PR DESCRIPTION
I haven't yet tested the nuking functionality, but I'm positive it should also work. Makes CI pass again!