### PR TITLE
Make random test more fault tolerant

### DIFF
--- a/spec/libsass-closed-issues/issue_657/default/input.scss
+++ b/spec/libsass-closed-issues/issue_657/default/input.scss
@@ -1,22 +1,22 @@
 $values: ();
 
 foo {
+    $duplicates: 0;
     $num: random();
     $is-number: type-of($num) == number;
     $is-within-range: $num >= 0 and $num < 1;
-    $is-random: index($values, $num) == null;
     $values: append($values, $num);
 
     @for $i from 1 through 1000 {
       $num: random();
       $is-number: $is-number and type-of($num) == number;
       $is-within-range: $is-within-range and $num >= 0 and $num < 1;
-      $is-random: $is-random and index($values, $num) == null;
+      @if (index($values, $num) != null) { $duplicates: $duplicates + 1; }
       $values: append($values, $num);
     }
 
     is-defined: $num != "random()";
     is-number: $is-number;
     is-within-range: $is-within-range;
-    is-random: $is-random;
+    is-random: $duplicates < 25;
 }


### PR DESCRIPTION
It's valid to get one or two duplicates for multiple
calls to random. Update test to take it into account!

Not sure why, but this is only really occuring after 3.4.16!