### PR TITLE
Ability to consume sass-spec as a rubygem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'minitest', '5.2.0'
-gem 'sass'
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,21 @@
+PATH
+  remote: .
+  specs:
+    sass-spec (3.3.3)
+      minitest (~> 5.8.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
-    minitest (5.2.0)
+    minitest (5.8.3)
+    rake (10.4.2)
     sass (3.4.21)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  minitest (= 5.2.0)
-  sass
+  bundler (~> 1.7)
+  rake (~> 10.0)
+  sass (~> 3.4)
+  sass-spec!

--- a/lib/sass_spec/version.rb
+++ b/lib/sass_spec/version.rb
@@ -1,0 +1,6 @@
+module Sass
+  module Spec
+    VERSION = "3.3.3"
+  end
+end
+

--- a/sass-spec.gemspec
+++ b/sass-spec.gemspec
@@ -1,0 +1,27 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'sass_spec/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = "sass-spec"
+  spec.version       = Sass::Spec::VERSION
+  spec.authors       = [ "Michael Mifsud <xzyfer@gmail.com>",
+                         "Marcel Greter <marcel.greter@ocbnet.ch>",
+                         "Marcin Cieślak <saper@saper.info>",
+                         "Hampton Catlin <hcatlin@gmail.com>",
+                         "Aaron Leung <aaron.leung@moovweb.com>"]
+  spec.email         = ["xzyfer@gmail.com"]
+  spec.summary       = %q{Test suite for Sass Implementations.}
+  spec.description   = %q{Test suite for testing compatibility with the Sass Stylesheet language.}
+  spec.homepage      = "https://github.com/sass/sass-spec"
+  spec.license       = "MIT"
+
+  spec.files         = `git ls-files -z`.split("\x0")
+  spec.require_paths = ["lib"]
+
+  spec.add_dependency "minitest", "~> 5.8.0"
+  spec.add_development_dependency "sass", "~> 3.4"
+  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "rake", "~> 10.0"
+end


### PR DESCRIPTION
Ruby Sass will consume sass-spec as a rubygem via this git repo. No need to release it to rubygems.org. This structure is just really helpful for doing parallel development and downloading sass-spec for CI and in development.