### PR TITLE
Add an option to not exit after running tests.

### DIFF
--- a/lib/sass_spec/runner.rb
+++ b/lib/sass_spec/runner.rb
@@ -45,7 +45,7 @@ class SassSpec::Runner
       Minitest.reporter = Minitap::TapY
     end
 
-    exit Minitest.run(minioptions)
+    Minitest.run(minioptions)
   end
 
 

--- a/sass-spec.rb
+++ b/sass-spec.rb
@@ -20,4 +20,6 @@
 #the output of running a command on it in the file expected_output* in the same directory
 
 require_relative 'lib/sass_spec'
-SassSpec::Runner.new(SassSpec::CLI.parse()).run
+unless SassSpec::Runner.new(SassSpec::CLI.parse()).run
+  exit 1
+end


### PR DESCRIPTION
This is needed to integrate sass-spec with ruby sass's build.