### PR TITLE
Revert "These are not dependencies, actually."

### DIFF
--- a/sass-spec.gemspec
+++ b/sass-spec.gemspec
@@ -22,4 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "minitest", "~> 5.8.0"
   spec.add_development_dependency "sass", "~> 3.4"
+  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
This reverts commit 9a3bf839d156dcc45138688b6ae76d7a303492d8.

@chriseppstein this commit [broke CI](https://travis-ci.org/sass/sass-spec/builds/115480697). I've had to revert to progress with some LibSass stuff.