### PR TITLE
Improve spec test runner

### DIFF
--- a/lib/sass_spec/test.rb
+++ b/lib/sass_spec/test.rb
@@ -11,7 +11,7 @@ def run_spec_test(test_case, options = {})
 
   if test_case.overwrite?
     if status != 0
-      File.open(test_case.status_path, "w+") do |f|
+      File.open(test_case.status_path, "w+", :binmode => true) do |f|
         f.write(status)
         f.close
       end
@@ -20,7 +20,7 @@ def run_spec_test(test_case, options = {})
     end
 
     if error.length > 0
-      File.open(test_case.error_path, "w+") do |f|
+      File.open(test_case.error_path, "w+", :binmode => true) do |f|
         f.write(error)
         f.close
       end
@@ -28,7 +28,7 @@ def run_spec_test(test_case, options = {})
       File.unlink(test_case.error_path)
     end
 
-    File.open(test_case.expected_path, "w+") do |f|
+    File.open(test_case.expected_path, "w+", :binmode => true) do |f|
       f.write(output)
       f.close
     end
@@ -83,12 +83,12 @@ def _clean_debug_path(error)
   pwd = Dir.pwd
   url = pwd.gsub(/\\/, '\/')
   error.gsub(/^.*?(input.scss:\d+ DEBUG:)/, '\1')
-       .gsub(/[ 	]+/, " ")
+       .gsub(/\/+/, "/")
        .gsub(/#{Regexp.quote(url)}\//, "/sass/sass-spec/")
        .gsub(/#{Regexp.quote(pwd)}\//, "/sass/sass-spec/")
        .gsub(/(?:\/todo_|_todo\/)/, "/")
-       .gsub(/\/libsass\-[a-z]+\-test\//, "/")
-       .gsub(/\/libsass\-[a-z]+\-issue/, "/libsass-issue")
+       .gsub(/\/libsass\-[a-z]+\-tests\//, "/")
+       .gsub(/\/libsass\-[a-z]+\-issues/, "/libsass-issues")
        .strip
 end
 

--- a/lib/sass_spec/test.rb
+++ b/lib/sass_spec/test.rb
@@ -47,15 +47,74 @@ def run_spec_test(test_case, options = {})
     if test_case.verify_stderr?
       # Compare only first line of error output (we can't compare stacktraces etc.)
       begin
+        skip = false
         error_lines = error.each_line
-        error_msg = error_lines.next.rstrip
-        if (error_msg =~ /DEPRECATION WARNING:? on line/)
-          error_msg = error_lines.next.rstrip
+        while error_line = error_lines.next do
+          if (error_line =~ /DEPRECATION WARNING/)
+            skip = false
+          end
+          if (error_line =~ /Error:/)
+            skip = false
+          end
+          # disable once we support this deprecation fully
+          if (error_line =~ /interpolation near operators will be simplified/)
+            skip = true
+            next
+          end
+          # disable once we support this deprecation fully
+          # if (error_line =~ /The subject selector operator \"!\" is deprecated and will be removed/)
+          #   skip = true
+          #   next
+          # end
+          # disable once we support this deprecation fully
+          if (error_line =~ /Passing a percentage as the alpha/)
+            skip = true
+            next
+          end
+          # disable once we support this deprecation fully (partial now)
+          # if (error_line =~ /, a non-string value, to unquote()/)
+          #   skip = true
+          #   next
+          # end
+          if (skip)
+            next
+          end
+          error_msg = error_line.rstrip
+          break
         end
         expected_error_lines = test_case.expected_error.each_line
-        expected_error_msg = expected_error_lines.next.rstrip
-        if (expected_error_msg =~ /DEPRECATION WARNING:? on line/)
-          expected_error_msg = expected_error_lines.next.rstrip
+        while expected_error_line = expected_error_lines.next do
+          if (expected_error_line =~ /DEPRECATION WARNING/)
+            skip = false
+          end
+          if (expected_error_line =~ /Error:/)
+            skip = false
+          end
+          # disable once we support this deprecation fully
+          if (expected_error_line =~ /interpolation near operators will be simplified/)
+            skip = true
+            next
+          end
+          # disable once we support this deprecation fully
+          # if (expected_error_line =~ /The subject selector operator \"!\" is deprecated and will be removed/)
+          #   skip = true
+          #   next
+          # end
+          # disable once we support this deprecation fully
+          if (expected_error_line =~ /Passing a percentage as the alpha/)
+            skip = true
+            next
+          end
+          # disable once we support this deprecation fully (partial now)
+          # if (expected_error_line =~ /, a non-string value, to unquote()/)
+          #   skip = true
+          #   next
+          # end
+          if (skip)
+            next
+          end
+          expected_error_msg = expected_error_line.rstrip
+          break
         end
         error_msg = _clean_debug_path(error_msg)
         expected_error_msg = _clean_debug_path(expected_error_msg)

--- a/lib/sass_spec/test.rb
+++ b/lib/sass_spec/test.rb
@@ -15,6 +15,8 @@ def run_spec_test(test_case, options = {})
         f.write(status)
         f.close
       end
+    elsif (File.file?(test_case.status_path))
+      File.unlink(test_case.status_path)
     end
 
     if error.length > 0
@@ -22,6 +24,8 @@ def run_spec_test(test_case, options = {})
         f.write(error)
         f.close
       end
+    elsif (File.file?(test_case.error_path))
+      File.unlink(test_case.error_path)
     end
 
     File.open(test_case.expected_path, "w+") do |f|

--- a/spec/colors/basic/error
+++ b/spec/colors/basic/error
@@ -1,6 +1,6 @@
 DEPRECATION WARNING: Passing red, a non-string value, to unquote()
 will be an error in future versions of Sass.
-        on line 8 of /sass/sass-spec/spec/colors/basic/input.scss
+        on line 8 of /sass/spec/colors/basic/input.scss
 DEPRECATION WARNING: Passing 0xf00, a non-string value, to unquote()
 will be an error in future versions of Sass.
-        on line 9 of /sass/sass-spec/spec/colors/basic/input.scss
+        on line 9 of /sass/spec/colors/basic/input.scss

--- a/spec/errors/extend/placeholder/missing/error
+++ b/spec/errors/extend/placeholder/missing/error
@@ -1,5 +1,5 @@
 Error: ".baz" failed to @extend "%foo".
        The selector "%foo" was not found.
        Use "@extend %foo !optional" if the extend should be able to fail.
-        on line 2 of /sass/sass-spec/spec/errors/extend/placeholder/missing/input.scss
+        on line 2 of /sass/spec/errors/extend/placeholder/missing/input.scss
   Use --trace for backtrace.

--- a/spec/errors/extend/selector/missing/error
+++ b/spec/errors/extend/selector/missing/error
@@ -1,5 +1,5 @@
 Error: ".baz" failed to @extend ".foo".
        The selector ".foo" was not found.
        Use "@extend .foo !optional" if the extend should be able to fail.
-        on line 2 of /sass/sass-spec/spec/errors/extend/selector/missing/input.scss
+        on line 2 of /sass/spec/errors/extend/selector/missing/input.scss
   Use --trace for backtrace.

--- a/spec/errors/fn-debug/property/error
+++ b/spec/errors/fn-debug/property/error
@@ -1,3 +1,3 @@
 Error: Illegal nesting: Only properties may be nested beneath properties.
-        on line 3 of /sass/sass-spec/spec/errors/fn-debug/property/input.scss
+        on line 3 of /sass/spec/errors/fn-debug/property/input.scss
   Use --trace for backtrace.

--- a/spec/errors/fn-debug/ruleset/error
+++ b/spec/errors/fn-debug/ruleset/error
@@ -1,1 +1,1 @@
-/sass/sass-spec/spec/errors/fn-debug/ruleset/input.scss:2 DEBUG: debug
+/sass/spec/errors/fn-debug/ruleset/input.scss:2 DEBUG: debug

--- a/spec/errors/fn-debug/simple/error
+++ b/spec/errors/fn-debug/simple/error
@@ -1,1 +1,1 @@
-/sass/sass-spec/spec/errors/fn-debug/simple/input.scss:1 DEBUG: debug
+/sass/spec/errors/fn-debug/simple/input.scss:1 DEBUG: debug

--- a/spec/errors/fn-error/property/error
+++ b/spec/errors/fn-error/property/error
@@ -1,3 +1,3 @@
 Error: Illegal nesting: Only properties may be nested beneath properties.
-        on line 3 of /sass/sass-spec/spec/errors/fn-error/property/input.scss
+        on line 3 of /sass/spec/errors/fn-error/property/input.scss
   Use --trace for backtrace.

--- a/spec/errors/fn-error/ruleset/error
+++ b/spec/errors/fn-error/ruleset/error
@@ -1,3 +1,3 @@
 Error: error
-        on line 2 of /sass/sass-spec/spec/errors/fn-error/ruleset/input.scss
+        on line 2 of /sass/spec/errors/fn-error/ruleset/input.scss
   Use --trace for backtrace.

--- a/spec/errors/fn-error/simple/error
+++ b/spec/errors/fn-error/simple/error
@@ -1,3 +1,3 @@
 Error: error
-        on line 1 of /sass/sass-spec/spec/errors/fn-error/simple/input.scss
+        on line 1 of /sass/spec/errors/fn-error/simple/input.scss
   Use --trace for backtrace.

--- a/spec/errors/fn-warn/property/error
+++ b/spec/errors/fn-warn/property/error
@@ -1,3 +1,3 @@
 Error: Illegal nesting: Only properties may be nested beneath properties.
-        on line 3 of /sass/sass-spec/spec/errors/fn-warn/property/input.scss
+        on line 3 of /sass/spec/errors/fn-warn/property/input.scss
   Use --trace for backtrace.

--- a/spec/errors/fn-warn/ruleset/error
+++ b/spec/errors/fn-warn/ruleset/error
@@ -1,2 +1,2 @@
 WARNING: warn
-         on line 2 of /sass/sass-spec/spec/errors/fn-warn/ruleset/input.scss
+         on line 2 of /sass/spec/errors/fn-warn/ruleset/input.scss

--- a/spec/errors/fn-warn/simple/error
+++ b/spec/errors/fn-warn/simple/error
@@ -1,2 +1,2 @@
 WARNING: warn
-         on line 1 of /sass/sass-spec/spec/errors/fn-warn/simple/input.scss
+         on line 1 of /sass/spec/errors/fn-warn/simple/input.scss

--- a/spec/errors/import/file/control-else/error
+++ b/spec/errors/import/file/control-else/error
@@ -1,3 +1,3 @@
 Error: Import directives may not be used within control directives or mixins.
-        on line 3 of /sass/sass-spec/spec/errors/import/file/control-else/input.scss
+        on line 3 of /sass/spec/errors/import/file/control-else/input.scss
   Use --trace for backtrace.

--- a/spec/errors/import/file/control-if/error
+++ b/spec/errors/import/file/control-if/error
@@ -1,3 +1,3 @@
 Error: Import directives may not be used within control directives or mixins.
-        on line 2 of /sass/sass-spec/spec/errors/import/file/control-if/input.scss
+        on line 2 of /sass/spec/errors/import/file/control-if/input.scss
   Use --trace for backtrace.

--- a/spec/errors/import/file/loop/each/error
+++ b/spec/errors/import/file/loop/each/error
@@ -1,3 +1,3 @@
 Error: Import directives may not be used within control directives or mixins.
-        on line 2 of /sass/sass-spec/spec/errors/import/file/loop/each/input.scss
+        on line 2 of /sass/spec/errors/import/file/loop/each/input.scss
   Use --trace for backtrace.

--- a/spec/errors/import/file/loop/for/error
+++ b/spec/errors/import/file/loop/for/error
@@ -1,3 +1,3 @@
 Error: Import directives may not be used within control directives or mixins.
-        on line 2 of /sass/sass-spec/spec/errors/import/file/loop/for/input.scss
+        on line 2 of /sass/spec/errors/import/file/loop/for/input.scss
   Use --trace for backtrace.

--- a/spec/errors/import/file/loop/while/error
+++ b/spec/errors/import/file/loop/while/error
@@ -1,3 +1,3 @@
 Error: Import directives may not be used within control directives or mixins.
-        on line 3 of /sass/sass-spec/spec/errors/import/file/loop/while/input.scss
+        on line 3 of /sass/spec/errors/import/file/loop/while/input.scss
   Use --trace for backtrace.

--- a/spec/errors/import/file/mixin/control-else/inside/error
+++ b/spec/errors/import/file/mixin/control-else/inside/error
@@ -1,3 +1,3 @@
 Error: Import directives may not be used within control directives or mixins.
-        on line 4 of /sass/sass-spec/spec/errors/import/file/mixin/control-else/inside/input.scss
+        on line 4 of /sass/spec/errors/import/file/mixin/control-else/inside/input.scss
   Use --trace for backtrace.

--- a/spec/errors/import/file/mixin/control-else/outside/error
+++ b/spec/errors/import/file/mixin/control-else/outside/error
@@ -1,3 +1,3 @@
 Error: Import directives may not be used within control directives or mixins.
-        on line 2 of /sass/sass-spec/spec/errors/import/file/mixin/control-else/outside/input.scss
+        on line 2 of /sass/spec/errors/import/file/mixin/control-else/outside/input.scss
   Use --trace for backtrace.

--- a/spec/errors/import/file/mixin/control-if/inside/error
+++ b/spec/errors/import/file/mixin/control-if/inside/error
@@ -1,3 +1,3 @@
 Error: Import directives may not be used within control directives or mixins.
-        on line 3 of /sass/sass-spec/spec/errors/import/file/mixin/control-if/inside/input.scss
+        on line 3 of /sass/spec/errors/import/file/mixin/control-if/inside/input.scss
   Use --trace for backtrace.

--- a/spec/errors/import/file/mixin/control-if/outside/error
+++ b/spec/errors/import/file/mixin/control-if/outside/error
@@ -1,3 +1,3 @@
 Error: Import directives may not be used within control directives or mixins.
-        on line 2 of /sass/sass-spec/spec/errors/import/file/mixin/control-if/outside/input.scss
+        on line 2 of /sass/spec/errors/import/file/mixin/control-if/outside/input.scss
   Use --trace for backtrace.

--- a/spec/errors/import/file/mixin/simple/inside/error
+++ b/spec/errors/import/file/mixin/simple/inside/error
@@ -1,4 +1,4 @@
 Error: Undefined variable: "$family".
-        on line 2 of /sass/sass-spec/spec/errors/import/file/mixin/simple/inside/input.scss, in `import-google-fonts'
-        from line 6 of /sass/sass-spec/spec/errors/import/file/mixin/simple/inside/input.scss
+        on line 2 of /sass/spec/errors/import/file/mixin/simple/inside/input.scss, in `import-google-fonts'
+        from line 6 of /sass/spec/errors/import/file/mixin/simple/inside/input.scss
   Use --trace for backtrace.

--- a/spec/errors/import/miss/control-else/error
+++ b/spec/errors/import/miss/control-else/error
@@ -1,3 +1,3 @@
 Error: Import directives may not be used within control directives or mixins.
-        on line 3 of /sass/sass-spec/spec/errors/import/miss/control-else/input.scss
+        on line 3 of /sass/spec/errors/import/miss/control-else/input.scss
   Use --trace for backtrace.

--- a/spec/errors/import/miss/control-if/error
+++ b/spec/errors/import/miss/control-if/error
@@ -1,3 +1,3 @@
 Error: Import directives may not be used within control directives or mixins.
-        on line 2 of /sass/sass-spec/spec/errors/import/miss/control-if/input.scss
+        on line 2 of /sass/spec/errors/import/miss/control-if/input.scss
   Use --trace for backtrace.

--- a/spec/errors/import/miss/loop/each/error
+++ b/spec/errors/import/miss/loop/each/error
@@ -1,3 +1,3 @@
 Error: Import directives may not be used within control directives or mixins.
-        on line 2 of /sass/sass-spec/spec/errors/import/miss/loop/each/input.scss
+        on line 2 of /sass/spec/errors/import/miss/loop/each/input.scss
   Use --trace for backtrace.

--- a/spec/errors/import/miss/loop/for/error
+++ b/spec/errors/import/miss/loop/for/error
@@ -1,3 +1,3 @@
 Error: Import directives may not be used within control directives or mixins.
-        on line 2 of /sass/sass-spec/spec/errors/import/miss/loop/for/input.scss
+        on line 2 of /sass/spec/errors/import/miss/loop/for/input.scss
   Use --trace for backtrace.

--- a/spec/errors/import/miss/loop/while/error
+++ b/spec/errors/import/miss/loop/while/error
@@ -1,3 +1,3 @@
 Error: Import directives may not be used within control directives or mixins.
-        on line 3 of /sass/sass-spec/spec/errors/import/miss/loop/while/input.scss
+        on line 3 of /sass/spec/errors/import/miss/loop/while/input.scss
   Use --trace for backtrace.

--- a/spec/errors/import/miss/mixin/control-else/inside/error
+++ b/spec/errors/import/miss/mixin/control-else/inside/error
@@ -1,3 +1,3 @@
 Error: Import directives may not be used within control directives or mixins.
-        on line 4 of /sass/sass-spec/spec/errors/import/miss/mixin/control-else/inside/input.scss
+        on line 4 of /sass/spec/errors/import/miss/mixin/control-else/inside/input.scss
   Use --trace for backtrace.

--- a/spec/errors/import/miss/mixin/control-else/outside/error
+++ b/spec/errors/import/miss/mixin/control-else/outside/error
@@ -1,3 +1,3 @@
 Error: Import directives may not be used within control directives or mixins.
-        on line 2 of /sass/sass-spec/spec/errors/import/miss/mixin/control-else/outside/input.scss
+        on line 2 of /sass/spec/errors/import/miss/mixin/control-else/outside/input.scss
   Use --trace for backtrace.

--- a/spec/errors/import/miss/mixin/control-if/inside/error
+++ b/spec/errors/import/miss/mixin/control-if/inside/error
@@ -1,3 +1,3 @@
 Error: Import directives may not be used within control directives or mixins.
-        on line 3 of /sass/sass-spec/spec/errors/import/miss/mixin/control-if/inside/input.scss
+        on line 3 of /sass/spec/errors/import/miss/mixin/control-if/inside/input.scss
   Use --trace for backtrace.

--- a/spec/errors/import/miss/mixin/control-if/outside/error
+++ b/spec/errors/import/miss/mixin/control-if/outside/error
@@ -1,3 +1,3 @@
 Error: Import directives may not be used within control directives or mixins.
-        on line 2 of /sass/sass-spec/spec/errors/import/miss/mixin/control-if/outside/input.scss
+        on line 2 of /sass/spec/errors/import/miss/mixin/control-if/outside/input.scss
   Use --trace for backtrace.

--- a/spec/errors/import/miss/mixin/simple/inside/error
+++ b/spec/errors/import/miss/mixin/simple/inside/error
@@ -1,4 +1,4 @@
 Error: Undefined variable: "$family".
-        on line 2 of /sass/sass-spec/spec/errors/import/miss/mixin/simple/inside/input.scss, in `import-google-fonts'
-        from line 6 of /sass/sass-spec/spec/errors/import/miss/mixin/simple/inside/input.scss
+        on line 2 of /sass/spec/errors/import/miss/mixin/simple/inside/input.scss, in `import-google-fonts'
+        from line 6 of /sass/spec/errors/import/miss/mixin/simple/inside/input.scss
   Use --trace for backtrace.

--- a/spec/errors/import/url/mixin/simple/inside/error
+++ b/spec/errors/import/url/mixin/simple/inside/error
@@ -1,4 +1,4 @@
 Error: Undefined variable: "$family".
-        on line 2 of /sass/sass-spec/spec/errors/import/url/mixin/simple/inside/input.scss, in `import-google-fonts'
-        from line 6 of /sass/sass-spec/spec/errors/import/url/mixin/simple/inside/input.scss
+        on line 2 of /sass/spec/errors/import/url/mixin/simple/inside/input.scss, in `import-google-fonts'
+        from line 6 of /sass/spec/errors/import/url/mixin/simple/inside/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1093/argument/function/error
+++ b/spec/libsass-closed-issues/issue_1093/argument/function/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "...ction foo($bar:": expected expression (e.g. 1px, bold), was "#{}) {"
-        on line 1 of /sass/sass-spec/spec/libsass-issues/issue_1093/argument/function/input.scss
+        on line 1 of /sass/spec/libsass-issues/issue_1093/argument/function/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1093/argument/mixin/error
+++ b/spec/libsass-closed-issues/issue_1093/argument/mixin/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "@mixin foo($bar:": expected expression (e.g. 1px, bold), was "#{}) {"
-        on line 1 of /sass/sass-spec/spec/libsass-issues/issue_1093/argument/mixin/input.scss
+        on line 1 of /sass/spec/libsass-issues/issue_1093/argument/mixin/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1093/assignment/error
+++ b/spec/libsass-closed-issues/issue_1093/assignment/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "$foo: #{": expected expression (e.g. 1px, bold), was "};"
-        on line 1 of /sass/sass-spec/spec/libsass-issues/issue_1093/assignment/input.scss
+        on line 1 of /sass/spec/libsass-issues/issue_1093/assignment/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1093/parameter/function/error
+++ b/spec/libsass-closed-issues/issue_1093/parameter/function/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "$foo: foo(#{": expected expression (e.g. 1px, bold), was "});"
-        on line 5 of /sass/sass-spec/spec/libsass-issues/issue_1093/parameter/function/input.scss
+        on line 5 of /sass/spec/libsass-issues/issue_1093/parameter/function/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1093/parameter/mixin/error
+++ b/spec/libsass-closed-issues/issue_1093/parameter/mixin/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "  @include foo(#{": expected expression (e.g. 1px, bold), was "});"
-        on line 6 of /sass/sass-spec/spec/libsass-issues/issue_1093/parameter/mixin/input.scss
+        on line 6 of /sass/spec/libsass-issues/issue_1093/parameter/mixin/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1093/property/error
+++ b/spec/libsass-closed-issues/issue_1093/property/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "  bar: #{": expected expression (e.g. 1px, bold), was "};"
-        on line 2 of /sass/sass-spec/spec/libsass-issues/issue_1093/property/input.scss
+        on line 2 of /sass/spec/libsass-issues/issue_1093/property/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1106/error
+++ b/spec/libsass-closed-issues/issue_1106/error
@@ -1,6 +1,6 @@
 DEPRECATION WARNING: Passing null, a non-string value, to unquote()
 will be an error in future versions of Sass.
-        on line 7 of /sass/sass-spec/spec/libsass-issues/issue_1106/input.scss
+        on line 7 of /sass/spec/libsass-issues/issue_1106/input.scss
 DEPRECATION WARNING: Passing null, a non-string value, to unquote()
 will be an error in future versions of Sass.
-        on line 13 of /sass/sass-spec/spec/libsass-issues/issue_1106/input.scss
+        on line 13 of /sass/spec/libsass-issues/issue_1106/input.scss

--- a/spec/libsass-closed-issues/issue_1124/error
+++ b/spec/libsass-closed-issues/issue_1124/error
@@ -1,6 +1,6 @@
 DEPRECATION WARNING: Passing null, a non-string value, to unquote()
 will be an error in future versions of Sass.
-        on line 17 of /sass/sass-spec/spec/libsass-issues/issue_1124/input.scss
+        on line 17 of /sass/spec/libsass-issues/issue_1124/input.scss
 DEPRECATION WARNING: Passing null, a non-string value, to unquote()
 will be an error in future versions of Sass.
-        on line 19 of /sass/sass-spec/spec/libsass-issues/issue_1124/input.scss
+        on line 19 of /sass/spec/libsass-issues/issue_1124/input.scss

--- a/spec/libsass-closed-issues/issue_1169/error/color/error
+++ b/spec/libsass-closed-issues/issue_1169/error/color/error
@@ -1,3 +1,3 @@
 Error: Duplicate key #ff0000 in map (red: "foo", red: "bar").
-        on line 1 of /sass/sass-spec/spec/libsass-issues/issue_1169/error/color/input.scss
+        on line 1 of /sass/spec/libsass-issues/issue_1169/error/color/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1169/error/functioncall/error
+++ b/spec/libsass-closed-issues/issue_1169/error/functioncall/error
@@ -1,3 +1,3 @@
 Error: Duplicate key "key" in map (fncall(1 + 2): "foo", fncall(1 + 2): "bar").
-        on line 5 of /sass/sass-spec/spec/libsass-issues/issue_1169/error/functioncall/input.scss
+        on line 5 of /sass/spec/libsass-issues/issue_1169/error/functioncall/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1169/error/interpolate/error
+++ b/spec/libsass-closed-issues/issue_1169/error/interpolate/error
@@ -1,3 +1,3 @@
 Error: Duplicate key "red" in map ("red": "bar", #{re}#{"d"}: "baz").
-        on line 1 of /sass/sass-spec/spec/libsass-issues/issue_1169/error/interpolate/input.scss
+        on line 1 of /sass/spec/libsass-issues/issue_1169/error/interpolate/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1187/error
+++ b/spec/libsass-closed-issues/issue_1187/error
@@ -1,3 +1,3 @@
 Error: Duplicate key "foo" in map ($a: 1, $b: 2).
-        on line 3 of /sass/sass-spec/spec/libsass-issues/issue_1187/input.scss
+        on line 3 of /sass/spec/libsass-issues/issue_1187/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1240/error
+++ b/spec/libsass-closed-issues/issue_1240/error
@@ -1,4 +1,4 @@
-/sass/sass-spec/spec/libsass-issues/issue_1240/input.scss:5 DEBUG: 1
-/sass/sass-spec/spec/libsass-issues/issue_1240/input.scss:6 DEBUG: 2, 3
-/sass/sass-spec/spec/libsass-issues/issue_1240/input.scss:7 DEBUG: 1 (2, 3)
-/sass/sass-spec/spec/libsass-issues/issue_1240/input.scss:8 DEBUG: 1 (2, 3)
+/sass/spec/libsass-issues/issue_1240/input.scss:5 DEBUG: 1
+/sass/spec/libsass-issues/issue_1240/input.scss:6 DEBUG: 2, 3
+/sass/spec/libsass-issues/issue_1240/input.scss:7 DEBUG: 1 (2, 3)
+/sass/spec/libsass-issues/issue_1240/input.scss:8 DEBUG: 1 (2, 3)

--- a/spec/libsass-closed-issues/issue_1243/debug/error
+++ b/spec/libsass-closed-issues/issue_1243/debug/error
@@ -1,1 +1,1 @@
-/sass/sass-spec/spec/libsass-issues/issue_1243/debug/input.scss:1 DEBUG: foo
+/sass/spec/libsass-issues/issue_1243/debug/input.scss:1 DEBUG: foo

--- a/spec/libsass-closed-issues/issue_1258/error
+++ b/spec/libsass-closed-issues/issue_1258/error
@@ -1,3 +1,3 @@
 DEPRECATION WARNING: Passing "(-webkit-min-device-pixel-ratio: 2)", "(min-resolution: 192dpi)", a non-string value, to unquote()
 will be an error in future versions of Sass.
-        on line 6 of /sass/sass-spec/spec/libsass-issues/issue_1258/input.scss
+        on line 6 of /sass/spec/libsass-issues/issue_1258/input.scss

--- a/spec/libsass-closed-issues/issue_1266/max/error
+++ b/spec/libsass-closed-issues/issue_1266/max/error
@@ -1,3 +1,3 @@
 Error: "blah" is not a number for `max'
-        on line 3 of /sass/sass-spec/spec/libsass-issues/issue_1266/max/input.scss
+        on line 3 of /sass/spec/libsass-issues/issue_1266/max/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1266/min/error
+++ b/spec/libsass-closed-issues/issue_1266/min/error
@@ -1,3 +1,3 @@
 Error: "blah" is not a number for `min'
-        on line 3 of /sass/sass-spec/spec/libsass-issues/issue_1266/min/input.scss
+        on line 3 of /sass/spec/libsass-issues/issue_1266/min/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1291/error
+++ b/spec/libsass-closed-issues/issue_1291/error
@@ -1,8 +1,8 @@
 DEPRECATION WARNING: Passing 3, a non-string value, to unquote()
 will be an error in future versions of Sass.
-        on line 2 of /sass/sass-spec/spec/libsass-issues/issue_1291/input.scss, in `spec1'
-        from line 16 of /sass/sass-spec/spec/libsass-issues/issue_1291/input.scss
+        on line 2 of /sass/spec/libsass-issues/issue_1291/input.scss, in `spec1'
+        from line 16 of /sass/spec/libsass-issues/issue_1291/input.scss
 DEPRECATION WARNING: Passing 5, a non-string value, to unquote()
 will be an error in future versions of Sass.
-        on line 7 of /sass/sass-spec/spec/libsass-issues/issue_1291/input.scss, in `spec2'
-        from line 18 of /sass/sass-spec/spec/libsass-issues/issue_1291/input.scss
+        on line 7 of /sass/spec/libsass-issues/issue_1291/input.scss, in `spec2'
+        from line 18 of /sass/spec/libsass-issues/issue_1291/input.scss

--- a/spec/libsass-closed-issues/issue_1331/error
+++ b/spec/libsass-closed-issues/issue_1331/error
@@ -1,5 +1,5 @@
-/sass/sass-spec/spec/libsass-issues/issue_1331/input.scss:3 DEBUG: (foo: 1px, null: 2px, false: 3px, true: 4px)
-/sass/sass-spec/spec/libsass-issues/issue_1331/input.scss:4 DEBUG: 1px
-/sass/sass-spec/spec/libsass-issues/issue_1331/input.scss:5 DEBUG: 2px
-/sass/sass-spec/spec/libsass-issues/issue_1331/input.scss:6 DEBUG: 3px
-/sass/sass-spec/spec/libsass-issues/issue_1331/input.scss:7 DEBUG: 4px
+/sass/spec/libsass-issues/issue_1331/input.scss:3 DEBUG: (foo: 1px, null: 2px, false: 3px, true: 4px)
+/sass/spec/libsass-issues/issue_1331/input.scss:4 DEBUG: 1px
+/sass/spec/libsass-issues/issue_1331/input.scss:5 DEBUG: 2px
+/sass/spec/libsass-issues/issue_1331/input.scss:6 DEBUG: 3px
+/sass/spec/libsass-issues/issue_1331/input.scss:7 DEBUG: 4px

--- a/spec/libsass-closed-issues/issue_1336/error
+++ b/spec/libsass-closed-issues/issue_1336/error
@@ -1,1 +1,1 @@
-/sass/sass-spec/spec/libsass-issues/issue_1336/input.scss:1 DEBUG: null
+/sass/spec/libsass-issues/issue_1336/input.scss:1 DEBUG: null

--- a/spec/libsass-closed-issues/issue_1355/error
+++ b/spec/libsass-closed-issues/issue_1355/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "  @return": expected expression (e.g. 1px, bold), was ";"
-        on line 2 of /sass/sass-spec/spec/libsass-issues/issue_1355/input.scss
+        on line 2 of /sass/spec/libsass-issues/issue_1355/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1418/dynamic/error
+++ b/spec/libsass-closed-issues/issue_1418/dynamic/error
@@ -1,3 +1,3 @@
 Error: Function missing doesn't support keyword arguments
-        on line 2 of /sass/sass-spec/spec/libsass-issues/issue_1418/dynamic/input.scss
+        on line 2 of /sass/spec/libsass-issues/issue_1418/dynamic/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1418/static/error
+++ b/spec/libsass-closed-issues/issue_1418/static/error
@@ -1,3 +1,3 @@
 Error: Function missing doesn't support keyword arguments
-        on line 2 of /sass/sass-spec/spec/libsass-issues/issue_1418/static/input.scss
+        on line 2 of /sass/spec/libsass-issues/issue_1418/static/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1432/is-superselector/error
+++ b/spec/libsass-closed-issues/issue_1432/is-superselector/error
@@ -1,4 +1,4 @@
 Error: $sub: null is not a valid selector: it must be a string,
        a list of strings, or a list of lists of strings for `is-superselector'
-        on line 1 of /sass/sass-spec/spec/libsass-issues/issue_1432/is-superselector/input.scss
+        on line 1 of /sass/spec/libsass-issues/issue_1432/is-superselector/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1432/selector-append/error
+++ b/spec/libsass-closed-issues/issue_1432/selector-append/error
@@ -1,4 +1,4 @@
 Error: $selectors: null is not a valid selector: it must be a string,
        a list of strings, or a list of lists of strings for `selector-append'
-        on line 1 of /sass/sass-spec/spec/libsass-issues/issue_1432/selector-append/input.scss
+        on line 1 of /sass/spec/libsass-issues/issue_1432/selector-append/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1432/selector-extend/error
+++ b/spec/libsass-closed-issues/issue_1432/selector-extend/error
@@ -1,4 +1,4 @@
 Error: $extender: null is not a valid selector: it must be a string,
        a list of strings, or a list of lists of strings for `selector-extend'
-        on line 1 of /sass/sass-spec/spec/libsass-issues/issue_1432/selector-extend/input.scss
+        on line 1 of /sass/spec/libsass-issues/issue_1432/selector-extend/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1432/selector-nest/error
+++ b/spec/libsass-closed-issues/issue_1432/selector-nest/error
@@ -1,4 +1,4 @@
 Error: $selectors: null is not a valid selector: it must be a string,
        a list of strings, or a list of lists of strings for `selector-nest'
-        on line 1 of /sass/sass-spec/spec/libsass-issues/issue_1432/selector-nest/input.scss
+        on line 1 of /sass/spec/libsass-issues/issue_1432/selector-nest/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1432/selector-parse/error
+++ b/spec/libsass-closed-issues/issue_1432/selector-parse/error
@@ -1,4 +1,4 @@
 Error: $selector: null is not a valid selector: it must be a string,
        a list of strings, or a list of lists of strings for `selector-parse'
-        on line 1 of /sass/sass-spec/spec/libsass-issues/issue_1432/selector-parse/input.scss
+        on line 1 of /sass/spec/libsass-issues/issue_1432/selector-parse/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1432/selector-replace/error
+++ b/spec/libsass-closed-issues/issue_1432/selector-replace/error
@@ -1,4 +1,4 @@
 Error: $replacement: null is not a valid selector: it must be a string,
        a list of strings, or a list of lists of strings for `selector-replace'
-        on line 1 of /sass/sass-spec/spec/libsass-issues/issue_1432/selector-replace/input.scss
+        on line 1 of /sass/spec/libsass-issues/issue_1432/selector-replace/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1432/selector-unify/error
+++ b/spec/libsass-closed-issues/issue_1432/selector-unify/error
@@ -1,4 +1,4 @@
 Error: $selector2: null is not a valid selector: it must be a string,
        a list of strings, or a list of lists of strings for `selector-unify'
-        on line 1 of /sass/sass-spec/spec/libsass-issues/issue_1432/selector-unify/input.scss
+        on line 1 of /sass/spec/libsass-issues/issue_1432/selector-unify/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1432/simple-selectors/error
+++ b/spec/libsass-closed-issues/issue_1432/simple-selectors/error
@@ -1,3 +1,3 @@
 Error: $selector: null is not a string for `simple-selectors'
-        on line 1 of /sass/sass-spec/spec/libsass-issues/issue_1432/simple-selectors/input.scss
+        on line 1 of /sass/spec/libsass-issues/issue_1432/simple-selectors/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1484/error
+++ b/spec/libsass-closed-issues/issue_1484/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "div {": expected "}", was ""
-        on line 2 of /sass/sass-spec/spec/libsass-issues/issue_1484/input.scss
+        on line 2 of /sass/spec/libsass-issues/issue_1484/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1487/error
+++ b/spec/libsass-closed-issues/issue_1487/error
@@ -1,4 +1,4 @@
 Error: Mixin "foo" does not accept a content block.
-        on line 6 of /sass/sass-spec/spec/libsass-issues/issue_1487/input.scss, in `foo'
-        from line 6 of /sass/sass-spec/spec/libsass-issues/issue_1487/input.scss
+        on line 6 of /sass/spec/libsass-issues/issue_1487/input.scss, in `foo'
+        from line 6 of /sass/spec/libsass-issues/issue_1487/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1527/extend/error
+++ b/spec/libsass-closed-issues/issue_1527/extend/error
@@ -1,3 +1,3 @@
 Error: Can't extend &: can't extend parent selectors
-        on line 2 of /sass/sass-spec/spec/libsass-closed-issues/issue_1527/extend/input.scss
+        on line 2 of /sass/spec/libsass-issues/issue_1527/extend/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1527/selector/first/error
+++ b/spec/libsass-closed-issues/issue_1527/selector/first/error
@@ -1,3 +1,3 @@
 Error: Base-level rules cannot contain the parent-selector-referencing character '&'.
-        on line 1 of /sass/sass-spec/spec/libsass-closed-issues/issue_1527/selector/first/input.scss
+        on line 1 of /sass/spec/libsass-issues/issue_1527/selector/first/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1527/selector/last/error
+++ b/spec/libsass-closed-issues/issue_1527/selector/last/error
@@ -1,3 +1,3 @@
 Error: Base-level rules cannot contain the parent-selector-referencing character '&'.
-        on line 1 of /sass/sass-spec/spec/libsass-closed-issues/issue_1527/selector/last/input.scss
+        on line 1 of /sass/spec/libsass-issues/issue_1527/selector/last/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1527/selector/only/error
+++ b/spec/libsass-closed-issues/issue_1527/selector/only/error
@@ -1,3 +1,3 @@
 Error: Base-level rules cannot contain the parent-selector-referencing character '&'.
-        on line 1 of /sass/sass-spec/spec/libsass-closed-issues/issue_1527/selector/only/input.scss
+        on line 1 of /sass/spec/libsass-issues/issue_1527/selector/only/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1550/each_embedded/error
+++ b/spec/libsass-closed-issues/issue_1550/each_embedded/error
@@ -1,3 +1,3 @@
 Error: Functions may not be defined within control directives or other mixins.
-        on line 2 of /sass/sass-spec/spec/libsass-issues/issue_1550/each_embedded/input.scss
+        on line 2 of /sass/spec/libsass-issues/issue_1550/each_embedded/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1550/for_embedded/error
+++ b/spec/libsass-closed-issues/issue_1550/for_embedded/error
@@ -1,3 +1,3 @@
 Error: Functions may not be defined within control directives or other mixins.
-        on line 2 of /sass/sass-spec/spec/libsass-issues/issue_1550/for_embedded/input.scss
+        on line 2 of /sass/spec/libsass-issues/issue_1550/for_embedded/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1550/if_embedded/error
+++ b/spec/libsass-closed-issues/issue_1550/if_embedded/error
@@ -1,3 +1,3 @@
 Error: Functions may not be defined within control directives or other mixins.
-        on line 2 of /sass/sass-spec/spec/libsass-issues/issue_1550/if_embedded/input.scss
+        on line 2 of /sass/spec/libsass-issues/issue_1550/if_embedded/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1550/mixin_embedded/error
+++ b/spec/libsass-closed-issues/issue_1550/mixin_embedded/error
@@ -1,3 +1,3 @@
 Error: Functions may not be defined within control directives or other mixins.
-        on line 2 of /sass/sass-spec/spec/libsass-issues/issue_1550/mixin_embedded/input.scss
+        on line 2 of /sass/spec/libsass-issues/issue_1550/mixin_embedded/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1550/while_embedded/error
+++ b/spec/libsass-closed-issues/issue_1550/while_embedded/error
@@ -1,3 +1,3 @@
 Error: Functions may not be defined within control directives or other mixins.
-        on line 3 of /sass/sass-spec/spec/libsass-issues/issue_1550/while_embedded/input.scss
+        on line 3 of /sass/spec/libsass-issues/issue_1550/while_embedded/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1569/error
+++ b/spec/libsass-closed-issues/issue_1569/error
@@ -1,3 +1,3 @@
 Error: Base-level rules cannot contain the parent-selector-referencing character '&'.
-        on line 2 of /sass/sass-spec/spec/libsass-issues/issue_1569/input.scss
+        on line 2 of /sass/spec/libsass-issues/issue_1569/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1577/error
+++ b/spec/libsass-closed-issues/issue_1577/error
@@ -1,3 +1,3 @@
 Error: Incompatible units: 'px' and '%'.
-        on line 3 of /sass/sass-spec/spec/libsass-issues/issue_1577/input.scss
+        on line 3 of /sass/spec/libsass-issues/issue_1577/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1601/error
+++ b/spec/libsass-closed-issues/issue_1601/error
@@ -1,3 +1,3 @@
 Error: Invalid parent selector for "&.ruby": ".code.ruby >"
-        on line 2 of /sass/sass-spec/spec/libsass-issues/issue_1601/input.scss
+        on line 2 of /sass/spec/libsass-issues/issue_1601/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1606/error
+++ b/spec/libsass-closed-issues/issue_1606/error
@@ -1,3 +1,3 @@
 Error: $limit: "5" is not a number for `random'
-        on line 2 of /sass/sass-spec/spec/libsass-issues/issue_1606/input.scss
+        on line 2 of /sass/spec/libsass-issues/issue_1606/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1651/with/error
+++ b/spec/libsass-closed-issues/issue_1651/with/error
@@ -1,3 +1,3 @@
 Error: Extend directives may only be used within rules.
-        on line 6 of /sass/sass-spec/spec/libsass-issues/issue_1651/with/input.scss
+        on line 6 of /sass/spec/libsass-issues/issue_1651/with/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1658/error
+++ b/spec/libsass-closed-issues/issue_1658/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS: @else must come after @if
-        on line 1 of /sass/sass-spec/spec/libsass-issues/issue_1658/input.scss
+        on line 1 of /sass/spec/libsass-issues/issue_1658/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1670/error
+++ b/spec/libsass-closed-issues/issue_1670/error
@@ -1,5 +1,5 @@
 Error: ".this-should-error" failed to @extend "%an-undefined-placeholder".
        The selector "%an-undefined-placeholder" was not found.
        Use "@extend %an-undefined-placeholder !optional" if the extend should be able to fail.
-        on line 2 of /sass/sass-spec/spec/libsass-issues/issue_1670/input.scss
+        on line 2 of /sass/spec/libsass-issues/issue_1670/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1681/calc/error
+++ b/spec/libsass-closed-issues/issue_1681/calc/error
@@ -1,3 +1,3 @@
-DEPRECATION WARNING on line 1 of /sass/sass-spec/spec/libsass-issues/issue_1681/calc/input.scss:
+DEPRECATION WARNING on line 1 of /sass/spec/libsass-issues/issue_1681/calc/input.scss:
 Naming a function "calc" is disallowed and will be an error in future versions of Sass.
 This name conflicts with an existing CSS function with special parse rules.

--- a/spec/libsass-closed-issues/issue_1681/element/error
+++ b/spec/libsass-closed-issues/issue_1681/element/error
@@ -1,3 +1,3 @@
-DEPRECATION WARNING on line 1 of /sass/sass-spec/spec/libsass-issues/issue_1681/element/input.scss:
+DEPRECATION WARNING on line 1 of /sass/spec/libsass-issues/issue_1681/element/input.scss:
 Naming a function "element" is disallowed and will be an error in future versions of Sass.
 This name conflicts with an existing CSS function with special parse rules.

--- a/spec/libsass-closed-issues/issue_1681/expression/error
+++ b/spec/libsass-closed-issues/issue_1681/expression/error
@@ -1,3 +1,3 @@
-DEPRECATION WARNING on line 1 of /sass/sass-spec/spec/libsass-issues/issue_1681/expression/input.scss:
+DEPRECATION WARNING on line 1 of /sass/spec/libsass-issues/issue_1681/expression/input.scss:
 Naming a function "expression" is disallowed and will be an error in future versions of Sass.
 This name conflicts with an existing CSS function with special parse rules.

--- a/spec/libsass-closed-issues/issue_1681/url/error
+++ b/spec/libsass-closed-issues/issue_1681/url/error
@@ -1,3 +1,3 @@
-DEPRECATION WARNING on line 1 of /sass/sass-spec/spec/libsass-issues/issue_1681/url/input.scss:
+DEPRECATION WARNING on line 1 of /sass/spec/libsass-issues/issue_1681/url/input.scss:
 Naming a function "url" is disallowed and will be an error in future versions of Sass.
 This name conflicts with an existing CSS function with special parse rules.

--- a/spec/libsass-closed-issues/issue_1683/function/error
+++ b/spec/libsass-closed-issues/issue_1683/function/error
@@ -1,3 +1,3 @@
 WARNING: Function foo takes 2 arguments but 3 were passed.
-        on line 4 of /sass/sass-spec/spec/libsass-issues/issue_1683/function/input.scss
+        on line 4 of /sass/spec/libsass-issues/issue_1683/function/input.scss
 This will be an error in future versions of Sass.

--- a/spec/libsass-closed-issues/issue_1683/mixin/error
+++ b/spec/libsass-closed-issues/issue_1683/mixin/error
@@ -1,3 +1,3 @@
 WARNING: Mixin foo takes 2 arguments but 3 were passed.
-        on line 4 of /sass/sass-spec/spec/libsass-issues/issue_1683/mixin/input.scss
+        on line 4 of /sass/spec/libsass-issues/issue_1683/mixin/input.scss
 This will be an error in future versions of Sass.

--- a/spec/libsass-closed-issues/issue_1715/error
+++ b/spec/libsass-closed-issues/issue_1715/error
@@ -1,3 +1,3 @@
 Error: wrong number of arguments (2 for 1) for `red'
-        on line 2 of /sass/sass-spec/spec/libsass-issues/issue_1715/input.scss
+        on line 2 of /sass/spec/libsass-issues/issue_1715/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1801/import-cycle/error
+++ b/spec/libsass-closed-issues/issue_1801/import-cycle/error
@@ -1,8 +1,8 @@
 Error: An @import loop has been found:
-           /sass/sass-spec/spec/libsass-issues/issue_1801/import-cycle/input.scss imports /sass/sass-spec/spec/libsass-issues/issue_1801/import-cycle/_alpha.scss
-           /sass/sass-spec/spec/libsass-issues/issue_1801/import-cycle/_alpha.scss imports /sass/sass-spec/spec/libsass-issues/issue_1801/import-cycle/_beta.scss
-           /sass/sass-spec/spec/libsass-issues/issue_1801/import-cycle/_beta.scss imports /sass/sass-spec/spec/libsass-issues/issue_1801/import-cycle/_alpha.scss
-        on line 1 of /sass/sass-spec/spec/libsass-issues/issue_1801/import-cycle/_beta.scss
-        from line 1 of /sass/sass-spec/spec/libsass-issues/issue_1801/import-cycle/_alpha.scss
-        from line 1 of /sass/sass-spec/spec/libsass-issues/issue_1801/import-cycle/input.scss
+           /sass/spec/libsass-issues/issue_1801/import-cycle/input.scss imports /sass/spec/libsass-issues/issue_1801/import-cycle/_alpha.scss
+           /sass/spec/libsass-issues/issue_1801/import-cycle/_alpha.scss imports /sass/spec/libsass-issues/issue_1801/import-cycle/_beta.scss
+           /sass/spec/libsass-issues/issue_1801/import-cycle/_beta.scss imports /sass/spec/libsass-issues/issue_1801/import-cycle/_alpha.scss
+        on line 1 of /sass/spec/libsass-issues/issue_1801/import-cycle/_beta.scss
+        from line 1 of /sass/spec/libsass-issues/issue_1801/import-cycle/_alpha.scss
+        from line 1 of /sass/spec/libsass-issues/issue_1801/import-cycle/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1803/nested/error
+++ b/spec/libsass-closed-issues/issue_1803/nested/error
@@ -1,3 +1,3 @@
 Error: Illegal nesting: Only properties may be nested beneath properties.
-        on line 5 of /sass/sass-spec/spec/libsass-issues/issue_1803/nested/input.scss
+        on line 5 of /sass/spec/libsass-issues/issue_1803/nested/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_1822/error
+++ b/spec/libsass-closed-issues/issue_1822/error
@@ -1,5 +1,5 @@
 Error: Invalid CSS after ".open": expected "{", was "&"
        
        "&" may only be used at the beginning of a compound selector.
-        on line 2 of /sass/sass-spec/spec/libsass-issues/issue_1822/input.scss
+        on line 2 of /sass/spec/libsass-issues/issue_1822/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_308/error
+++ b/spec/libsass-closed-issues/issue_308/error
@@ -1,0 +1,5 @@
+WARNING on line 7, column 2 of /sass/spec/libsass-issues/issue_308/input.scss:
+You probably don't mean to use the color value `orange' in interpolation here.
+It may end up represented as #ffa500, which will likely produce invalid CSS.
+Always quote color names when using them as strings (for example, "orange").
+If you really want to use the color value here, use `"" + $var'.

--- a/spec/libsass-closed-issues/issue_674/error
+++ b/spec/libsass-closed-issues/issue_674/error
@@ -1,3 +1,3 @@
-DEPRECATION WARNING on line 5 of /sass/sass-spec/spec/libsass-issues/issue_674/input.scss:
+DEPRECATION WARNING on line 5 of /sass/spec/libsass-issues/issue_674/input.scss:
 Naming a function "url" is disallowed and will be an error in future versions of Sass.
 This name conflicts with an existing CSS function with special parse rules.

--- a/spec/libsass-closed-issues/issue_698/error
+++ b/spec/libsass-closed-issues/issue_698/error
@@ -1,3 +1,3 @@
 Error: Invalid null operation: ""foo" plus null".
-        on line 2 of /sass/sass-spec/spec/libsass-issues/issue_698/input.scss
+        on line 2 of /sass/spec/libsass-issues/issue_698/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_712/error
+++ b/spec/libsass-closed-issues/issue_712/error
@@ -1,5 +1,5 @@
 Error: You may not @extend an outer selector from within @media.
        You may only @extend selectors within the same directive.
-       From "@extend .foo" on line 7 of /sass/sass-spec/spec/libsass-issues/issue_712/input.scss.
-        on line 1 of /sass/sass-spec/spec/libsass-issues/issue_712/input.scss
+       From "@extend .foo" on line 7 of /sass/spec/libsass-issues/issue_712/input.scss.
+        on line 1 of /sass/spec/libsass-issues/issue_712/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_713/and/error
+++ b/spec/libsass-closed-issues/issue_713/and/error
@@ -1,3 +1,3 @@
 Error: Invalid function name "and".
-        on line  of /sass/sass-spec/spec/libsass-issues/issue_713/and/input.scss
+        on line  of /sass/spec/libsass-issues/issue_713/and/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_713/not/error
+++ b/spec/libsass-closed-issues/issue_713/not/error
@@ -1,3 +1,3 @@
 Error: Invalid function name "not".
-        on line  of /sass/sass-spec/spec/libsass-issues/issue_713/not/input.scss
+        on line  of /sass/spec/libsass-issues/issue_713/not/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_713/or/error
+++ b/spec/libsass-closed-issues/issue_713/or/error
@@ -1,3 +1,3 @@
 Error: Invalid function name "or".
-        on line  of /sass/sass-spec/spec/libsass-issues/issue_713/or/input.scss
+        on line  of /sass/spec/libsass-issues/issue_713/or/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_871/error
+++ b/spec/libsass-closed-issues/issue_871/error
@@ -1,5 +1,5 @@
 Error: ".bar" failed to @extend ".foo".
        The selector ".foo" was not found.
        Use "@extend .foo !optional" if the extend should be able to fail.
-        on line 2 of /sass/sass-spec/spec/libsass-issues/issue_871/input.scss
+        on line 2 of /sass/spec/libsass-issues/issue_871/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_945/error
+++ b/spec/libsass-closed-issues/issue_945/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "  d:": expected expression (e.g. 1px, bold), was "}"
-        on line 4 of /sass/sass-spec/spec/libsass-issues/issue_945/input.scss
+        on line 4 of /sass/spec/libsass-issues/issue_945/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-issues/issue_1096/error
+++ b/spec/libsass-todo-issues/issue_1096/error
@@ -1,3 +1,0 @@
-DEPRECATION WARNING on line 4, column 13 of /sass/sass-spec/spec/libsass-issues/issue_1096/input.scss:
-Unescaped multiline strings are deprecated and will be removed in a future version of Sass.
-To include a newline in a string, use "\a" or "\a " as in CSS.

--- a/spec/libsass-todo-issues/issue_1452/error
+++ b/spec/libsass-todo-issues/issue_1452/error
@@ -1,3 +1,3 @@
 Error: () isn't a valid CSS value.
-        on line 2 of /sass/sass-spec/spec/libsass-issues/issue_1452/input.scss
+        on line 2 of /sass/spec/libsass-issues/issue_1452/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-issues/issue_1537/error
+++ b/spec/libsass-todo-issues/issue_1537/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "  a: 1, two": expected ":", was ", 3,"
-        on line 2 of /sass/sass-spec/spec/libsass-issues/issue_1537/input.scss
+        on line 2 of /sass/spec/libsass-issues/issue_1537/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-issues/issue_1585/error
+++ b/spec/libsass-todo-issues/issue_1585/error
@@ -1,3 +1,3 @@
 Error: Properties are only allowed within rules, directives, mixin includes, or other properties.
-        on line 7 of /sass/sass-spec/spec/libsass-issues/issue_1585/input.scss
+        on line 7 of /sass/spec/libsass-issues/issue_1585/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-issues/issue_1644/complex/error
+++ b/spec/libsass-todo-issues/issue_1644/complex/error
@@ -1,5 +1,5 @@
 Error: Base-level rules cannot contain the parent-selector-referencing character '&'.
-        on line 30 of /sass/sass-spec/spec/libsass-issues/issue_1644/complex/input.scss, in `@content'
-        from line 22 of /sass/sass-spec/spec/libsass-issues/issue_1644/complex/input.scss, in `grid-media-query'
-        from line 29 of /sass/sass-spec/spec/libsass-issues/issue_1644/complex/input.scss
+        on line 30 of /sass/spec/libsass-issues/issue_1644/complex/input.scss, in `@content'
+        from line 22 of /sass/spec/libsass-issues/issue_1644/complex/input.scss, in `grid-media-query'
+        from line 29 of /sass/spec/libsass-issues/issue_1644/complex/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-issues/issue_1644/mixin-parent/error
+++ b/spec/libsass-todo-issues/issue_1644/mixin-parent/error
@@ -1,5 +1,5 @@
 Error: Base-level rules cannot contain the parent-selector-referencing character '&'.
-        on line 6 of /sass/sass-spec/spec/libsass-issues/issue_1644/mixin-parent/input.scss, in `@content'
-        from line 2 of /sass/sass-spec/spec/libsass-issues/issue_1644/mixin-parent/input.scss, in `parent'
-        from line 5 of /sass/sass-spec/spec/libsass-issues/issue_1644/mixin-parent/input.scss
+        on line 6 of /sass/spec/libsass-issues/issue_1644/mixin-parent/input.scss, in `@content'
+        from line 2 of /sass/spec/libsass-issues/issue_1644/mixin-parent/input.scss, in `parent'
+        from line 5 of /sass/spec/libsass-issues/issue_1644/mixin-parent/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-issues/issue_1694/quoted-right-dbl-paren/error
+++ b/spec/libsass-todo-issues/issue_1694/quoted-right-dbl-paren/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "...ha(opacity=20\)": expected ";", was ");"
-        on line 2 of /sass/sass-spec/spec/libsass-issues/issue_1694/quoted-right-dbl-paren/input.scss
+        on line 2 of /sass/spec/libsass-issues/issue_1694/quoted-right-dbl-paren/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-issues/issue_1706/error
+++ b/spec/libsass-todo-issues/issue_1706/error
@@ -1,7 +1,7 @@
-DEPRECATION WARNING on line 1 of /sass/sass-spec/spec/libsass-issues/issue_1706/input.scss:
+DEPRECATION WARNING on line 1 of /sass/spec/libsass-issues/issue_1706/input.scss:
 Naming a function "calc" is disallowed and will be an error in future versions of Sass.
 This name conflicts with an existing CSS function with special parse rules.
 
-DEPRECATION WARNING on line 2 of /sass/sass-spec/spec/libsass-issues/issue_1706/input.scss:
+DEPRECATION WARNING on line 2 of /sass/spec/libsass-issues/issue_1706/input.scss:
 Naming a function "-foo-calc" is disallowed and will be an error in future versions of Sass.
 This name conflicts with an existing CSS function with special parse rules.

--- a/spec/libsass-todo-issues/issue_1720/error
+++ b/spec/libsass-todo-issues/issue_1720/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "}": expected ";", was ""
-        on line 4 of /sass/sass-spec/spec/libsass-issues/issue_1720/input.scss
+        on line 4 of /sass/spec/libsass-issues/issue_1720/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-issues/issue_1732/error
+++ b/spec/libsass-todo-issues/issue_1732/error
@@ -1,3 +1,3 @@
 Error: Properties are only allowed within rules, directives, mixin includes, or other properties.
-        on line 2 of /sass/sass-spec/spec/libsass-issues/issue_1732/input.scss
+        on line 2 of /sass/spec/libsass-issues/issue_1732/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-issues/issue_1752/error
+++ b/spec/libsass-todo-issues/issue_1752/error
@@ -1,1 +1,1 @@
-/sass/sass-spec/spec/libsass-issues/issue_1752/input.scss:3 DEBUG: ()
+/sass/spec/libsass-issues/issue_1752/input.scss:3 DEBUG: ()

--- a/spec/libsass-todo-issues/issue_1768/error
+++ b/spec/libsass-todo-issues/issue_1768/error
@@ -1,4 +1,4 @@
-/sass/sass-spec/spec/libsass-issues/issue_1768/input.scss:1 DEBUG: ()
-/sass/sass-spec/spec/libsass-issues/issue_1768/input.scss:2 DEBUG: foo, (), bar
-/sass/sass-spec/spec/libsass-issues/issue_1768/input.scss:3 DEBUG: foo () bar
-/sass/sass-spec/spec/libsass-issues/issue_1768/input.scss:4 DEBUG: (foo: (), bar: baz)
+/sass/spec/libsass-issues/issue_1768/input.scss:1 DEBUG: ()
+/sass/spec/libsass-issues/issue_1768/input.scss:2 DEBUG: foo, (), bar
+/sass/spec/libsass-issues/issue_1768/input.scss:3 DEBUG: foo () bar
+/sass/spec/libsass-issues/issue_1768/input.scss:4 DEBUG: (foo: (), bar: baz)

--- a/spec/libsass-todo-issues/issue_1793/error
+++ b/spec/libsass-todo-issues/issue_1793/error
@@ -1,3 +1,3 @@
 Error: 10in*px isn't a valid CSS value.
-        on line 1 of /sass/sass-spec/spec/libsass-issues/issue_1793/input.scss
+        on line 1 of /sass/spec/libsass-issues/issue_1793/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-issues/issue_1801/simple-import-loop/error
+++ b/spec/libsass-todo-issues/issue_1801/simple-import-loop/error
@@ -1,5 +1,5 @@
-Error: An @import loop has been found: /sass/sass-spec/spec/libsass-issues/issue_1801/simple-import-loop/_susy.scss imports itself
-        on line 1 of /sass/sass-spec/spec/libsass-issues/issue_1801/simple-import-loop/_susy.scss
-        from line 1 of /sass/sass-spec/spec/libsass-issues/issue_1801/simple-import-loop/_susy.scss
-        from line 1 of /sass/sass-spec/spec/libsass-issues/issue_1801/simple-import-loop/input.scss
+Error: An @import loop has been found: /sass/spec/libsass-issues/issue_1801/simple-import-loop/_susy.scss imports itself
+        on line 1 of /sass/spec/libsass-issues/issue_1801/simple-import-loop/_susy.scss
+        from line 1 of /sass/spec/libsass-issues/issue_1801/simple-import-loop/_susy.scss
+        from line 1 of /sass/spec/libsass-issues/issue_1801/simple-import-loop/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-issues/issue_1804/inline/error
+++ b/spec/libsass-todo-issues/issue_1804/inline/error
@@ -1,3 +1,3 @@
 Error: 10in*px isn't a valid CSS value.
-        on line 2 of /sass/sass-spec/spec/libsass-issues/issue_1804/inline/input.scss
+        on line 2 of /sass/spec/libsass-issues/issue_1804/inline/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-issues/issue_1804/variable/error
+++ b/spec/libsass-todo-issues/issue_1804/variable/error
@@ -1,3 +1,3 @@
 Error: 10in*px isn't a valid CSS value.
-        on line 5 of /sass/sass-spec/spec/libsass-issues/issue_1804/variable/input.scss
+        on line 5 of /sass/spec/libsass-issues/issue_1804/variable/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-tests/errors/addition/alpha-channels/error
+++ b/spec/libsass-todo-tests/errors/addition/alpha-channels/error
@@ -1,3 +1,3 @@
 Error: Alpha channels must be equal: rgba(16, 16, 16, 0.5) + #aAa
-        on line 4 of /sass/sass-spec/spec/errors/addition/alpha-channels/input.scss
+        on line 4 of /sass/spec/errors/addition/alpha-channels/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-tests/errors/subtraction/alpha-channels/error
+++ b/spec/libsass-todo-tests/errors/subtraction/alpha-channels/error
@@ -1,3 +1,3 @@
 Error: Alpha channels must be equal: rgba(16, 16, 16, 0.5) - #aAa
-        on line 4 of /sass/sass-spec/spec/errors/subtraction/alpha-channels/input.scss
+        on line 4 of /sass/spec/errors/subtraction/alpha-channels/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-tests/extend-tests/200_test_extend_with_subject_transfers_subject_to_extender/error
+++ b/spec/libsass-todo-tests/extend-tests/200_test_extend_with_subject_transfers_subject_to_extender/error
@@ -1,4 +1,0 @@
-DEPRECATION WARNING on line 1, column 1:
-The subject selector operator "!" is deprecated and will be removed in a future release.
-This operator has been replaced by ":has()" in the CSS spec.
-For example: foo bar:has(baz)

--- a/spec/libsass-todo-tests/extend-tests/201_test_extend_with_subject_transfers_subject_to_extender/error
+++ b/spec/libsass-todo-tests/extend-tests/201_test_extend_with_subject_transfers_subject_to_extender/error
@@ -1,4 +1,0 @@
-DEPRECATION WARNING on line 1, column 1:
-The subject selector operator "!" is deprecated and will be removed in a future release.
-This operator has been replaced by ":has()" in the CSS spec.
-For example: foo.x bar.y:has(baz.z)

--- a/spec/libsass-todo-tests/extend-tests/202_test_extend_with_subject_retains_subject_on_target/error
+++ b/spec/libsass-todo-tests/extend-tests/202_test_extend_with_subject_retains_subject_on_target/error
@@ -1,4 +1,0 @@
-DEPRECATION WARNING on line 1, column 1:
-The subject selector operator "!" is deprecated and will be removed in a future release.
-This operator has been replaced by ":has()" in the CSS spec.
-For example: .foo:has(.bar)

--- a/spec/libsass-todo-tests/extend-tests/203_test_extend_with_subject_transfers_subject_to_target/error
+++ b/spec/libsass-todo-tests/extend-tests/203_test_extend_with_subject_transfers_subject_to_target/error
@@ -1,4 +1,0 @@
-DEPRECATION WARNING on line 1, column 1:
-The subject selector operator "!" is deprecated and will be removed in a future release.
-This operator has been replaced by ":has()" in the CSS spec.
-For example: .bip .bap

--- a/spec/libsass-todo-tests/extend-tests/204_test_extend_with_subject_retains_subject_on_extender/error
+++ b/spec/libsass-todo-tests/extend-tests/204_test_extend_with_subject_retains_subject_on_extender/error
@@ -1,4 +1,0 @@
-DEPRECATION WARNING on line 1, column 1:
-The subject selector operator "!" is deprecated and will be removed in a future release.
-This operator has been replaced by ":has()" in the CSS spec.
-For example: .bip:has(.bap)

--- a/spec/libsass-todo-tests/extend-tests/205_test_extend_with_subject_fails_with_conflicting_subject/error
+++ b/spec/libsass-todo-tests/extend-tests/205_test_extend_with_subject_fails_with_conflicting_subject/error
@@ -1,9 +1,0 @@
-DEPRECATION WARNING on line 1, column 1:
-The subject selector operator "!" is deprecated and will be removed in a future release.
-This operator has been replaced by ":has()" in the CSS spec.
-For example: x:has(.bar)
-
-DEPRECATION WARNING on line 1, column 1:
-The subject selector operator "!" is deprecated and will be removed in a future release.
-This operator has been replaced by ":has()" in the CSS spec.
-For example: y:has(.bap)

--- a/spec/libsass-todo-tests/libsass/delayed/error
+++ b/spec/libsass-todo-tests/libsass/delayed/error
@@ -1,5 +1,5 @@
 WARNING: 2/3
-         on line 21 of /sass/sass-spec/spec/libsass-todo-tests/libsass/delayed/input.scss
+         on line 21 of /sass/spec/libsass/delayed/input.scss
 
 WARNING: blah blah
-         on line 31 of /sass/sass-spec/spec/libsass-todo-tests/libsass/delayed/input.scss
+         on line 31 of /sass/spec/libsass/delayed/input.scss

--- a/spec/libsass-todo-tests/libsass/propsets/error
+++ b/spec/libsass-todo-tests/libsass/propsets/error
@@ -1,2 +1,2 @@
 WARNING: 5
-         on line 28 of /sass/sass-spec/spec/libsass-todo-tests/libsass/propsets/input.scss
+         on line 28 of /sass/spec/libsass/propsets/input.scss

--- a/spec/libsass-todo-tests/parent-selector/missing/error
+++ b/spec/libsass-todo-tests/parent-selector/missing/error
@@ -1,5 +1,5 @@
 Error: Base-level rules cannot contain the parent-selector-referencing character '&'.
-        on line 30 of /sass/sass-spec/spec/libsass-todo-tests/parent-selector/missing/input.scss, in `@content'
-        from line 22 of /sass/sass-spec/spec/libsass-todo-tests/parent-selector/missing/input.scss, in `grid-media-query'
-        from line 29 of /sass/sass-spec/spec/libsass-todo-tests/parent-selector/missing/input.scss
+        on line 30 of /sass/spec/parent-selector/missing/input.scss, in `@content'
+        from line 22 of /sass/spec/parent-selector/missing/input.scss, in `grid-media-query'
+        from line 29 of /sass/spec/parent-selector/missing/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-tests/parser/operations/addition/fractions/pairs/error
+++ b/spec/libsass-todo-tests/parser/operations/addition/fractions/pairs/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "  test-17: .25+#{": expected expression (e.g. 1px, bold), was ".}25;"
-        on line 18 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/addition/fractions/pairs/input.scss
+        on line 18 of /sass/spec/parser/operations/addition/fractions/pairs/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-tests/parser/operations/division/fractions/pairs/error
+++ b/spec/libsass-todo-tests/parser/operations/division/fractions/pairs/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "  test-17: .25/#{": expected expression (e.g. 1px, bold), was ".}25;"
-        on line 18 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/division/fractions/pairs/input.scss
+        on line 18 of /sass/spec/parser/operations/division/fractions/pairs/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-tests/parser/operations/logic_eq/dimensions/pairs/error
+++ b/spec/libsass-todo-tests/parser/operations/logic_eq/dimensions/pairs/error
@@ -1,47 +1,47 @@
-DEPRECATION WARNING on line 6 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_eq/dimensions/pairs/input.scss:
+DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
 The result of `10 == 10px` will be `false` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 7 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_eq/dimensions/pairs/input.scss:
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
 The result of `10 == 10px` will be `false` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 8 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_eq/dimensions/pairs/input.scss:
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
 The result of `10 == 10px` will be `false` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 9 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_eq/dimensions/pairs/input.scss:
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
 The result of `10 == 10px` will be `false` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 38 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_eq/dimensions/pairs/input.scss:
+DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
 The result of `10px == 10` will be `false` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 39 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_eq/dimensions/pairs/input.scss:
+DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
 The result of `10px == 10` will be `false` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 40 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_eq/dimensions/pairs/input.scss:
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
 The result of `10px == 10` will be `false` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 41 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_eq/dimensions/pairs/input.scss:
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
 The result of `10px == 10` will be `false` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 42 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_eq/dimensions/pairs/input.scss:
+DEPRECATION WARNING on line 42 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
 The result of `10px == 10` will be `false` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 43 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_eq/dimensions/pairs/input.scss:
+DEPRECATION WARNING on line 43 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
 The result of `10px == 10` will be `false` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 44 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_eq/dimensions/pairs/input.scss:
+DEPRECATION WARNING on line 44 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
 The result of `10px == 10` will be `false` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 45 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_eq/dimensions/pairs/input.scss:
+DEPRECATION WARNING on line 45 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
 The result of `10px == 10` will be `false` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.

--- a/spec/libsass-todo-tests/parser/operations/logic_eq/fractions/pairs/error
+++ b/spec/libsass-todo-tests/parser/operations/logic_eq/fractions/pairs/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "  test-17: .25==#{": expected expression (e.g. 1px, bold), was ".}25;"
-        on line 18 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_eq/fractions/pairs/input.scss
+        on line 18 of /sass/spec/parser/operations/logic_eq/fractions/pairs/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-tests/parser/operations/logic_eq/mixed/pairs/error
+++ b/spec/libsass-todo-tests/parser/operations/logic_eq/mixed/pairs/error
@@ -1,31 +1,31 @@
-DEPRECATION WARNING on line 6 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_eq/mixed/pairs/input.scss:
+DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss:
 The result of `10 == 10%` will be `false` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 7 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_eq/mixed/pairs/input.scss:
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss:
 The result of `10 == 10%` will be `false` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 8 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_eq/mixed/pairs/input.scss:
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss:
 The result of `10 == 10%` will be `false` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 9 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_eq/mixed/pairs/input.scss:
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss:
 The result of `10 == 10%` will be `false` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 10 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_eq/mixed/pairs/input.scss:
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss:
 The result of `10 == 10px` will be `false` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 11 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_eq/mixed/pairs/input.scss:
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss:
 The result of `10 == 10px` will be `false` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 12 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_eq/mixed/pairs/input.scss:
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss:
 The result of `10 == 10px` will be `false` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 13 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_eq/mixed/pairs/input.scss:
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss:
 The result of `10 == 10px` will be `false` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.

--- a/spec/libsass-todo-tests/parser/operations/logic_ge/dimensions/pairs/error
+++ b/spec/libsass-todo-tests/parser/operations/logic_ge/dimensions/pairs/error
@@ -1,3 +1,3 @@
 Error: Undefined operation: "px gte 1".
-        on line 50 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_ge/dimensions/pairs/input.scss
+        on line 50 of /sass/spec/parser/operations/logic_ge/dimensions/pairs/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-tests/parser/operations/logic_ge/fractions/pairs/error
+++ b/spec/libsass-todo-tests/parser/operations/logic_ge/fractions/pairs/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "  test-17: .25>=#{": expected expression (e.g. 1px, bold), was ".}25;"
-        on line 18 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_ge/fractions/pairs/input.scss
+        on line 18 of /sass/spec/parser/operations/logic_ge/fractions/pairs/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-tests/parser/operations/logic_ge/mixed/pairs/error
+++ b/spec/libsass-todo-tests/parser/operations/logic_ge/mixed/pairs/error
@@ -1,3 +1,3 @@
 Error: Undefined operation: "10 gte #AAA".
-        on line 14 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_ge/mixed/pairs/input.scss
+        on line 14 of /sass/spec/parser/operations/logic_ge/mixed/pairs/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-tests/parser/operations/logic_gt/dimensions/pairs/error
+++ b/spec/libsass-todo-tests/parser/operations/logic_gt/dimensions/pairs/error
@@ -1,3 +1,3 @@
 Error: Undefined operation: "px gt 1".
-        on line 50 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_gt/dimensions/pairs/input.scss
+        on line 50 of /sass/spec/parser/operations/logic_gt/dimensions/pairs/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-tests/parser/operations/logic_gt/fractions/pairs/error
+++ b/spec/libsass-todo-tests/parser/operations/logic_gt/fractions/pairs/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "  test-17: .25>#{": expected expression (e.g. 1px, bold), was ".}25;"
-        on line 18 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_gt/fractions/pairs/input.scss
+        on line 18 of /sass/spec/parser/operations/logic_gt/fractions/pairs/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-tests/parser/operations/logic_gt/mixed/pairs/error
+++ b/spec/libsass-todo-tests/parser/operations/logic_gt/mixed/pairs/error
@@ -1,3 +1,3 @@
 Error: Undefined operation: "10 gt #AAA".
-        on line 14 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_gt/mixed/pairs/input.scss
+        on line 14 of /sass/spec/parser/operations/logic_gt/mixed/pairs/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-tests/parser/operations/logic_le/dimensions/pairs/error
+++ b/spec/libsass-todo-tests/parser/operations/logic_le/dimensions/pairs/error
@@ -1,3 +1,3 @@
 Error: Undefined operation: "px lte 1".
-        on line 50 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_le/dimensions/pairs/input.scss
+        on line 50 of /sass/spec/parser/operations/logic_le/dimensions/pairs/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-tests/parser/operations/logic_le/fractions/pairs/error
+++ b/spec/libsass-todo-tests/parser/operations/logic_le/fractions/pairs/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "  test-17: .25<=#{": expected expression (e.g. 1px, bold), was ".}25;"
-        on line 18 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_le/fractions/pairs/input.scss
+        on line 18 of /sass/spec/parser/operations/logic_le/fractions/pairs/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-tests/parser/operations/logic_le/mixed/pairs/error
+++ b/spec/libsass-todo-tests/parser/operations/logic_le/mixed/pairs/error
@@ -1,3 +1,3 @@
 Error: Undefined operation: "10 lte #AAA".
-        on line 14 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_le/mixed/pairs/input.scss
+        on line 14 of /sass/spec/parser/operations/logic_le/mixed/pairs/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-tests/parser/operations/logic_lt/dimensions/pairs/error
+++ b/spec/libsass-todo-tests/parser/operations/logic_lt/dimensions/pairs/error
@@ -1,3 +1,3 @@
 Error: Undefined operation: "px lt 1".
-        on line 50 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_lt/dimensions/pairs/input.scss
+        on line 50 of /sass/spec/parser/operations/logic_lt/dimensions/pairs/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-tests/parser/operations/logic_lt/fractions/pairs/error
+++ b/spec/libsass-todo-tests/parser/operations/logic_lt/fractions/pairs/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "  test-17: .25<#{": expected expression (e.g. 1px, bold), was ".}25;"
-        on line 18 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_lt/fractions/pairs/input.scss
+        on line 18 of /sass/spec/parser/operations/logic_lt/fractions/pairs/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-tests/parser/operations/logic_lt/mixed/pairs/error
+++ b/spec/libsass-todo-tests/parser/operations/logic_lt/mixed/pairs/error
@@ -1,3 +1,3 @@
 Error: Undefined operation: "10 lt #AAA".
-        on line 14 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_lt/mixed/pairs/input.scss
+        on line 14 of /sass/spec/parser/operations/logic_lt/mixed/pairs/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-tests/parser/operations/logic_ne/dimensions/pairs/error
+++ b/spec/libsass-todo-tests/parser/operations/logic_ne/dimensions/pairs/error
@@ -1,47 +1,47 @@
-DEPRECATION WARNING on line 6 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_ne/dimensions/pairs/input.scss:
+DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
 The result of `10 != 10px` will be `true` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 7 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_ne/dimensions/pairs/input.scss:
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
 The result of `10 != 10px` will be `true` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 8 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_ne/dimensions/pairs/input.scss:
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
 The result of `10 != 10px` will be `true` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 9 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_ne/dimensions/pairs/input.scss:
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
 The result of `10 != 10px` will be `true` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 38 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_ne/dimensions/pairs/input.scss:
+DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
 The result of `10px != 10` will be `true` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 39 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_ne/dimensions/pairs/input.scss:
+DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
 The result of `10px != 10` will be `true` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 40 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_ne/dimensions/pairs/input.scss:
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
 The result of `10px != 10` will be `true` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 41 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_ne/dimensions/pairs/input.scss:
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
 The result of `10px != 10` will be `true` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 42 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_ne/dimensions/pairs/input.scss:
+DEPRECATION WARNING on line 42 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
 The result of `10px != 10` will be `true` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 43 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_ne/dimensions/pairs/input.scss:
+DEPRECATION WARNING on line 43 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
 The result of `10px != 10` will be `true` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 44 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_ne/dimensions/pairs/input.scss:
+DEPRECATION WARNING on line 44 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
 The result of `10px != 10` will be `true` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 45 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_ne/dimensions/pairs/input.scss:
+DEPRECATION WARNING on line 45 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
 The result of `10px != 10` will be `true` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.

--- a/spec/libsass-todo-tests/parser/operations/logic_ne/fractions/pairs/error
+++ b/spec/libsass-todo-tests/parser/operations/logic_ne/fractions/pairs/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "  test-17: .25!=#{": expected expression (e.g. 1px, bold), was ".}25;"
-        on line 18 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_ne/fractions/pairs/input.scss
+        on line 18 of /sass/spec/parser/operations/logic_ne/fractions/pairs/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-tests/parser/operations/logic_ne/mixed/pairs/error
+++ b/spec/libsass-todo-tests/parser/operations/logic_ne/mixed/pairs/error
@@ -1,31 +1,31 @@
-DEPRECATION WARNING on line 6 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_ne/mixed/pairs/input.scss:
+DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss:
 The result of `10 != 10%` will be `true` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 7 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_ne/mixed/pairs/input.scss:
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss:
 The result of `10 != 10%` will be `true` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 8 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_ne/mixed/pairs/input.scss:
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss:
 The result of `10 != 10%` will be `true` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 9 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_ne/mixed/pairs/input.scss:
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss:
 The result of `10 != 10%` will be `true` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 10 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_ne/mixed/pairs/input.scss:
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss:
 The result of `10 != 10px` will be `true` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 11 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_ne/mixed/pairs/input.scss:
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss:
 The result of `10 != 10px` will be `true` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 12 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_ne/mixed/pairs/input.scss:
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss:
 The result of `10 != 10px` will be `true` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.
 
-DEPRECATION WARNING on line 13 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/logic_ne/mixed/pairs/input.scss:
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss:
 The result of `10 != 10px` will be `true` in future releases of Sass.
 Unitless numbers will no longer be equal to the same numbers with units.

--- a/spec/libsass-todo-tests/parser/operations/modulo/dimensions/pairs/error
+++ b/spec/libsass-todo-tests/parser/operations/modulo/dimensions/pairs/error
@@ -1,3 +1,3 @@
 Error: Undefined operation: "px mod 1".
-        on line 50 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/modulo/dimensions/pairs/input.scss
+        on line 50 of /sass/spec/parser/operations/modulo/dimensions/pairs/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-tests/parser/operations/modulo/fractions/pairs/error
+++ b/spec/libsass-todo-tests/parser/operations/modulo/fractions/pairs/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "  test-17: .25%#{": expected expression (e.g. 1px, bold), was ".}25;"
-        on line 18 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/modulo/fractions/pairs/input.scss
+        on line 18 of /sass/spec/parser/operations/modulo/fractions/pairs/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-tests/parser/operations/modulo/mixed/pairs/error
+++ b/spec/libsass-todo-tests/parser/operations/modulo/mixed/pairs/error
@@ -1,3 +1,3 @@
 Error: Undefined operation: "10 mod #AAA".
-        on line 15 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/modulo/mixed/pairs/input.scss
+        on line 15 of /sass/spec/parser/operations/modulo/mixed/pairs/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-tests/parser/operations/multiply/fractions/pairs/error
+++ b/spec/libsass-todo-tests/parser/operations/multiply/fractions/pairs/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "  test-17: .25*#{": expected expression (e.g. 1px, bold), was ".}25;"
-        on line 18 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/multiply/fractions/pairs/input.scss
+        on line 18 of /sass/spec/parser/operations/multiply/fractions/pairs/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-tests/parser/operations/multiply/mixed/pairs/error
+++ b/spec/libsass-todo-tests/parser/operations/multiply/mixed/pairs/error
@@ -1,3 +1,3 @@
 Error: 100%*% isn't a valid CSS value.
-        on line 22 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/multiply/mixed/pairs/input.scss
+        on line 22 of /sass/spec/parser/operations/multiply/mixed/pairs/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-tests/parser/operations/subtract/fractions/pairs/error
+++ b/spec/libsass-todo-tests/parser/operations/subtract/fractions/pairs/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "  test-17: .25-#{": expected expression (e.g. 1px, bold), was ".}25;"
-        on line 18 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/subtract/fractions/pairs/input.scss
+        on line 18 of /sass/spec/parser/operations/subtract/fractions/pairs/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-todo-tests/scss-tests/046_test_parent_selector_with_subject/error
+++ b/spec/libsass-todo-tests/scss-tests/046_test_parent_selector_with_subject/error
@@ -1,9 +1,0 @@
-DEPRECATION WARNING on line 1, column 1:
-The subject selector operator "!" is deprecated and will be removed in a future release.
-This operator has been replaced by ":has()" in the CSS spec.
-For example: bar &.baz:has(.bip)
-
-DEPRECATION WARNING on line 1, column 1:
-The subject selector operator "!" is deprecated and will be removed in a future release.
-This operator has been replaced by ":has()" in the CSS spec.
-For example: bar &.baz:has(.bip)

--- a/spec/libsass-todo-tests/scss-tests/118_test_parent_selector_with_parent_and_subject/error
+++ b/spec/libsass-todo-tests/scss-tests/118_test_parent_selector_with_parent_and_subject/error
@@ -1,4 +1,4 @@
-DEPRECATION WARNING on line 3, column 1 of /sass/sass-spec/spec/libsass-todo-tests/scss-tests/118_test_parent_selector_with_parent_and_subject/input.scss:
+DEPRECATION WARNING on line 3, column 1 of /sass/spec/scss-tests/118_test_parent_selector_with_parent_and_subject/input.scss:
 The subject selector operator "!" is deprecated and will be removed in a future release.
 This operator has been replaced by ":has()" in the CSS spec.
 For example: bar &.baz:has(.bip)

--- a/spec/libsass/debug-directive-nested/function/error
+++ b/spec/libsass/debug-directive-nested/function/error
@@ -1,2 +1,2 @@
 WARNING: test
-         on line 2 of /sass/sass-spec/spec/libsass/debug-directive-nested/function/input.scss
+         on line 2 of /sass/spec/libsass/debug-directive-nested/function/input.scss

--- a/spec/libsass/debug-directive-nested/inline/error
+++ b/spec/libsass/debug-directive-nested/inline/error
@@ -1,3 +1,3 @@
 Error: Illegal nesting: Only properties may be nested beneath properties.
-        on line 3 of /sass/sass-spec/spec/libsass-todo-tests/debug-directive-nested/inline/input.scss
+        on line 3 of /sass/spec/libsass/debug-directive-nested/inline/input.scss
   Use --trace for backtrace.

--- a/spec/libsass/debug-directive-nested/mixin/error
+++ b/spec/libsass/debug-directive-nested/mixin/error
@@ -1,3 +1,3 @@
 WARNING: test
-         on line 2 of /sass/sass-spec/spec/libsass/debug-directive-nested/mixin/input.scss, in `c'
-         from line 8 of /sass/sass-spec/spec/libsass/debug-directive-nested/mixin/input.scss
+         on line 2 of /sass/spec/libsass/debug-directive-nested/mixin/input.scss, in `c'
+         from line 8 of /sass/spec/libsass/debug-directive-nested/mixin/input.scss

--- a/spec/libsass/error-directive-nested/function/error
+++ b/spec/libsass/error-directive-nested/function/error
@@ -1,3 +1,3 @@
 Error: test
-        on line 2 of /sass/sass-spec/spec/libsass/error-directive-nested/function/input.scss
+        on line 2 of /sass/spec/libsass/error-directive-nested/function/input.scss
   Use --trace for backtrace.

--- a/spec/libsass/error-directive-nested/inline/error
+++ b/spec/libsass/error-directive-nested/inline/error
@@ -1,3 +1,3 @@
 Error: Illegal nesting: Only properties may be nested beneath properties.
-        on line 3 of /sass/sass-spec/spec/libsass-todo-tests/error-directive-nested/inline/input.scss
+        on line 3 of /sass/spec/libsass/error-directive-nested/inline/input.scss
   Use --trace for backtrace.

--- a/spec/libsass/error-directive-nested/mixin/error
+++ b/spec/libsass/error-directive-nested/mixin/error
@@ -1,4 +1,4 @@
 Error: test
-        on line 2 of /sass/sass-spec/spec/libsass/error-directive-nested/mixin/input.scss, in `c'
-        from line 8 of /sass/sass-spec/spec/libsass/error-directive-nested/mixin/input.scss
+        on line 2 of /sass/spec/libsass/error-directive-nested/mixin/input.scss, in `c'
+        from line 8 of /sass/spec/libsass/error-directive-nested/mixin/input.scss
   Use --trace for backtrace.

--- a/spec/libsass/unquote/error
+++ b/spec/libsass/unquote/error
@@ -1,3 +1,3 @@
 DEPRECATION WARNING: Passing 24, a non-string value, to unquote()
 will be an error in future versions of Sass.
-        on line 6 of /sass/sass-spec/spec/libsass/unquote/input.scss
+        on line 6 of /sass/spec/libsass/unquote/input.scss

--- a/spec/libsass/var-args/error
+++ b/spec/libsass/var-args/error
@@ -1,6 +1,6 @@
 WARNING: Mixin bar takes 3 arguments but 5 were passed.
-        on line 35 of /sass/sass-spec/spec/libsass/var-args/input.scss
+        on line 35 of /sass/spec/libsass/var-args/input.scss
 This will be an error in future versions of Sass.
 WARNING: Mixin bar takes 3 arguments but 4 were passed.
-        on line 37 of /sass/sass-spec/spec/libsass/var-args/input.scss
+        on line 37 of /sass/spec/libsass/var-args/input.scss
 This will be an error in future versions of Sass.

--- a/spec/libsass/warn-directive-nested/function/error
+++ b/spec/libsass/warn-directive-nested/function/error
@@ -1,2 +1,2 @@
 WARNING: test
-         on line 2 of /sass/sass-spec/spec/libsass/warn-directive-nested/function/input.scss
+         on line 2 of /sass/spec/libsass/warn-directive-nested/function/input.scss

--- a/spec/libsass/warn-directive-nested/inline/error
+++ b/spec/libsass/warn-directive-nested/inline/error
@@ -1,3 +1,3 @@
 Error: Illegal nesting: Only properties may be nested beneath properties.
-        on line 3 of /sass/sass-spec/spec/libsass-todo-tests/warn-directive-nested/inline/input.scss
+        on line 3 of /sass/spec/libsass/warn-directive-nested/inline/input.scss
   Use --trace for backtrace.

--- a/spec/libsass/warn-directive-nested/mixin/error
+++ b/spec/libsass/warn-directive-nested/mixin/error
@@ -1,3 +1,3 @@
 WARNING: test
-         on line 2 of /sass/sass-spec/spec/libsass/warn-directive-nested/mixin/input.scss, in `c'
-         from line 8 of /sass/sass-spec/spec/libsass/warn-directive-nested/mixin/input.scss
+         on line 2 of /sass/spec/libsass/warn-directive-nested/mixin/input.scss, in `c'
+         from line 8 of /sass/spec/libsass/warn-directive-nested/mixin/input.scss

--- a/spec/maps/duplicate-keys/error
+++ b/spec/maps/duplicate-keys/error
@@ -1,3 +1,3 @@
 Error: Duplicate key "eta" in map (eta: 5, eta: 6).
-        on line 5 of /sass/sass-spec/spec/libsass-todo-tests/maps/duplicate-keys/input.scss
+        on line 5 of /sass/spec/maps/duplicate-keys/input.scss
   Use --trace for backtrace.

--- a/spec/misc/error-directive/error
+++ b/spec/misc/error-directive/error
@@ -1,3 +1,3 @@
 Error: Buckle your seatbelt Dorothy, 'cause Kansas is going bye-bye
-        on line 1 of /sass/sass-spec/spec/misc/error-directive/input.scss
+        on line 1 of /sass/spec/misc/error-directive/input.scss
   Use --trace for backtrace.

--- a/spec/misc/warn-directive/error
+++ b/spec/misc/warn-directive/error
@@ -1,2 +1,2 @@
 WARNING: Don't crash the ambulance, whatever you do
-         on line 2 of /sass/sass-spec/spec/misc/warn-directive/input.scss
+         on line 2 of /sass/spec/misc/warn-directive/input.scss

--- a/spec/parser/interpolate/44_selector/colon_twice_todo/error
+++ b/spec/parser/interpolate/44_selector/colon_twice_todo/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after "  filter: progid": expected ";", was ":DXImageTransfo..."
-        on line 2 of /sass/sass-spec/spec/parser/interpolate/44_selector/colon_twice/input.scss
+        on line 2 of /sass/spec/parser/interpolate/44_selector/colon_twice/input.scss
   Use --trace for backtrace.

--- a/spec/parser/interpolate/44_selector/todo_single_escape/11_escaped_interpolated_value/error
+++ b/spec/parser/interpolate/44_selector/todo_single_escape/11_escaped_interpolated_value/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after ".test11": expected selector, was "@bar"
-        on line 2 of /sass/sass-spec/spec/parser/interpolate/44_selector/single_escape/11_escaped_interpolated_value/input.scss
+        on line 2 of /sass/spec/parser/interpolate/44_selector/single_escape/11_escaped_interpolated_value/input.scss
   Use --trace for backtrace.

--- a/spec/parser/interpolate/44_selector/todo_single_escape/21_escaped_interpolated_variable/error
+++ b/spec/parser/interpolate/44_selector/todo_single_escape/21_escaped_interpolated_variable/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after ".test21": expected selector, was "@bar"
-        on line 3 of /sass/sass-spec/spec/parser/interpolate/44_selector/single_escape/21_escaped_interpolated_variable/input.scss
+        on line 3 of /sass/spec/parser/interpolate/44_selector/single_escape/21_escaped_interpolated_variable/input.scss
   Use --trace for backtrace.

--- a/spec/parser/interpolate/44_selector/todo_single_escape/31_escaped_literal/error
+++ b/spec/parser/interpolate/44_selector/todo_single_escape/31_escaped_literal/error
@@ -1,3 +1,3 @@
 Error: Invalid CSS after ".test31": expected selector, was "@baz"
-        on line 1 of /sass/sass-spec/spec/parser/interpolate/44_selector/single_escape/31_escaped_literal/input.scss
+        on line 1 of /sass/spec/parser/interpolate/44_selector/single_escape/31_escaped_literal/input.scss
   Use --trace for backtrace.

--- a/spec/parser/operations/addition/mixed/pairs/error
+++ b/spec/parser/operations/addition/mixed/pairs/error
@@ -1,3 +1,3 @@
 Error: Incompatible units: 'px' and '%'.
-        on line 26 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/addition/mixed/pairs/input.scss
+        on line 26 of /sass/spec/parser/operations/addition/mixed/pairs/input.scss
   Use --trace for backtrace.

--- a/spec/parser/operations/subtract/mixed/pairs/error
+++ b/spec/parser/operations/subtract/mixed/pairs/error
@@ -1,3 +1,3 @@
 Error: Incompatible units: 'px' and '%'.
-        on line 26 of /sass/sass-spec/spec/libsass-todo-tests/parser/operations/subtract/mixed/pairs/input.scss
+        on line 26 of /sass/spec/parser/operations/subtract/mixed/pairs/input.scss
   Use --trace for backtrace.


### PR DESCRIPTION
Had to make some changes to get everything running correctly on windows.
Also fixed a small issue that is also addressed in https://github.com/sass/sass-spec/pull/630 (//CC @saper)

It changes the string handling internally to not bother about the encoding. We need to open/read files with `:binmode => true` on windows, as it's the only way I know to disable the linefeed conversion, which triggered a wrongly failed spec test. And we really don't care about the encoding as long as the binary representations are exactly equal.

Also re-introduced parallelize_me conditionally, since it should be ok when invoking external commands.

Also cleaned up the cleanup functions a bit. Hope CI doesn't mind!