### PR TITLE
Refactor warnings

### DIFF
--- a/lib/sass_spec/engine_adapter.rb
+++ b/lib/sass_spec/engine_adapter.rb
@@ -113,8 +113,7 @@ class SassEngineAdapter < EngineAdapter
     rescue Sass::SyntaxError => e
       # prepend the prefix to the message
       # and indent all lines to match it
-      err_output = "Error: " + e.message.to_s
-                   .gsub(/(?:\r?\n)(?!\z)/, "\n       ")
+      err_output = e.sass_backtrace_str("standard input") + "\n  Use --trace for backtrace.\n"
       err_output.force_encoding('ASCII-8BIT')
       ["", err_output, 65]
     rescue => e

--- a/lib/sass_spec/test_case.rb
+++ b/lib/sass_spec/test_case.rb
@@ -68,16 +68,16 @@ class SassSpec::TestCase
     @error_path
   end
 
-  def verify_stderr?
-    @verify_stderr
-  end
-
   def status_path
     @status_path
   end
 
   def options_path
     @options_path
+  end
+
+  def verify_stderr?
+    @verify_stderr
   end
 
   def interactive?
@@ -151,7 +151,12 @@ class SassSpec::TestCase
   end
 
   def expected_error
-    @expected_error = _clean_error((File.read(@error_path, :binmode => true, :encoding => "ASCII-8BIT") rescue ""))
+    @expected_error ||= if File.file?(@error_path)
+                          _clean_error(File.read(@error_path, :binmode => true,
+                                                 :encoding => "ASCII-8BIT"))
+                        else
+                          ""
+                        end
   end
 
   def expected_status

--- a/spec/basic/23_basic_value_interpolation/error
+++ b/spec/basic/23_basic_value_interpolation/error
@@ -1,0 +1,9 @@
+DEPRECATION WARNING on line 5 of /sass/spec/basic/23_basic_value_interpolation/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("123")
+
+DEPRECATION WARNING on line 7 of /sass/spec/basic/23_basic_value_interpolation/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{12 + 111}")

--- a/spec/basic/23_basic_value_interpolation/options.yml
+++ b/spec/basic/23_basic_value_interpolation/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/libsass-closed-issues/issue_1333/error
+++ b/spec/libsass-closed-issues/issue_1333/error
@@ -1,0 +1,6 @@
+DEPRECATION WARNING on line 6 of /sass/spec/libsass-issues/issue_1333/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('#{baz()}" !important"')
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/libsass-closed-issues/issue_1333/options.yml
+++ b/spec/libsass-closed-issues/issue_1333/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/libsass-closed-issues/issue_1396/error
+++ b/spec/libsass-closed-issues/issue_1396/error
@@ -1,0 +1,6 @@
+DEPRECATION WARNING on line 2 of /sass/spec/libsass-issues/issue_1396/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{foo "bar"}baz")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/libsass-closed-issues/issue_1396/options.yml
+++ b/spec/libsass-closed-issues/issue_1396/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/libsass-closed-issues/issue_1413/error
+++ b/spec/libsass-closed-issues/issue_1413/error
@@ -1,0 +1,175 @@
+DEPRECATION WARNING on line 2 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B"C"')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"BC')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B#{C "D"}')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"A" B}C#{D "E"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{A "B"}C#{D "E"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B"C"')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"BC')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B#{C "D"}')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"A" B}C#{D "E"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{A "B"}C#{D "E"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B"C"')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"BC')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B#{C "D"}')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"A" B}C#{D "E"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{A "B"}C#{D "E"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('A"B"')
+
+DEPRECATION WARNING on line 19 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('A"B"C')
+
+DEPRECATION WARNING on line 20 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('AB"C"')
+
+DEPRECATION WARNING on line 22 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("A#{B "C"}")
+
+DEPRECATION WARNING on line 26 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("A#{"B" C "D" "E"}")
+
+DEPRECATION WARNING on line 31 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('A"B"')
+
+DEPRECATION WARNING on line 33 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('A"B"C')
+
+DEPRECATION WARNING on line 34 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('AB"C"')
+
+DEPRECATION WARNING on line 36 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("A#{B "C"}")
+
+DEPRECATION WARNING on line 40 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("A#{"B" C "D" "E"}")

--- a/spec/libsass-closed-issues/issue_1413/options.yml
+++ b/spec/libsass-closed-issues/issue_1413/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/libsass-closed-issues/issue_152/error
+++ b/spec/libsass-closed-issues/issue_152/error
@@ -1,0 +1,20 @@
+DEPRECATION WARNING on line 5 of /sass/spec/libsass-issues/issue_152/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10% 100%")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/libsass-issues/issue_152/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 100%")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/libsass-issues/issue_152/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %100%")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/libsass-closed-issues/issue_152/options.yml
+++ b/spec/libsass-closed-issues/issue_152/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/libsass-closed-issues/issue_1709/error
+++ b/spec/libsass-closed-issues/issue_1709/error
@@ -1,0 +1,6 @@
+DEPRECATION WARNING on line 14 of /sass/spec/libsass-issues/issue_1709/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{$prefix}#{$transition}")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/libsass-closed-issues/issue_1709/options.yml
+++ b/spec/libsass-closed-issues/issue_1709/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/libsass-closed-issues/issue_1739/interpolate/both/error
+++ b/spec/libsass-closed-issues/issue_1739/interpolate/both/error
@@ -1,0 +1,97 @@
+DEPRECATION WARNING on line 9 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2}+#{1 + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2}+ #{1 + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2} +#{1 + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2} + #{1 + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 - 2}- #{1 - 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 - 2} - #{1 - 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 * 2}*#{1 * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 * 2}* #{1 * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 * 2} *#{1 * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 * 2} * #{1 * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1% 2}%#{1% 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1% 2}% #{1% 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 % 2} %#{1 % 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 % 2} % #{1 % 2}")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/libsass-closed-issues/issue_1739/interpolate/both/options.yml
+++ b/spec/libsass-closed-issues/issue_1739/interpolate/both/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/libsass-closed-issues/issue_1739/interpolate/left/error
+++ b/spec/libsass-closed-issues/issue_1739/interpolate/left/error
@@ -1,0 +1,90 @@
+DEPRECATION WARNING on line 9 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2}+3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2}+ 3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2} +3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2} + 3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 - 2} - 3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 * 2}*3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 * 2}* 3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 * 2} *3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 * 2} * 3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1% 2}%3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1% 2}% 3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 % 2} %3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 % 2} % 3")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/libsass-closed-issues/issue_1739/interpolate/left/options.yml
+++ b/spec/libsass-closed-issues/issue_1739/interpolate/left/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/libsass-closed-issues/issue_1739/interpolate/right/error
+++ b/spec/libsass-closed-issues/issue_1739/interpolate/right/error
@@ -1,0 +1,83 @@
+DEPRECATION WARNING on line 9 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3+#{1 + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3+ #{1 + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3 +#{1 + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3 + #{1 + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3- #{1 - 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3 - #{1 - 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3*#{1 * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3* #{1 * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3 *#{1 * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3 * #{1 * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3 %#{1 % 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3 % #{1 % 2}")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/libsass-closed-issues/issue_1739/interpolate/right/options.yml
+++ b/spec/libsass-closed-issues/issue_1739/interpolate/right/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/libsass-closed-issues/issue_1916/error
+++ b/spec/libsass-closed-issues/issue_1916/error
@@ -1,5 +1,5 @@
 Error: ".btn:hover" failed to @extend ".z-depth-half-1".
        The selector ".z-depth-half-1" was not found.
        Use "@extend .z-depth-half-1 !optional" if the extend should be able to fail.
-        on line 13 of /home/saper/sw/sass-spec/spec/libsass-todo-issues/issue_1916/input.scss
+        on line 13 of /sass/spec/libsass-issues/issue_1916/input.scss
   Use --trace for backtrace.

--- a/spec/libsass-closed-issues/issue_442/error
+++ b/spec/libsass-closed-issues/issue_442/error
@@ -1,0 +1,6 @@
+DEPRECATION WARNING on line 1 of /sass/spec/libsass-issues/issue_442/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{100 / 10}rem")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/libsass-closed-issues/issue_442/options.yml
+++ b/spec/libsass-closed-issues/issue_442/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/libsass-closed-issues/issue_870/error
+++ b/spec/libsass-closed-issues/issue_870/error
@@ -1,0 +1,13 @@
+DEPRECATION WARNING on line 9 of /sass/spec/libsass-issues/issue_870/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"["#{$quoted-strings-csv}"]"')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/libsass-issues/issue_870/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"["#{$quoted-strings-ssv}"]"')
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/libsass-closed-issues/issue_870/options.yml
+++ b/spec/libsass-closed-issues/issue_870/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/libsass-closed-issues/issue_948/error
+++ b/spec/libsass-closed-issues/issue_948/error
@@ -1,0 +1,6 @@
+DEPRECATION WARNING on line 1 of /sass/spec/libsass-issues/issue_948/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 * 5}px")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/libsass-closed-issues/issue_948/options.yml
+++ b/spec/libsass-closed-issues/issue_948/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/libsass/arithmetic/error
+++ b/spec/libsass/arithmetic/error
@@ -1,0 +1,41 @@
+DEPRECATION WARNING on line 12 of /sass/spec/libsass/arithmetic/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{3 + un}quo#{te("hello")}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/libsass/arithmetic/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{3 - un}quo#{te("hello")}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 55 of /sass/spec/libsass/arithmetic/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{3 / un}quo#{te("hello")}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 80 of /sass/spec/libsass/arithmetic/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{50% + un}quo#{te("hello")}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 91 of /sass/spec/libsass/arithmetic/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{50% - un}quo#{te("hello")}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 113 of /sass/spec/libsass/arithmetic/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{50% / un}quo#{te("hello")}")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/libsass/arithmetic/options.yml
+++ b/spec/libsass/arithmetic/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/libsass/interpolated-function-call/error
+++ b/spec/libsass/interpolated-function-call/error
@@ -1,0 +1,6 @@
+DEPRECATION WARNING on line 4 of /sass/spec/libsass/interpolated-function-call/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{$f}#{a, 1 + 2, c}")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/libsass/interpolated-function-call/options.yml
+++ b/spec/libsass/interpolated-function-call/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/libsass/interpolated-urls/error
+++ b/spec/libsass/interpolated-urls/error
@@ -1,0 +1,13 @@
+DEPRECATION WARNING on line 3 of /sass/spec/libsass/interpolated-urls/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"url("#{$base_url}"img/beta.png)"')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/libsass/interpolated-urls/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{blix "fludge"}#{hey now}123")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/libsass/interpolated-urls/options.yml
+++ b/spec/libsass/interpolated-urls/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/basic/23_basic_value_interpolation/error
+++ b/spec/output_styles/compact/basic/23_basic_value_interpolation/error
@@ -1,0 +1,9 @@
+DEPRECATION WARNING on line 5 of /sass/spec/output_styles/compact/basic/23_basic_value_interpolation/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("123")
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compact/basic/23_basic_value_interpolation/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{12 + 111}")

--- a/spec/output_styles/compact/basic/23_basic_value_interpolation/options.yml
+++ b/spec/output_styles/compact/basic/23_basic_value_interpolation/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1333/error
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1333/error
@@ -1,0 +1,6 @@
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compact/libsass-issues/issue_1333/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('#{baz()}" !important"')
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1333/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1333/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1396/error
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1396/error
@@ -1,0 +1,6 @@
+DEPRECATION WARNING on line 2 of /sass/spec/output_styles/compact/libsass-issues/issue_1396/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{foo "bar"}baz")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1396/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1396/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1413/error
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1413/error
@@ -1,0 +1,175 @@
+DEPRECATION WARNING on line 2 of /sass/spec/output_styles/compact/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/compact/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B"C"')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compact/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"BC')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compact/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B#{C "D"}')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compact/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"A" B}C#{D "E"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compact/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{A "B"}C#{D "E"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compact/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compact/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B"C"')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compact/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"BC')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compact/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B#{C "D"}')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compact/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"A" B}C#{D "E"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compact/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{A "B"}C#{D "E"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compact/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compact/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B"C"')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compact/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"BC')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compact/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B#{C "D"}')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compact/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"A" B}C#{D "E"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compact/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{A "B"}C#{D "E"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compact/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('A"B"')
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compact/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('A"B"C')
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compact/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('AB"C"')
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compact/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("A#{B "C"}")
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compact/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("A#{"B" C "D" "E"}")
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compact/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('A"B"')
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compact/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('A"B"C')
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compact/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('AB"C"')
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compact/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("A#{B "C"}")
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compact/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("A#{"B" C "D" "E"}")

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1413/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1413/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_152/error
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_152/error
@@ -1,0 +1,20 @@
+DEPRECATION WARNING on line 5 of /sass/spec/output_styles/compact/libsass-issues/issue_152/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10% 100%")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compact/libsass-issues/issue_152/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 100%")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compact/libsass-issues/issue_152/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %100%")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/libsass-closed-issues/issue_152/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_152/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1709/error
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1709/error
@@ -1,0 +1,6 @@
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compact/libsass-issues/issue_1709/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{$prefix}#{$transition}")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1709/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1709/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1739/interpolate/both/error
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1739/interpolate/both/error
@@ -1,0 +1,97 @@
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2}+#{1 + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2}+ #{1 + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2} +#{1 + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2} + #{1 + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 - 2}- #{1 - 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 - 2} - #{1 - 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 * 2}*#{1 * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 * 2}* #{1 * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 * 2} *#{1 * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 * 2} * #{1 * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1% 2}%#{1% 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1% 2}% #{1% 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 % 2} %#{1 % 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 % 2} % #{1 % 2}")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1739/interpolate/both/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1739/interpolate/both/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1739/interpolate/left/error
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1739/interpolate/left/error
@@ -1,0 +1,90 @@
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2}+3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2}+ 3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2} +3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2} + 3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 - 2} - 3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 * 2}*3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 * 2}* 3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 * 2} *3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 * 2} * 3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1% 2}%3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1% 2}% 3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 % 2} %3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 % 2} % 3")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1739/interpolate/left/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1739/interpolate/left/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1739/interpolate/right/error
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1739/interpolate/right/error
@@ -1,0 +1,83 @@
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3+#{1 + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3+ #{1 + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3 +#{1 + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3 + #{1 + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3- #{1 - 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3 - #{1 - 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3*#{1 * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3* #{1 * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3 *#{1 * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3 * #{1 * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3 %#{1 % 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compact/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3 % #{1 % 2}")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1739/interpolate/right/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1739/interpolate/right/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_442/error
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_442/error
@@ -1,0 +1,6 @@
+DEPRECATION WARNING on line 1 of /sass/spec/output_styles/compact/libsass-issues/issue_442/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{100 / 10}rem")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/libsass-closed-issues/issue_442/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_442/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_870/error
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_870/error
@@ -1,0 +1,13 @@
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compact/libsass-issues/issue_870/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"["#{$quoted-strings-csv}"]"')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compact/libsass-issues/issue_870/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"["#{$quoted-strings-ssv}"]"')
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/libsass-closed-issues/issue_870/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_870/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_948/error
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_948/error
@@ -1,0 +1,6 @@
+DEPRECATION WARNING on line 1 of /sass/spec/output_styles/compact/libsass-issues/issue_948/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 * 5}px")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/libsass-closed-issues/issue_948/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_948/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/libsass/arithmetic/error
+++ b/spec/output_styles/compact/libsass/arithmetic/error
@@ -1,0 +1,41 @@
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compact/libsass/arithmetic/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{3 + un}quo#{te("hello")}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compact/libsass/arithmetic/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{3 - un}quo#{te("hello")}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 55 of /sass/spec/output_styles/compact/libsass/arithmetic/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{3 / un}quo#{te("hello")}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 80 of /sass/spec/output_styles/compact/libsass/arithmetic/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{50% + un}quo#{te("hello")}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 91 of /sass/spec/output_styles/compact/libsass/arithmetic/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{50% - un}quo#{te("hello")}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 113 of /sass/spec/output_styles/compact/libsass/arithmetic/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{50% / un}quo#{te("hello")}")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/libsass/arithmetic/options.yml
+++ b/spec/output_styles/compact/libsass/arithmetic/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/libsass/interpolated-function-call/error
+++ b/spec/output_styles/compact/libsass/interpolated-function-call/error
@@ -1,0 +1,6 @@
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/compact/libsass/interpolated-function-call/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{$f}#{a, 1 + 2, c}")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/libsass/interpolated-function-call/options.yml
+++ b/spec/output_styles/compact/libsass/interpolated-function-call/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/libsass/interpolated-urls/error
+++ b/spec/output_styles/compact/libsass/interpolated-urls/error
@@ -1,0 +1,13 @@
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/compact/libsass/interpolated-urls/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"url("#{$base_url}"img/beta.png)"')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compact/libsass/interpolated-urls/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{blix "fludge"}#{hey now}123")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/libsass/interpolated-urls/options.yml
+++ b/spec/output_styles/compact/libsass/interpolated-urls/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/parser/interpolate/00_concatenation/unspaced/error
+++ b/spec/output_styles/compact/parser/interpolate/00_concatenation/unspaced/error
@@ -1,0 +1,41 @@
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compact/parser/interpolate/00_concatenation/unspaced/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{$input}#{$input}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compact/parser/interpolate/00_concatenation/unspaced/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{$input}literal")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compact/parser/interpolate/00_concatenation/unspaced/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('#{$input}"literal"')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compact/parser/interpolate/00_concatenation/unspaced/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{$input}#{$input}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compact/parser/interpolate/00_concatenation/unspaced/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal#{$input}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compact/parser/interpolate/00_concatenation/unspaced/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"literal"#{$input}')
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/parser/interpolate/00_concatenation/unspaced/options.yml
+++ b/spec/output_styles/compact/parser/interpolate/00_concatenation/unspaced/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/parser/interpolate/29_binary_operation/06_escape_interpolation/error
+++ b/spec/output_styles/compact/parser/interpolate/29_binary_operation/06_escape_interpolation/error
@@ -1,0 +1,20 @@
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/compact/parser/interpolate/29_binary_operation/06_escape_interpolation/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"[\#{" foo}#{"ba" + "r"}#{baz "}]"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/compact/parser/interpolate/29_binary_operation/06_escape_interpolation/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"\#{" foo}#{"ba" + "r"}#{baz "}"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compact/parser/interpolate/29_binary_operation/06_escape_interpolation/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"['\#{" foo}#{"ba" + "r"}#{baz "}']"}")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/parser/interpolate/29_binary_operation/06_escape_interpolation/options.yml
+++ b/spec/output_styles/compact/parser/interpolate/29_binary_operation/06_escape_interpolation/options.yml
@@ -1,0 +1,3 @@
+---
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/parser/interpolate/30_base_test/06_escape_interpolation/error
+++ b/spec/output_styles/compact/parser/interpolate/30_base_test/06_escape_interpolation/error
@@ -1,0 +1,20 @@
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/compact/parser/interpolate/30_base_test/06_escape_interpolation/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"[\#{" foo}#{"ba" + "r"}#{baz "}]"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/compact/parser/interpolate/30_base_test/06_escape_interpolation/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"\#{" foo}#{"ba" + "r"}#{baz "}"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compact/parser/interpolate/30_base_test/06_escape_interpolation/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"['\#{" foo}#{"ba" + "r"}#{baz "}']"}")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/parser/interpolate/30_base_test/06_escape_interpolation/options.yml
+++ b/spec/output_styles/compact/parser/interpolate/30_base_test/06_escape_interpolation/options.yml
@@ -1,0 +1,3 @@
+---
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/error
+++ b/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/error
@@ -1,0 +1,307 @@
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px+10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px +10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px+ 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px + 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 42 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 43 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 44 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 45 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 46 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px+10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 47 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px +10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 48 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px+ 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 49 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px + 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 74 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px+10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 75 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px +10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 76 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px+ 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 77 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px + 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 78 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px+10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 79 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px +10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 80 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px+ 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 81 of /sass/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px + 10px")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/options.yml
+++ b/spec/output_styles/compact/parser/operations/addition/dimensions/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/parser/operations/addition/numbers/pairs/error
+++ b/spec/output_styles/compact/parser/operations/addition/numbers/pairs/error
@@ -1,0 +1,251 @@
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compact/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/parser/operations/addition/numbers/pairs/options.yml
+++ b/spec/output_styles/compact/parser/operations/addition/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/parser/operations/addition/strings/pairs/error
+++ b/spec/output_styles/compact/parser/operations/addition/strings/pairs/error
@@ -1,0 +1,335 @@
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal+interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal +interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal+ interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal + interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal + lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal + lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal + lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal + lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal+litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal +litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal+ litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal + litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"+interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" +interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"+ interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" + interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" + lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" + lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" + lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" + lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"+litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" +litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"+ litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" + litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant+interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant +interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant+ interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant + interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 42 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant+lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 43 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant +lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 44 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant+ lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 45 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant + lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 46 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant+litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 47 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant +litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 48 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant+ litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 49 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant + litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 50 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp+lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 51 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp +lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 52 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp+ lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 53 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp + lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 54 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp+litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 55 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp +litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 56 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp+ litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 57 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp + litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 58 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema+litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 59 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema +litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 60 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema+ litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 61 of /sass/spec/output_styles/compact/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema + litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/parser/operations/addition/strings/pairs/options.yml
+++ b/spec/output_styles/compact/parser/operations/addition/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/parser/operations/division/dimensions/pairs/error
+++ b/spec/output_styles/compact/parser/operations/division/dimensions/pairs/error
@@ -1,0 +1,167 @@
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compact/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compact/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compact/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compact/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compact/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compact/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compact/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compact/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compact/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compact/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compact/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compact/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compact/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compact/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compact/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compact/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compact/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compact/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compact/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compact/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 42 of /sass/spec/output_styles/compact/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 43 of /sass/spec/output_styles/compact/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 44 of /sass/spec/output_styles/compact/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 45 of /sass/spec/output_styles/compact/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/parser/operations/division/dimensions/pairs/options.yml
+++ b/spec/output_styles/compact/parser/operations/division/dimensions/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/parser/operations/division/numbers/pairs/error
+++ b/spec/output_styles/compact/parser/operations/division/numbers/pairs/error
@@ -1,0 +1,27 @@
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compact/parser/operations/division/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compact/parser/operations/division/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compact/parser/operations/division/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compact/parser/operations/division/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 1}0")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/parser/operations/division/numbers/pairs/options.yml
+++ b/spec/output_styles/compact/parser/operations/division/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/parser/operations/division/strings/pairs/error
+++ b/spec/output_styles/compact/parser/operations/division/strings/pairs/error
@@ -1,0 +1,55 @@
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compact/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal / lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compact/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal / lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compact/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal / lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compact/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal / lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compact/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" / lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compact/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" / lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compact/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" / lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compact/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" / lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/parser/operations/division/strings/pairs/options.yml
+++ b/spec/output_styles/compact/parser/operations/division/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/error
+++ b/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/error
@@ -1,0 +1,251 @@
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 ==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10== 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 == 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 == 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 == 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 == 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 == 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 ==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10== 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 == 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 ==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10== 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 == 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 ==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10== 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 == 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 ==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10== 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 == 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 ==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10== 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 == 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 ==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10== 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 == 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 ==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10== 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 == 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/options.yml
+++ b/spec/output_styles/compact/parser/operations/logic_eq/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/error
+++ b/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/error
@@ -1,0 +1,335 @@
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal==interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal ==interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal== interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal == interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal == lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal == lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal == lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal == lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal==litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal ==litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal== litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal == litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"==interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" ==interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"== interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" == interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" == lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" == lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" == lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" == lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"==litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" ==litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"== litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" == litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant==interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant ==interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant== interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant == interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 42 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant==lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 43 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant ==lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 44 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant== lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 45 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant == lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 46 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant==litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 47 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant ==litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 48 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant== litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 49 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant == litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 50 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp==lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 51 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp ==lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 52 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp== lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 53 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp == lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 54 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp==litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 55 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp ==litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 56 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp== litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 57 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp == litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 58 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema==litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 59 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema ==litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 60 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema== litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 61 of /sass/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema == litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/options.yml
+++ b/spec/output_styles/compact/parser/operations/logic_eq/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/error
+++ b/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/error
@@ -1,0 +1,251 @@
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 >= 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 >= 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 >= 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 >= 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >= 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/options.yml
+++ b/spec/output_styles/compact/parser/operations/logic_ge/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/parser/operations/logic_ge/strings/pairs/error
+++ b/spec/output_styles/compact/parser/operations/logic_ge/strings/pairs/error
@@ -1,0 +1,167 @@
+DEPRECATION WARNING on line 2 of /sass/spec/output_styles/compact/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>=interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/compact/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >=interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/compact/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>= interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 5 of /sass/spec/output_styles/compact/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >= interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compact/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compact/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compact/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compact/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compact/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compact/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compact/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compact/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compact/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp>=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compact/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp >=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compact/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp>= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compact/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp >= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compact/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp>=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compact/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp >=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compact/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp>= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compact/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp >= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compact/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema>=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compact/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema >=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compact/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema>= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compact/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema >= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/parser/operations/logic_ge/strings/pairs/options.yml
+++ b/spec/output_styles/compact/parser/operations/logic_ge/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/error
+++ b/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/error
@@ -1,0 +1,251 @@
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10> 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 > 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 > 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 > 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 > 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 > 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10> 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 > 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10> 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 > 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10> 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 > 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10> 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 > 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10> 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 > 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10> 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 > 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10> 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 > 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/options.yml
+++ b/spec/output_styles/compact/parser/operations/logic_gt/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/parser/operations/logic_gt/strings/pairs/error
+++ b/spec/output_styles/compact/parser/operations/logic_gt/strings/pairs/error
@@ -1,0 +1,167 @@
+DEPRECATION WARNING on line 2 of /sass/spec/output_styles/compact/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/compact/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/compact/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant> interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 5 of /sass/spec/output_styles/compact/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant > interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compact/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compact/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compact/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant> lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compact/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant > lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compact/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compact/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compact/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant> litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compact/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant > litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compact/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp>lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compact/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp >lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compact/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp> lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compact/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp > lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compact/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp>litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compact/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp >litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compact/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp> litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compact/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp > litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compact/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema>litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compact/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema >litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compact/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema> litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compact/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema > litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/parser/operations/logic_gt/strings/pairs/options.yml
+++ b/spec/output_styles/compact/parser/operations/logic_gt/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/error
+++ b/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/error
@@ -1,0 +1,251 @@
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 <= 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 <= 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 <= 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 <= 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <= 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/options.yml
+++ b/spec/output_styles/compact/parser/operations/logic_le/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/parser/operations/logic_le/strings/pairs/error
+++ b/spec/output_styles/compact/parser/operations/logic_le/strings/pairs/error
@@ -1,0 +1,167 @@
+DEPRECATION WARNING on line 2 of /sass/spec/output_styles/compact/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<=interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/compact/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <=interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/compact/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<= interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 5 of /sass/spec/output_styles/compact/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <= interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compact/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compact/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compact/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compact/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compact/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compact/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compact/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compact/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compact/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp<=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compact/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp <=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compact/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp<= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compact/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp <= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compact/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp<=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compact/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp <=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compact/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp<= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compact/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp <= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compact/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema<=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compact/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema <=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compact/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema<= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compact/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema <= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/parser/operations/logic_le/strings/pairs/options.yml
+++ b/spec/output_styles/compact/parser/operations/logic_le/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/error
+++ b/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/error
@@ -1,0 +1,251 @@
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10< 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 < 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 < 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 < 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 < 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 < 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10< 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 < 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10< 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 < 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10< 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 < 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10< 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 < 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10< 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 < 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10< 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 < 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10< 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 < 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/options.yml
+++ b/spec/output_styles/compact/parser/operations/logic_lt/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/parser/operations/logic_lt/strings/pairs/error
+++ b/spec/output_styles/compact/parser/operations/logic_lt/strings/pairs/error
@@ -1,0 +1,167 @@
+DEPRECATION WARNING on line 2 of /sass/spec/output_styles/compact/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/compact/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/compact/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant< interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 5 of /sass/spec/output_styles/compact/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant < interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compact/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compact/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compact/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant< lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compact/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant < lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compact/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compact/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compact/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant< litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compact/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant < litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compact/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp<lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compact/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp <lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compact/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp< lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compact/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp < lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compact/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp<litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compact/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp <litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compact/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp< litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compact/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp < litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compact/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema<litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compact/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema <litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compact/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema< litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compact/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema < litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/parser/operations/logic_lt/strings/pairs/options.yml
+++ b/spec/output_styles/compact/parser/operations/logic_lt/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/error
+++ b/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/error
@@ -1,0 +1,251 @@
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 !=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 != 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 != 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 != 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 != 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 != 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 !=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 != 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 !=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 != 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 !=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 != 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 !=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 != 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 !=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 != 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 !=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 != 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 !=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 != 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/options.yml
+++ b/spec/output_styles/compact/parser/operations/logic_ne/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/error
+++ b/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/error
@@ -1,0 +1,335 @@
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal!=interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal !=interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal!= interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal != interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal != lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal != lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal != lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal != lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal!=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal !=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal!= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal != litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"!=interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" !=interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"!= interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" != interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" != lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" != lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" != lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" != lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"!=litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" !=litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"!= litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" != litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant!=interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant !=interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant!= interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant != interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 42 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant!=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 43 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant !=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 44 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant!= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 45 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant != lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 46 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant!=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 47 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant !=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 48 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant!= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 49 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant != litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 50 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp!=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 51 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp !=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 52 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp!= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 53 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp != lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 54 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp!=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 55 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp !=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 56 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp!= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 57 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp != litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 58 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema!=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 59 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema !=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 60 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema!= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 61 of /sass/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema != litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/options.yml
+++ b/spec/output_styles/compact/parser/operations/logic_ne/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/error
+++ b/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/error
@@ -1,0 +1,209 @@
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10% 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 % 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10% 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 % 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10%10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10% 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10%10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10% 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10%10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10% 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10%10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10% 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10%10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10% 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/options.yml
+++ b/spec/output_styles/compact/parser/operations/modulo/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/parser/operations/modulo/strings/pairs/error
+++ b/spec/output_styles/compact/parser/operations/modulo/strings/pairs/error
@@ -1,0 +1,167 @@
+DEPRECATION WARNING on line 2 of /sass/spec/output_styles/compact/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant%interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/compact/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant %interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/compact/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant% interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 5 of /sass/spec/output_styles/compact/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant % interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compact/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant%lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compact/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant %lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compact/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant% lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compact/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant % lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compact/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant%litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compact/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant %litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compact/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant% litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compact/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant % litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compact/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp%lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compact/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp %lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compact/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp% lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compact/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp % lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compact/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp%litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compact/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp %litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compact/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp% litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compact/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp % litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compact/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema%litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compact/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema %litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compact/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema% litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compact/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema % litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/parser/operations/modulo/strings/pairs/options.yml
+++ b/spec/output_styles/compact/parser/operations/modulo/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/error
+++ b/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/error
@@ -1,0 +1,251 @@
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10*10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 *10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10* 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 * 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 * 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 * 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 * 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 * 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10*10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 *10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10* 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 * 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10*10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 *10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10* 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 * 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10*10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 *10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10* 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 * 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10*10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 *10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10* 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 * 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10*10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 *10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10* 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 * 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10*10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 *10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10* 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 * 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10*10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 *10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10* 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 * 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/options.yml
+++ b/spec/output_styles/compact/parser/operations/multiply/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/parser/operations/multiply/strings/pairs/error
+++ b/spec/output_styles/compact/parser/operations/multiply/strings/pairs/error
@@ -1,0 +1,167 @@
+DEPRECATION WARNING on line 2 of /sass/spec/output_styles/compact/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant*interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/compact/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant *interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/compact/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant* interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 5 of /sass/spec/output_styles/compact/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant * interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compact/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant*lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compact/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant *lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compact/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant* lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compact/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant * lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compact/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant*litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compact/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant *litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compact/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant* litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compact/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant * litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compact/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp*lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compact/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp *lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compact/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp* lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compact/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp * lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compact/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp*litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compact/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp *litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compact/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp* litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compact/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp * litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compact/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema*litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compact/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema *litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compact/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema* litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compact/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema * litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/parser/operations/multiply/strings/pairs/options.yml
+++ b/spec/output_styles/compact/parser/operations/multiply/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/error
+++ b/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/error
@@ -1,0 +1,209 @@
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10- 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 -1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 -10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 -10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px - 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px - 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px -1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px- 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px - 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px -10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px- 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 42 of /sass/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 43 of /sass/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px -10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 44 of /sass/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px- 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 45 of /sass/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 49 of /sass/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px - 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 77 of /sass/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px - 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 81 of /sass/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px - 10px")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/options.yml
+++ b/spec/output_styles/compact/parser/operations/subtract/dimensions/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/parser/operations/subtract/numbers/pairs/error
+++ b/spec/output_styles/compact/parser/operations/subtract/numbers/pairs/error
@@ -1,0 +1,125 @@
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compact/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10- 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compact/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compact/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compact/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 -1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compact/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compact/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compact/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10- 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compact/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compact/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10- 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compact/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compact/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/compact/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10- 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/compact/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compact/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compact/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10- 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compact/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compact/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10- 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compact/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/parser/operations/subtract/numbers/pairs/options.yml
+++ b/spec/output_styles/compact/parser/operations/subtract/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/parser/operations/subtract/strings/pairs/error
+++ b/spec/output_styles/compact/parser/operations/subtract/strings/pairs/error
@@ -1,0 +1,153 @@
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compact/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal - interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compact/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal -lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compact/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal- lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compact/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal - lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compact/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal - litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/compact/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"- interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/compact/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" - interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compact/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" -lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compact/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" -lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compact/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" - lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compact/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" - lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compact/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"- litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compact/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" - litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compact/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant- interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compact/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant - interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 45 of /sass/spec/output_styles/compact/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant - lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 48 of /sass/spec/output_styles/compact/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant- litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 49 of /sass/spec/output_styles/compact/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant - litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 53 of /sass/spec/output_styles/compact/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp - lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 56 of /sass/spec/output_styles/compact/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp- litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 57 of /sass/spec/output_styles/compact/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp - litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 61 of /sass/spec/output_styles/compact/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema - litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/parser/operations/subtract/strings/pairs/options.yml
+++ b/spec/output_styles/compact/parser/operations/subtract/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/scss/function-names/error
+++ b/spec/output_styles/compact/scss/function-names/error
@@ -1,0 +1,6 @@
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/compact/scss/function-names/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"hello" un}quote")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/scss/function-names/options.yml
+++ b/spec/output_styles/compact/scss/function-names/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/scss/interpolation-operators-precedence/error
+++ b/spec/output_styles/compact/scss/interpolation-operators-precedence/error
@@ -1,0 +1,209 @@
+DEPRECATION WARNING on line 2 of /sass/spec/output_styles/compact/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a+#{5% + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/compact/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a+ #{5% + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/compact/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a +#{5% + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 5 of /sass/spec/output_styles/compact/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a + #{5% + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compact/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5 + 2%}+a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compact/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5 + 2%}+ a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compact/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5 + 2%} +a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compact/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5 + 2%} + a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compact/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a +#{5% + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compact/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("*5%")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compact/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a +#{5% - 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compact/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("*5%")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compact/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a +#{5% / 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compact/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a *#{5% / 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compact/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a +#{5% * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compact/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a *#{5% * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compact/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5 + 2%} +a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/compact/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("2% *a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compact/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5 - 2%} +a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compact/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("2% *a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compact/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5% / 2} +a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compact/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5% / 2} *a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compact/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5 * 2%} +a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compact/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5 * 2%} *a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 42 of /sass/spec/output_styles/compact/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a ==#{5% == 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 43 of /sass/spec/output_styles/compact/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a >#{5% > 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 44 of /sass/spec/output_styles/compact/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a <#{5% < 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 45 of /sass/spec/output_styles/compact/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a >=#{5% >= 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 46 of /sass/spec/output_styles/compact/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a <=#{5% <= 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 47 of /sass/spec/output_styles/compact/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a !=#{5% != 2}")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compact/scss/interpolation-operators-precedence/options.yml
+++ b/spec/output_styles/compact/scss/interpolation-operators-precedence/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compact/types/error
+++ b/spec/output_styles/compact/types/error
@@ -1,0 +1,21 @@
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/compact/types/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2}+3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compact/types/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2}px")
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compact/types/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#abc")
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compact/types/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("leng#{th(a b c d)}")

--- a/spec/output_styles/compact/types/options.yml
+++ b/spec/output_styles/compact/types/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/basic/23_basic_value_interpolation/error
+++ b/spec/output_styles/compressed/basic/23_basic_value_interpolation/error
@@ -1,0 +1,9 @@
+DEPRECATION WARNING on line 5 of /sass/spec/output_styles/compressed/basic/23_basic_value_interpolation/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("123")
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compressed/basic/23_basic_value_interpolation/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{12 + 111}")

--- a/spec/output_styles/compressed/basic/23_basic_value_interpolation/options.yml
+++ b/spec/output_styles/compressed/basic/23_basic_value_interpolation/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1333/error
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1333/error
@@ -1,0 +1,6 @@
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compressed/libsass-issues/issue_1333/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('#{baz()}" !important"')
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1333/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1333/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1396/error
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1396/error
@@ -1,0 +1,6 @@
+DEPRECATION WARNING on line 2 of /sass/spec/output_styles/compressed/libsass-issues/issue_1396/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{foo "bar"}baz")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1396/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1396/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1413/error
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1413/error
@@ -1,0 +1,175 @@
+DEPRECATION WARNING on line 2 of /sass/spec/output_styles/compressed/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/compressed/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B"C"')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compressed/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"BC')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compressed/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B#{C "D"}')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compressed/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"A" B}C#{D "E"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compressed/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{A "B"}C#{D "E"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compressed/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compressed/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B"C"')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compressed/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"BC')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compressed/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B#{C "D"}')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compressed/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"A" B}C#{D "E"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compressed/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{A "B"}C#{D "E"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compressed/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compressed/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B"C"')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compressed/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"BC')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compressed/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B#{C "D"}')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compressed/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"A" B}C#{D "E"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compressed/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{A "B"}C#{D "E"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compressed/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('A"B"')
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compressed/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('A"B"C')
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compressed/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('AB"C"')
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compressed/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("A#{B "C"}")
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compressed/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("A#{"B" C "D" "E"}")
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compressed/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('A"B"')
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compressed/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('A"B"C')
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compressed/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('AB"C"')
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compressed/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("A#{B "C"}")
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compressed/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("A#{"B" C "D" "E"}")

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1413/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1413/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_152/error
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_152/error
@@ -1,0 +1,20 @@
+DEPRECATION WARNING on line 5 of /sass/spec/output_styles/compressed/libsass-issues/issue_152/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10% 100%")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compressed/libsass-issues/issue_152/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 100%")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compressed/libsass-issues/issue_152/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %100%")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_152/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_152/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1709/error
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1709/error
@@ -1,0 +1,6 @@
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compressed/libsass-issues/issue_1709/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{$prefix}#{$transition}")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1709/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1709/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1739/interpolate/both/error
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1739/interpolate/both/error
@@ -1,0 +1,97 @@
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2}+#{1 + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2}+ #{1 + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2} +#{1 + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2} + #{1 + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 - 2}- #{1 - 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 - 2} - #{1 - 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 * 2}*#{1 * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 * 2}* #{1 * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 * 2} *#{1 * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 * 2} * #{1 * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1% 2}%#{1% 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1% 2}% #{1% 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 % 2} %#{1 % 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 % 2} % #{1 % 2}")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1739/interpolate/both/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1739/interpolate/both/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1739/interpolate/left/error
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1739/interpolate/left/error
@@ -1,0 +1,90 @@
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2}+3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2}+ 3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2} +3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2} + 3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 - 2} - 3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 * 2}*3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 * 2}* 3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 * 2} *3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 * 2} * 3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1% 2}%3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1% 2}% 3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 % 2} %3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 % 2} % 3")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1739/interpolate/left/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1739/interpolate/left/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1739/interpolate/right/error
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1739/interpolate/right/error
@@ -1,0 +1,83 @@
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3+#{1 + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3+ #{1 + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3 +#{1 + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3 + #{1 + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3- #{1 - 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3 - #{1 - 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3*#{1 * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3* #{1 * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3 *#{1 * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3 * #{1 * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3 %#{1 % 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compressed/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3 % #{1 % 2}")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1739/interpolate/right/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1739/interpolate/right/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_442/error
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_442/error
@@ -1,0 +1,6 @@
+DEPRECATION WARNING on line 1 of /sass/spec/output_styles/compressed/libsass-issues/issue_442/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{100 / 10}rem")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_442/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_442/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_870/error
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_870/error
@@ -1,0 +1,13 @@
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compressed/libsass-issues/issue_870/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"["#{$quoted-strings-csv}"]"')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compressed/libsass-issues/issue_870/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"["#{$quoted-strings-ssv}"]"')
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_870/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_870/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_948/error
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_948/error
@@ -1,0 +1,6 @@
+DEPRECATION WARNING on line 1 of /sass/spec/output_styles/compressed/libsass-issues/issue_948/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 * 5}px")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_948/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_948/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/libsass/arithmetic/error
+++ b/spec/output_styles/compressed/libsass/arithmetic/error
@@ -1,0 +1,41 @@
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compressed/libsass/arithmetic/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{3 + un}quo#{te("hello")}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compressed/libsass/arithmetic/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{3 - un}quo#{te("hello")}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 55 of /sass/spec/output_styles/compressed/libsass/arithmetic/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{3 / un}quo#{te("hello")}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 80 of /sass/spec/output_styles/compressed/libsass/arithmetic/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{50% + un}quo#{te("hello")}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 91 of /sass/spec/output_styles/compressed/libsass/arithmetic/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{50% - un}quo#{te("hello")}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 113 of /sass/spec/output_styles/compressed/libsass/arithmetic/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{50% / un}quo#{te("hello")}")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/libsass/arithmetic/options.yml
+++ b/spec/output_styles/compressed/libsass/arithmetic/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/libsass/interpolated-function-call/error
+++ b/spec/output_styles/compressed/libsass/interpolated-function-call/error
@@ -1,0 +1,6 @@
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/compressed/libsass/interpolated-function-call/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{$f}#{a, 1 + 2, c}")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/libsass/interpolated-function-call/options.yml
+++ b/spec/output_styles/compressed/libsass/interpolated-function-call/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/libsass/interpolated-urls/error
+++ b/spec/output_styles/compressed/libsass/interpolated-urls/error
@@ -1,0 +1,13 @@
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/compressed/libsass/interpolated-urls/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"url("#{$base_url}"img/beta.png)"')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compressed/libsass/interpolated-urls/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{blix "fludge"}#{hey now}123")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/libsass/interpolated-urls/options.yml
+++ b/spec/output_styles/compressed/libsass/interpolated-urls/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/parser/interpolate/00_concatenation/unspaced/error
+++ b/spec/output_styles/compressed/parser/interpolate/00_concatenation/unspaced/error
@@ -1,0 +1,41 @@
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compressed/parser/interpolate/00_concatenation/unspaced/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{$input}#{$input}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compressed/parser/interpolate/00_concatenation/unspaced/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{$input}literal")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compressed/parser/interpolate/00_concatenation/unspaced/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('#{$input}"literal"')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compressed/parser/interpolate/00_concatenation/unspaced/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{$input}#{$input}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compressed/parser/interpolate/00_concatenation/unspaced/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal#{$input}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compressed/parser/interpolate/00_concatenation/unspaced/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"literal"#{$input}')
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/parser/interpolate/00_concatenation/unspaced/options.yml
+++ b/spec/output_styles/compressed/parser/interpolate/00_concatenation/unspaced/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/parser/interpolate/29_binary_operation/06_escape_interpolation/error
+++ b/spec/output_styles/compressed/parser/interpolate/29_binary_operation/06_escape_interpolation/error
@@ -1,0 +1,20 @@
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/compressed/parser/interpolate/29_binary_operation/06_escape_interpolation/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"[\#{" foo}#{"ba" + "r"}#{baz "}]"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/compressed/parser/interpolate/29_binary_operation/06_escape_interpolation/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"\#{" foo}#{"ba" + "r"}#{baz "}"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compressed/parser/interpolate/29_binary_operation/06_escape_interpolation/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"['\#{" foo}#{"ba" + "r"}#{baz "}']"}")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/parser/interpolate/29_binary_operation/06_escape_interpolation/options.yml
+++ b/spec/output_styles/compressed/parser/interpolate/29_binary_operation/06_escape_interpolation/options.yml
@@ -1,0 +1,3 @@
+---
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/parser/interpolate/30_base_test/06_escape_interpolation/error
+++ b/spec/output_styles/compressed/parser/interpolate/30_base_test/06_escape_interpolation/error
@@ -1,0 +1,20 @@
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/compressed/parser/interpolate/30_base_test/06_escape_interpolation/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"[\#{" foo}#{"ba" + "r"}#{baz "}]"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/compressed/parser/interpolate/30_base_test/06_escape_interpolation/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"\#{" foo}#{"ba" + "r"}#{baz "}"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compressed/parser/interpolate/30_base_test/06_escape_interpolation/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"['\#{" foo}#{"ba" + "r"}#{baz "}']"}")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/parser/interpolate/30_base_test/06_escape_interpolation/options.yml
+++ b/spec/output_styles/compressed/parser/interpolate/30_base_test/06_escape_interpolation/options.yml
@@ -1,0 +1,3 @@
+---
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/error
+++ b/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/error
@@ -1,0 +1,307 @@
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px+10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px +10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px+ 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px + 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 42 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 43 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 44 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 45 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 46 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px+10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 47 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px +10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 48 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px+ 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 49 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px + 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 74 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px+10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 75 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px +10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 76 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px+ 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 77 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px + 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 78 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px+10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 79 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px +10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 80 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px+ 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 81 of /sass/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px + 10px")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/options.yml
+++ b/spec/output_styles/compressed/parser/operations/addition/dimensions/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/error
+++ b/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/error
@@ -1,0 +1,251 @@
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/options.yml
+++ b/spec/output_styles/compressed/parser/operations/addition/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/parser/operations/addition/strings/pairs/error
+++ b/spec/output_styles/compressed/parser/operations/addition/strings/pairs/error
@@ -1,0 +1,335 @@
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal+interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal +interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal+ interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal + interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal + lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal + lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal + lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal + lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal+litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal +litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal+ litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal + litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"+interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" +interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"+ interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" + interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" + lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" + lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" + lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" + lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"+litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" +litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"+ litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" + litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant+interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant +interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant+ interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant + interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 42 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant+lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 43 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant +lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 44 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant+ lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 45 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant + lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 46 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant+litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 47 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant +litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 48 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant+ litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 49 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant + litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 50 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp+lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 51 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp +lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 52 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp+ lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 53 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp + lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 54 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp+litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 55 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp +litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 56 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp+ litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 57 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp + litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 58 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema+litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 59 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema +litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 60 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema+ litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 61 of /sass/spec/output_styles/compressed/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema + litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/parser/operations/addition/strings/pairs/options.yml
+++ b/spec/output_styles/compressed/parser/operations/addition/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/parser/operations/division/dimensions/pairs/error
+++ b/spec/output_styles/compressed/parser/operations/division/dimensions/pairs/error
@@ -1,0 +1,167 @@
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compressed/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compressed/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compressed/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compressed/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compressed/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compressed/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compressed/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compressed/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compressed/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compressed/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compressed/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compressed/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compressed/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compressed/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compressed/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compressed/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compressed/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compressed/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compressed/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compressed/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 42 of /sass/spec/output_styles/compressed/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 43 of /sass/spec/output_styles/compressed/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 44 of /sass/spec/output_styles/compressed/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 45 of /sass/spec/output_styles/compressed/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/parser/operations/division/dimensions/pairs/options.yml
+++ b/spec/output_styles/compressed/parser/operations/division/dimensions/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/parser/operations/division/numbers/pairs/error
+++ b/spec/output_styles/compressed/parser/operations/division/numbers/pairs/error
@@ -1,0 +1,27 @@
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compressed/parser/operations/division/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compressed/parser/operations/division/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compressed/parser/operations/division/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compressed/parser/operations/division/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 1}0")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/parser/operations/division/numbers/pairs/options.yml
+++ b/spec/output_styles/compressed/parser/operations/division/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/parser/operations/division/strings/pairs/error
+++ b/spec/output_styles/compressed/parser/operations/division/strings/pairs/error
@@ -1,0 +1,55 @@
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compressed/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal / lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compressed/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal / lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compressed/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal / lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compressed/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal / lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compressed/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" / lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compressed/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" / lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compressed/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" / lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compressed/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" / lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/parser/operations/division/strings/pairs/options.yml
+++ b/spec/output_styles/compressed/parser/operations/division/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/error
+++ b/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/error
@@ -1,0 +1,251 @@
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 ==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10== 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 == 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 == 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 == 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 == 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 == 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 ==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10== 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 == 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 ==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10== 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 == 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 ==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10== 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 == 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 ==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10== 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 == 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 ==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10== 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 == 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 ==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10== 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 == 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 ==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10== 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 == 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/options.yml
+++ b/spec/output_styles/compressed/parser/operations/logic_eq/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/error
+++ b/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/error
@@ -1,0 +1,335 @@
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal==interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal ==interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal== interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal == interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal == lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal == lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal == lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal == lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal==litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal ==litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal== litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal == litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"==interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" ==interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"== interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" == interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" == lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" == lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" == lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" == lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"==litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" ==litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"== litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" == litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant==interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant ==interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant== interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant == interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 42 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant==lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 43 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant ==lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 44 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant== lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 45 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant == lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 46 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant==litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 47 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant ==litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 48 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant== litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 49 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant == litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 50 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp==lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 51 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp ==lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 52 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp== lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 53 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp == lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 54 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp==litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 55 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp ==litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 56 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp== litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 57 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp == litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 58 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema==litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 59 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema ==litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 60 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema== litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 61 of /sass/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema == litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/options.yml
+++ b/spec/output_styles/compressed/parser/operations/logic_eq/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/error
+++ b/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/error
@@ -1,0 +1,251 @@
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 >= 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 >= 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 >= 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 >= 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >= 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/options.yml
+++ b/spec/output_styles/compressed/parser/operations/logic_ge/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/parser/operations/logic_ge/strings/pairs/error
+++ b/spec/output_styles/compressed/parser/operations/logic_ge/strings/pairs/error
@@ -1,0 +1,167 @@
+DEPRECATION WARNING on line 2 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>=interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >=interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>= interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 5 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >= interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp>=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp >=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp>= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp >= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp>=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp >=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp>= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp >= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema>=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema >=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema>= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compressed/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema >= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/parser/operations/logic_ge/strings/pairs/options.yml
+++ b/spec/output_styles/compressed/parser/operations/logic_ge/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/error
+++ b/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/error
@@ -1,0 +1,251 @@
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10> 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 > 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 > 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 > 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 > 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 > 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10> 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 > 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10> 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 > 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10> 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 > 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10> 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 > 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10> 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 > 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10> 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 > 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10> 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 > 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/options.yml
+++ b/spec/output_styles/compressed/parser/operations/logic_gt/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/parser/operations/logic_gt/strings/pairs/error
+++ b/spec/output_styles/compressed/parser/operations/logic_gt/strings/pairs/error
@@ -1,0 +1,167 @@
+DEPRECATION WARNING on line 2 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant> interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 5 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant > interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant> lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant > lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant> litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant > litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp>lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp >lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp> lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp > lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp>litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp >litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp> litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp > litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema>litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema >litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema> litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compressed/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema > litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/parser/operations/logic_gt/strings/pairs/options.yml
+++ b/spec/output_styles/compressed/parser/operations/logic_gt/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/error
+++ b/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/error
@@ -1,0 +1,251 @@
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 <= 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 <= 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 <= 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 <= 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <= 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/options.yml
+++ b/spec/output_styles/compressed/parser/operations/logic_le/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/parser/operations/logic_le/strings/pairs/error
+++ b/spec/output_styles/compressed/parser/operations/logic_le/strings/pairs/error
@@ -1,0 +1,167 @@
+DEPRECATION WARNING on line 2 of /sass/spec/output_styles/compressed/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<=interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/compressed/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <=interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/compressed/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<= interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 5 of /sass/spec/output_styles/compressed/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <= interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compressed/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compressed/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compressed/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compressed/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compressed/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compressed/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compressed/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compressed/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compressed/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp<=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compressed/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp <=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compressed/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp<= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compressed/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp <= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compressed/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp<=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compressed/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp <=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compressed/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp<= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compressed/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp <= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compressed/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema<=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compressed/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema <=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compressed/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema<= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compressed/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema <= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/parser/operations/logic_le/strings/pairs/options.yml
+++ b/spec/output_styles/compressed/parser/operations/logic_le/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/error
+++ b/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/error
@@ -1,0 +1,251 @@
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10< 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 < 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 < 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 < 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 < 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 < 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10< 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 < 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10< 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 < 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10< 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 < 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10< 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 < 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10< 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 < 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10< 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 < 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10< 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 < 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/options.yml
+++ b/spec/output_styles/compressed/parser/operations/logic_lt/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/parser/operations/logic_lt/strings/pairs/error
+++ b/spec/output_styles/compressed/parser/operations/logic_lt/strings/pairs/error
@@ -1,0 +1,167 @@
+DEPRECATION WARNING on line 2 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant< interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 5 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant < interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant< lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant < lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant< litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant < litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp<lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp <lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp< lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp < lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp<litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp <litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp< litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp < litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema<litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema <litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema< litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compressed/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema < litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/parser/operations/logic_lt/strings/pairs/options.yml
+++ b/spec/output_styles/compressed/parser/operations/logic_lt/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/error
+++ b/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/error
@@ -1,0 +1,251 @@
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 !=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 != 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 != 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 != 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 != 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 != 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 !=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 != 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 !=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 != 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 !=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 != 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 !=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 != 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 !=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 != 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 !=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 != 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 !=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 != 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/options.yml
+++ b/spec/output_styles/compressed/parser/operations/logic_ne/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/error
+++ b/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/error
@@ -1,0 +1,335 @@
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal!=interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal !=interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal!= interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal != interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal != lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal != lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal != lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal != lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal!=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal !=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal!= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal != litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"!=interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" !=interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"!= interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" != interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" != lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" != lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" != lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" != lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"!=litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" !=litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"!= litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" != litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant!=interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant !=interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant!= interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant != interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 42 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant!=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 43 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant !=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 44 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant!= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 45 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant != lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 46 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant!=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 47 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant !=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 48 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant!= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 49 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant != litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 50 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp!=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 51 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp !=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 52 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp!= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 53 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp != lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 54 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp!=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 55 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp !=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 56 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp!= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 57 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp != litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 58 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema!=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 59 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema !=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 60 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema!= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 61 of /sass/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema != litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/options.yml
+++ b/spec/output_styles/compressed/parser/operations/logic_ne/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/error
+++ b/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/error
@@ -1,0 +1,209 @@
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10% 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 % 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10% 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 % 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10%10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10% 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10%10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10% 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10%10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10% 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10%10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10% 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10%10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10% 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/options.yml
+++ b/spec/output_styles/compressed/parser/operations/modulo/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/parser/operations/modulo/strings/pairs/error
+++ b/spec/output_styles/compressed/parser/operations/modulo/strings/pairs/error
@@ -1,0 +1,167 @@
+DEPRECATION WARNING on line 2 of /sass/spec/output_styles/compressed/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant%interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/compressed/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant %interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/compressed/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant% interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 5 of /sass/spec/output_styles/compressed/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant % interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compressed/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant%lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compressed/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant %lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compressed/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant% lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compressed/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant % lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compressed/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant%litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compressed/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant %litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compressed/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant% litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compressed/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant % litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compressed/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp%lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compressed/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp %lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compressed/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp% lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compressed/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp % lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compressed/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp%litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compressed/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp %litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compressed/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp% litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compressed/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp % litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compressed/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema%litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compressed/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema %litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compressed/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema% litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compressed/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema % litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/parser/operations/modulo/strings/pairs/options.yml
+++ b/spec/output_styles/compressed/parser/operations/modulo/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/error
+++ b/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/error
@@ -1,0 +1,251 @@
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10*10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 *10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10* 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 * 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 * 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 * 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 * 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 * 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10*10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 *10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10* 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 * 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10*10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 *10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10* 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 * 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10*10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 *10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10* 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 * 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10*10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 *10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10* 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 * 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10*10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 *10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10* 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 * 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10*10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 *10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10* 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 * 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10*10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 *10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10* 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 * 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/options.yml
+++ b/spec/output_styles/compressed/parser/operations/multiply/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/parser/operations/multiply/strings/pairs/error
+++ b/spec/output_styles/compressed/parser/operations/multiply/strings/pairs/error
@@ -1,0 +1,167 @@
+DEPRECATION WARNING on line 2 of /sass/spec/output_styles/compressed/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant*interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/compressed/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant *interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/compressed/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant* interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 5 of /sass/spec/output_styles/compressed/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant * interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compressed/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant*lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compressed/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant *lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compressed/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant* lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compressed/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant * lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compressed/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant*litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compressed/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant *litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compressed/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant* litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compressed/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant * litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compressed/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp*lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compressed/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp *lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compressed/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp* lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compressed/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp * lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compressed/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp*litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compressed/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp *litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compressed/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp* litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compressed/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp * litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compressed/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema*litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compressed/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema *litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compressed/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema* litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compressed/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema * litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/parser/operations/multiply/strings/pairs/options.yml
+++ b/spec/output_styles/compressed/parser/operations/multiply/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/error
+++ b/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/error
@@ -1,0 +1,209 @@
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10- 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 -1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 -10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 -10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px - 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px - 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px -1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px- 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px - 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px -10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px- 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 42 of /sass/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 43 of /sass/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px -10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 44 of /sass/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px- 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 45 of /sass/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 49 of /sass/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px - 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 77 of /sass/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px - 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 81 of /sass/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px - 10px")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/options.yml
+++ b/spec/output_styles/compressed/parser/operations/subtract/dimensions/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/parser/operations/subtract/numbers/pairs/error
+++ b/spec/output_styles/compressed/parser/operations/subtract/numbers/pairs/error
@@ -1,0 +1,125 @@
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compressed/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10- 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compressed/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compressed/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compressed/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 -1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compressed/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compressed/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compressed/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10- 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compressed/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compressed/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10- 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compressed/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compressed/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/compressed/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10- 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/compressed/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compressed/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compressed/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10- 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compressed/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compressed/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10- 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compressed/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/parser/operations/subtract/numbers/pairs/options.yml
+++ b/spec/output_styles/compressed/parser/operations/subtract/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/parser/operations/subtract/strings/pairs/error
+++ b/spec/output_styles/compressed/parser/operations/subtract/strings/pairs/error
@@ -1,0 +1,153 @@
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compressed/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal - interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compressed/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal -lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compressed/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal- lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compressed/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal - lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compressed/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal - litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/compressed/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"- interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/compressed/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" - interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compressed/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" -lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compressed/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" -lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compressed/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" - lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compressed/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" - lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compressed/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"- litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compressed/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" - litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compressed/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant- interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compressed/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant - interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 45 of /sass/spec/output_styles/compressed/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant - lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 48 of /sass/spec/output_styles/compressed/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant- litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 49 of /sass/spec/output_styles/compressed/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant - litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 53 of /sass/spec/output_styles/compressed/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp - lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 56 of /sass/spec/output_styles/compressed/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp- litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 57 of /sass/spec/output_styles/compressed/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp - litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 61 of /sass/spec/output_styles/compressed/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema - litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/parser/operations/subtract/strings/pairs/options.yml
+++ b/spec/output_styles/compressed/parser/operations/subtract/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/scss/function-names/error
+++ b/spec/output_styles/compressed/scss/function-names/error
@@ -1,0 +1,6 @@
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/compressed/scss/function-names/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"hello" un}quote")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/scss/function-names/options.yml
+++ b/spec/output_styles/compressed/scss/function-names/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/scss/interpolation-operators-precedence/error
+++ b/spec/output_styles/compressed/scss/interpolation-operators-precedence/error
@@ -1,0 +1,209 @@
+DEPRECATION WARNING on line 2 of /sass/spec/output_styles/compressed/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a+#{5% + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/compressed/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a+ #{5% + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/compressed/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a +#{5% + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 5 of /sass/spec/output_styles/compressed/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a + #{5% + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compressed/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5 + 2%}+a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compressed/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5 + 2%}+ a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compressed/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5 + 2%} +a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compressed/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5 + 2%} + a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compressed/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a +#{5% + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compressed/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("*5%")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compressed/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a +#{5% - 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compressed/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("*5%")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compressed/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a +#{5% / 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compressed/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a *#{5% / 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compressed/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a +#{5% * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compressed/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a *#{5% * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compressed/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5 + 2%} +a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/compressed/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("2% *a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compressed/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5 - 2%} +a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compressed/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("2% *a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compressed/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5% / 2} +a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compressed/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5% / 2} *a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compressed/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5 * 2%} +a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compressed/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5 * 2%} *a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 42 of /sass/spec/output_styles/compressed/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a ==#{5% == 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 43 of /sass/spec/output_styles/compressed/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a >#{5% > 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 44 of /sass/spec/output_styles/compressed/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a <#{5% < 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 45 of /sass/spec/output_styles/compressed/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a >=#{5% >= 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 46 of /sass/spec/output_styles/compressed/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a <=#{5% <= 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 47 of /sass/spec/output_styles/compressed/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a !=#{5% != 2}")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/compressed/scss/interpolation-operators-precedence/options.yml
+++ b/spec/output_styles/compressed/scss/interpolation-operators-precedence/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/compressed/types/error
+++ b/spec/output_styles/compressed/types/error
@@ -1,0 +1,21 @@
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/compressed/types/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2}+3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compressed/types/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2}px")
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compressed/types/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#abc")
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compressed/types/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("leng#{th(a b c d)}")

--- a/spec/output_styles/compressed/types/options.yml
+++ b/spec/output_styles/compressed/types/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/basic/23_basic_value_interpolation/error
+++ b/spec/output_styles/expanded/basic/23_basic_value_interpolation/error
@@ -1,0 +1,9 @@
+DEPRECATION WARNING on line 5 of /sass/spec/output_styles/expanded/basic/23_basic_value_interpolation/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("123")
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/expanded/basic/23_basic_value_interpolation/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{12 + 111}")

--- a/spec/output_styles/expanded/basic/23_basic_value_interpolation/options.yml
+++ b/spec/output_styles/expanded/basic/23_basic_value_interpolation/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/libsass-closed-issues/issue_1333/error
+++ b/spec/output_styles/expanded/libsass-closed-issues/issue_1333/error
@@ -1,0 +1,6 @@
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/expanded/libsass-issues/issue_1333/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('#{baz()}" !important"')
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/libsass-closed-issues/issue_1333/options.yml
+++ b/spec/output_styles/expanded/libsass-closed-issues/issue_1333/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/libsass-closed-issues/issue_1396/error
+++ b/spec/output_styles/expanded/libsass-closed-issues/issue_1396/error
@@ -1,0 +1,6 @@
+DEPRECATION WARNING on line 2 of /sass/spec/output_styles/expanded/libsass-issues/issue_1396/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{foo "bar"}baz")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/libsass-closed-issues/issue_1396/options.yml
+++ b/spec/output_styles/expanded/libsass-closed-issues/issue_1396/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/libsass-closed-issues/issue_1413/error
+++ b/spec/output_styles/expanded/libsass-closed-issues/issue_1413/error
@@ -1,0 +1,175 @@
+DEPRECATION WARNING on line 2 of /sass/spec/output_styles/expanded/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/expanded/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B"C"')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/expanded/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"BC')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/expanded/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B#{C "D"}')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/expanded/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"A" B}C#{D "E"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/expanded/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{A "B"}C#{D "E"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/expanded/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/expanded/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B"C"')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/expanded/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"BC')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/expanded/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B#{C "D"}')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/expanded/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"A" B}C#{D "E"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/expanded/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{A "B"}C#{D "E"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/expanded/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/expanded/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B"C"')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/expanded/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"BC')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/expanded/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"A"B#{C "D"}')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/expanded/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"A" B}C#{D "E"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/expanded/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{A "B"}C#{D "E"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/expanded/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('A"B"')
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/expanded/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('A"B"C')
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/expanded/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('AB"C"')
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/expanded/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("A#{B "C"}")
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/expanded/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("A#{"B" C "D" "E"}")
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/expanded/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('A"B"')
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/expanded/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('A"B"C')
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/expanded/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('AB"C"')
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/expanded/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("A#{B "C"}")
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/expanded/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("A#{"B" C "D" "E"}")

--- a/spec/output_styles/expanded/libsass-closed-issues/issue_1413/options.yml
+++ b/spec/output_styles/expanded/libsass-closed-issues/issue_1413/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/libsass-closed-issues/issue_152/error
+++ b/spec/output_styles/expanded/libsass-closed-issues/issue_152/error
@@ -1,0 +1,20 @@
+DEPRECATION WARNING on line 5 of /sass/spec/output_styles/expanded/libsass-issues/issue_152/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10% 100%")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/expanded/libsass-issues/issue_152/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 100%")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/expanded/libsass-issues/issue_152/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %100%")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/libsass-closed-issues/issue_152/options.yml
+++ b/spec/output_styles/expanded/libsass-closed-issues/issue_152/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/libsass-closed-issues/issue_1709/error
+++ b/spec/output_styles/expanded/libsass-closed-issues/issue_1709/error
@@ -1,0 +1,6 @@
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/expanded/libsass-issues/issue_1709/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{$prefix}#{$transition}")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/libsass-closed-issues/issue_1709/options.yml
+++ b/spec/output_styles/expanded/libsass-closed-issues/issue_1709/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/libsass-closed-issues/issue_1739/interpolate/both/error
+++ b/spec/output_styles/expanded/libsass-closed-issues/issue_1739/interpolate/both/error
@@ -1,0 +1,97 @@
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2}+#{1 + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2}+ #{1 + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2} +#{1 + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2} + #{1 + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 - 2}- #{1 - 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 - 2} - #{1 - 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 * 2}*#{1 * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 * 2}* #{1 * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 * 2} *#{1 * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 * 2} * #{1 * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1% 2}%#{1% 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1% 2}% #{1% 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 % 2} %#{1 % 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 % 2} % #{1 % 2}")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/libsass-closed-issues/issue_1739/interpolate/both/options.yml
+++ b/spec/output_styles/expanded/libsass-closed-issues/issue_1739/interpolate/both/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/libsass-closed-issues/issue_1739/interpolate/left/error
+++ b/spec/output_styles/expanded/libsass-closed-issues/issue_1739/interpolate/left/error
@@ -1,0 +1,90 @@
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2}+3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2}+ 3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2} +3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2} + 3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 - 2} - 3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 * 2}*3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 * 2}* 3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 * 2} *3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 * 2} * 3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1% 2}%3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1% 2}% 3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 % 2} %3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 % 2} % 3")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/libsass-closed-issues/issue_1739/interpolate/left/options.yml
+++ b/spec/output_styles/expanded/libsass-closed-issues/issue_1739/interpolate/left/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/libsass-closed-issues/issue_1739/interpolate/right/error
+++ b/spec/output_styles/expanded/libsass-closed-issues/issue_1739/interpolate/right/error
@@ -1,0 +1,83 @@
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3+#{1 + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3+ #{1 + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3 +#{1 + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3 + #{1 + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3- #{1 - 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3 - #{1 - 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3*#{1 * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3* #{1 * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3 *#{1 * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3 * #{1 * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3 %#{1 % 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/expanded/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("3 % #{1 % 2}")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/libsass-closed-issues/issue_1739/interpolate/right/options.yml
+++ b/spec/output_styles/expanded/libsass-closed-issues/issue_1739/interpolate/right/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/libsass-closed-issues/issue_442/error
+++ b/spec/output_styles/expanded/libsass-closed-issues/issue_442/error
@@ -1,0 +1,6 @@
+DEPRECATION WARNING on line 1 of /sass/spec/output_styles/expanded/libsass-issues/issue_442/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{100 / 10}rem")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/libsass-closed-issues/issue_442/options.yml
+++ b/spec/output_styles/expanded/libsass-closed-issues/issue_442/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/libsass-closed-issues/issue_870/error
+++ b/spec/output_styles/expanded/libsass-closed-issues/issue_870/error
@@ -1,0 +1,13 @@
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/expanded/libsass-issues/issue_870/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"["#{$quoted-strings-csv}"]"')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/expanded/libsass-issues/issue_870/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"["#{$quoted-strings-ssv}"]"')
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/libsass-closed-issues/issue_870/options.yml
+++ b/spec/output_styles/expanded/libsass-closed-issues/issue_870/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/libsass-closed-issues/issue_948/error
+++ b/spec/output_styles/expanded/libsass-closed-issues/issue_948/error
@@ -1,0 +1,6 @@
+DEPRECATION WARNING on line 1 of /sass/spec/output_styles/expanded/libsass-issues/issue_948/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 * 5}px")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/libsass-closed-issues/issue_948/options.yml
+++ b/spec/output_styles/expanded/libsass-closed-issues/issue_948/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/libsass/arithmetic/error
+++ b/spec/output_styles/expanded/libsass/arithmetic/error
@@ -1,0 +1,41 @@
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/expanded/libsass/arithmetic/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{3 + un}quo#{te("hello")}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/expanded/libsass/arithmetic/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{3 - un}quo#{te("hello")}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 55 of /sass/spec/output_styles/expanded/libsass/arithmetic/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{3 / un}quo#{te("hello")}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 80 of /sass/spec/output_styles/expanded/libsass/arithmetic/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{50% + un}quo#{te("hello")}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 91 of /sass/spec/output_styles/expanded/libsass/arithmetic/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{50% - un}quo#{te("hello")}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 113 of /sass/spec/output_styles/expanded/libsass/arithmetic/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{50% / un}quo#{te("hello")}")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/libsass/arithmetic/options.yml
+++ b/spec/output_styles/expanded/libsass/arithmetic/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/libsass/interpolated-function-call/error
+++ b/spec/output_styles/expanded/libsass/interpolated-function-call/error
@@ -1,0 +1,6 @@
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/expanded/libsass/interpolated-function-call/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{$f}#{a, 1 + 2, c}")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/libsass/interpolated-function-call/options.yml
+++ b/spec/output_styles/expanded/libsass/interpolated-function-call/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/libsass/interpolated-urls/error
+++ b/spec/output_styles/expanded/libsass/interpolated-urls/error
@@ -1,0 +1,13 @@
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/expanded/libsass/interpolated-urls/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"url("#{$base_url}"img/beta.png)"')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/expanded/libsass/interpolated-urls/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{blix "fludge"}#{hey now}123")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/libsass/interpolated-urls/options.yml
+++ b/spec/output_styles/expanded/libsass/interpolated-urls/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/parser/interpolate/00_concatenation/unspaced/error
+++ b/spec/output_styles/expanded/parser/interpolate/00_concatenation/unspaced/error
@@ -1,0 +1,41 @@
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/expanded/parser/interpolate/00_concatenation/unspaced/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{$input}#{$input}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/expanded/parser/interpolate/00_concatenation/unspaced/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{$input}literal")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/expanded/parser/interpolate/00_concatenation/unspaced/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('#{$input}"literal"')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/expanded/parser/interpolate/00_concatenation/unspaced/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{$input}#{$input}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/expanded/parser/interpolate/00_concatenation/unspaced/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal#{$input}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/expanded/parser/interpolate/00_concatenation/unspaced/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"literal"#{$input}')
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/parser/interpolate/00_concatenation/unspaced/options.yml
+++ b/spec/output_styles/expanded/parser/interpolate/00_concatenation/unspaced/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/parser/interpolate/29_binary_operation/06_escape_interpolation/error
+++ b/spec/output_styles/expanded/parser/interpolate/29_binary_operation/06_escape_interpolation/error
@@ -1,0 +1,20 @@
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/expanded/parser/interpolate/29_binary_operation/06_escape_interpolation/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"[\#{" foo}#{"ba" + "r"}#{baz "}]"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/expanded/parser/interpolate/29_binary_operation/06_escape_interpolation/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"\#{" foo}#{"ba" + "r"}#{baz "}"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/expanded/parser/interpolate/29_binary_operation/06_escape_interpolation/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"['\#{" foo}#{"ba" + "r"}#{baz "}']"}")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/parser/interpolate/29_binary_operation/06_escape_interpolation/options.yml
+++ b/spec/output_styles/expanded/parser/interpolate/29_binary_operation/06_escape_interpolation/options.yml
@@ -1,0 +1,3 @@
+---
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/parser/interpolate/30_base_test/06_escape_interpolation/error
+++ b/spec/output_styles/expanded/parser/interpolate/30_base_test/06_escape_interpolation/error
@@ -1,0 +1,20 @@
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/expanded/parser/interpolate/30_base_test/06_escape_interpolation/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"[\#{" foo}#{"ba" + "r"}#{baz "}]"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/expanded/parser/interpolate/30_base_test/06_escape_interpolation/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"\#{" foo}#{"ba" + "r"}#{baz "}"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/expanded/parser/interpolate/30_base_test/06_escape_interpolation/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"['\#{" foo}#{"ba" + "r"}#{baz "}']"}")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/parser/interpolate/30_base_test/06_escape_interpolation/options.yml
+++ b/spec/output_styles/expanded/parser/interpolate/30_base_test/06_escape_interpolation/options.yml
@@ -1,0 +1,3 @@
+---
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/error
+++ b/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/error
@@ -1,0 +1,307 @@
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px+10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px +10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px+ 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px + 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 42 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 43 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 44 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 45 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 46 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px+10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 47 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px +10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 48 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px+ 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 49 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px + 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 74 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px+10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 75 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px +10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 76 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px+ 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 77 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px + 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 78 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px+10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 79 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px +10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 80 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px+ 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 81 of /sass/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px + 10px")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/options.yml
+++ b/spec/output_styles/expanded/parser/operations/addition/dimensions/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/error
+++ b/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/error
@@ -1,0 +1,251 @@
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/options.yml
+++ b/spec/output_styles/expanded/parser/operations/addition/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/parser/operations/addition/strings/pairs/error
+++ b/spec/output_styles/expanded/parser/operations/addition/strings/pairs/error
@@ -1,0 +1,335 @@
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal+interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal +interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal+ interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal + interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal + lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal + lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal + lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal + lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal+litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal +litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal+ litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal + litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"+interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" +interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"+ interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" + interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" + lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" + lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" + lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" + lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"+litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" +litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"+ litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" + litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant+interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant +interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant+ interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant + interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 42 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant+lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 43 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant +lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 44 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant+ lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 45 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant + lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 46 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant+litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 47 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant +litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 48 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant+ litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 49 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant + litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 50 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp+lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 51 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp +lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 52 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp+ lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 53 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp + lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 54 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp+litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 55 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp +litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 56 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp+ litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 57 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp + litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 58 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema+litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 59 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema +litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 60 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema+ litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 61 of /sass/spec/output_styles/expanded/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema + litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/parser/operations/addition/strings/pairs/options.yml
+++ b/spec/output_styles/expanded/parser/operations/addition/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/parser/operations/division/dimensions/pairs/error
+++ b/spec/output_styles/expanded/parser/operations/division/dimensions/pairs/error
@@ -1,0 +1,167 @@
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/expanded/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/expanded/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/expanded/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/expanded/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/expanded/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/expanded/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/expanded/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/expanded/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/expanded/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/expanded/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/expanded/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/expanded/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/expanded/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/expanded/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/expanded/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/expanded/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/expanded/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/expanded/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/expanded/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/expanded/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 42 of /sass/spec/output_styles/expanded/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 43 of /sass/spec/output_styles/expanded/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 44 of /sass/spec/output_styles/expanded/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 45 of /sass/spec/output_styles/expanded/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/parser/operations/division/dimensions/pairs/options.yml
+++ b/spec/output_styles/expanded/parser/operations/division/dimensions/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/parser/operations/division/numbers/pairs/error
+++ b/spec/output_styles/expanded/parser/operations/division/numbers/pairs/error
@@ -1,0 +1,27 @@
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/expanded/parser/operations/division/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/expanded/parser/operations/division/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/expanded/parser/operations/division/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/expanded/parser/operations/division/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 1}0")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/parser/operations/division/numbers/pairs/options.yml
+++ b/spec/output_styles/expanded/parser/operations/division/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/parser/operations/division/strings/pairs/error
+++ b/spec/output_styles/expanded/parser/operations/division/strings/pairs/error
@@ -1,0 +1,55 @@
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/expanded/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal / lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/expanded/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal / lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/expanded/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal / lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/expanded/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal / lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/expanded/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" / lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/expanded/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" / lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/expanded/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" / lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/expanded/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" / lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/parser/operations/division/strings/pairs/options.yml
+++ b/spec/output_styles/expanded/parser/operations/division/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/error
+++ b/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/error
@@ -1,0 +1,251 @@
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 ==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10== 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 == 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 == 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 == 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 == 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 == 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 ==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10== 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 == 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 ==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10== 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 == 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 ==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10== 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 == 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 ==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10== 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 == 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 ==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10== 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 == 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 ==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10== 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 == 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 ==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10== 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 == 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/options.yml
+++ b/spec/output_styles/expanded/parser/operations/logic_eq/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/error
+++ b/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/error
@@ -1,0 +1,335 @@
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal==interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal ==interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal== interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal == interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal == lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal == lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal == lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal == lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal==litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal ==litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal== litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal == litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"==interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" ==interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"== interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" == interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" == lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" == lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" == lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" == lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"==litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" ==litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"== litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" == litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant==interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant ==interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant== interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant == interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 42 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant==lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 43 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant ==lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 44 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant== lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 45 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant == lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 46 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant==litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 47 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant ==litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 48 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant== litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 49 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant == litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 50 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp==lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 51 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp ==lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 52 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp== lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 53 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp == lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 54 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp==litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 55 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp ==litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 56 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp== litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 57 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp == litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 58 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema==litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 59 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema ==litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 60 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema== litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 61 of /sass/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema == litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/options.yml
+++ b/spec/output_styles/expanded/parser/operations/logic_eq/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/error
+++ b/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/error
@@ -1,0 +1,251 @@
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 >= 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 >= 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 >= 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 >= 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >= 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/options.yml
+++ b/spec/output_styles/expanded/parser/operations/logic_ge/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/parser/operations/logic_ge/strings/pairs/error
+++ b/spec/output_styles/expanded/parser/operations/logic_ge/strings/pairs/error
@@ -1,0 +1,167 @@
+DEPRECATION WARNING on line 2 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>=interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >=interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>= interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 5 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >= interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp>=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp >=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp>= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp >= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp>=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp >=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp>= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp >= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema>=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema >=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema>= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/expanded/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema >= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/parser/operations/logic_ge/strings/pairs/options.yml
+++ b/spec/output_styles/expanded/parser/operations/logic_ge/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/error
+++ b/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/error
@@ -1,0 +1,251 @@
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10> 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 > 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 > 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 > 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 > 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 > 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10> 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 > 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10> 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 > 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10> 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 > 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10> 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 > 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10> 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 > 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10> 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 > 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10> 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 > 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/options.yml
+++ b/spec/output_styles/expanded/parser/operations/logic_gt/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/parser/operations/logic_gt/strings/pairs/error
+++ b/spec/output_styles/expanded/parser/operations/logic_gt/strings/pairs/error
@@ -1,0 +1,167 @@
+DEPRECATION WARNING on line 2 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant> interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 5 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant > interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant> lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant > lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant> litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant > litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp>lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp >lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp> lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp > lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp>litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp >litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp> litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp > litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema>litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema >litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema> litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/expanded/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema > litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/parser/operations/logic_gt/strings/pairs/options.yml
+++ b/spec/output_styles/expanded/parser/operations/logic_gt/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/error
+++ b/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/error
@@ -1,0 +1,251 @@
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 <= 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 <= 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 <= 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 <= 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <= 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/options.yml
+++ b/spec/output_styles/expanded/parser/operations/logic_le/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/parser/operations/logic_le/strings/pairs/error
+++ b/spec/output_styles/expanded/parser/operations/logic_le/strings/pairs/error
@@ -1,0 +1,167 @@
+DEPRECATION WARNING on line 2 of /sass/spec/output_styles/expanded/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<=interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/expanded/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <=interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/expanded/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<= interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 5 of /sass/spec/output_styles/expanded/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <= interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/expanded/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/expanded/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/expanded/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/expanded/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/expanded/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/expanded/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/expanded/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/expanded/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/expanded/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp<=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/expanded/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp <=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/expanded/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp<= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/expanded/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp <= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/expanded/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp<=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/expanded/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp <=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/expanded/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp<= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/expanded/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp <= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/expanded/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema<=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/expanded/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema <=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/expanded/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema<= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/expanded/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema <= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/parser/operations/logic_le/strings/pairs/options.yml
+++ b/spec/output_styles/expanded/parser/operations/logic_le/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/error
+++ b/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/error
@@ -1,0 +1,251 @@
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10< 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 < 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 < 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 < 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 < 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 < 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10< 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 < 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10< 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 < 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10< 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 < 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10< 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 < 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10< 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 < 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10< 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 < 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10< 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 < 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/options.yml
+++ b/spec/output_styles/expanded/parser/operations/logic_lt/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/parser/operations/logic_lt/strings/pairs/error
+++ b/spec/output_styles/expanded/parser/operations/logic_lt/strings/pairs/error
@@ -1,0 +1,167 @@
+DEPRECATION WARNING on line 2 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant< interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 5 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant < interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant< lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant < lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant< litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant < litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp<lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp <lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp< lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp < lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp<litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp <litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp< litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp < litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema<litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema <litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema< litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/expanded/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema < litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/parser/operations/logic_lt/strings/pairs/options.yml
+++ b/spec/output_styles/expanded/parser/operations/logic_lt/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/error
+++ b/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/error
@@ -1,0 +1,251 @@
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 !=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 != 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 != 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 != 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 != 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 != 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 !=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 != 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 !=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 != 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 !=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 != 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 !=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 != 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 !=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 != 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 !=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 != 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 !=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 != 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/options.yml
+++ b/spec/output_styles/expanded/parser/operations/logic_ne/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/error
+++ b/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/error
@@ -1,0 +1,335 @@
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal!=interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal !=interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal!= interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal != interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal != lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal != lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal != lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal != lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal!=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal !=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal!= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal != litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"!=interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" !=interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"!= interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" != interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" != lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" != lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" != lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" != lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"!=litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" !=litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"!= litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" != litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant!=interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant !=interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant!= interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant != interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 42 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant!=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 43 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant !=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 44 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant!= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 45 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant != lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 46 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant!=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 47 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant !=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 48 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant!= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 49 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant != litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 50 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp!=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 51 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp !=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 52 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp!= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 53 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp != lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 54 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp!=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 55 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp !=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 56 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp!= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 57 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp != litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 58 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema!=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 59 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema !=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 60 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema!= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 61 of /sass/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema != litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/options.yml
+++ b/spec/output_styles/expanded/parser/operations/logic_ne/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/error
+++ b/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/error
@@ -1,0 +1,209 @@
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10% 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 % 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10% 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 % 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10%10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10% 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10%10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10% 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10%10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10% 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10%10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10% 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10%10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10% 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/options.yml
+++ b/spec/output_styles/expanded/parser/operations/modulo/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/parser/operations/modulo/strings/pairs/error
+++ b/spec/output_styles/expanded/parser/operations/modulo/strings/pairs/error
@@ -1,0 +1,167 @@
+DEPRECATION WARNING on line 2 of /sass/spec/output_styles/expanded/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant%interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/expanded/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant %interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/expanded/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant% interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 5 of /sass/spec/output_styles/expanded/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant % interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/expanded/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant%lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/expanded/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant %lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/expanded/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant% lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/expanded/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant % lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/expanded/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant%litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/expanded/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant %litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/expanded/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant% litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/expanded/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant % litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/expanded/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp%lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/expanded/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp %lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/expanded/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp% lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/expanded/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp % lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/expanded/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp%litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/expanded/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp %litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/expanded/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp% litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/expanded/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp % litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/expanded/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema%litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/expanded/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema %litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/expanded/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema% litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/expanded/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema % litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/parser/operations/modulo/strings/pairs/options.yml
+++ b/spec/output_styles/expanded/parser/operations/modulo/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/error
+++ b/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/error
@@ -1,0 +1,251 @@
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10*10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 *10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10* 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 * 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 * 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 * 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 * 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 * 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10*10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 *10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10* 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 * 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10*10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 *10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10* 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 * 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10*10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 *10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10* 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 * 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10*10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 *10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10* 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 * 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10*10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 *10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10* 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 * 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10*10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 *10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10* 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 * 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10*10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 *10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10* 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 * 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/options.yml
+++ b/spec/output_styles/expanded/parser/operations/multiply/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/parser/operations/multiply/strings/pairs/error
+++ b/spec/output_styles/expanded/parser/operations/multiply/strings/pairs/error
@@ -1,0 +1,167 @@
+DEPRECATION WARNING on line 2 of /sass/spec/output_styles/expanded/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant*interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/expanded/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant *interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/expanded/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant* interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 5 of /sass/spec/output_styles/expanded/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant * interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/expanded/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant*lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/expanded/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant *lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/expanded/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant* lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/expanded/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant * lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/expanded/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant*litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/expanded/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant *litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/expanded/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant* litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/expanded/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant * litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/expanded/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp*lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/expanded/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp *lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/expanded/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp* lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/expanded/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp * lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/expanded/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp*litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/expanded/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp *litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/expanded/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp* litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/expanded/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp * litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/expanded/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema*litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/expanded/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema *litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/expanded/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema* litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/expanded/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema * litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/parser/operations/multiply/strings/pairs/options.yml
+++ b/spec/output_styles/expanded/parser/operations/multiply/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/error
+++ b/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/error
@@ -1,0 +1,209 @@
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10- 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 -1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 -10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 -10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px - 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px - 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px -1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px- 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px - 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px -10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px- 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 42 of /sass/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 43 of /sass/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px -10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 44 of /sass/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px- 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 45 of /sass/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 49 of /sass/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px - 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 77 of /sass/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px - 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 81 of /sass/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px - 10px")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/options.yml
+++ b/spec/output_styles/expanded/parser/operations/subtract/dimensions/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/parser/operations/subtract/numbers/pairs/error
+++ b/spec/output_styles/expanded/parser/operations/subtract/numbers/pairs/error
@@ -1,0 +1,125 @@
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/expanded/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10- 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/expanded/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/expanded/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/expanded/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 -1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/expanded/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/expanded/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/expanded/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10- 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/expanded/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/expanded/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10- 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/expanded/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/expanded/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/expanded/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10- 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/expanded/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/expanded/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/expanded/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10- 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/expanded/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/expanded/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10- 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/expanded/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/parser/operations/subtract/numbers/pairs/options.yml
+++ b/spec/output_styles/expanded/parser/operations/subtract/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/parser/operations/subtract/strings/pairs/error
+++ b/spec/output_styles/expanded/parser/operations/subtract/strings/pairs/error
@@ -1,0 +1,153 @@
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/expanded/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal - interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/expanded/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal -lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/expanded/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal- lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/expanded/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal - lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/expanded/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal - litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/expanded/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"- interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/expanded/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" - interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/expanded/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" -lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/expanded/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" -lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/expanded/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" - lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/expanded/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" - lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/expanded/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"- litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/expanded/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" - litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/expanded/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant- interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/expanded/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant - interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 45 of /sass/spec/output_styles/expanded/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant - lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 48 of /sass/spec/output_styles/expanded/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant- litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 49 of /sass/spec/output_styles/expanded/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant - litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 53 of /sass/spec/output_styles/expanded/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp - lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 56 of /sass/spec/output_styles/expanded/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp- litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 57 of /sass/spec/output_styles/expanded/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp - litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 61 of /sass/spec/output_styles/expanded/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema - litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/parser/operations/subtract/strings/pairs/options.yml
+++ b/spec/output_styles/expanded/parser/operations/subtract/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/scss/function-names/error
+++ b/spec/output_styles/expanded/scss/function-names/error
@@ -1,0 +1,6 @@
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/expanded/scss/function-names/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"hello" un}quote")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/scss/function-names/options.yml
+++ b/spec/output_styles/expanded/scss/function-names/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/scss/interpolation-operators-precedence/error
+++ b/spec/output_styles/expanded/scss/interpolation-operators-precedence/error
@@ -1,0 +1,209 @@
+DEPRECATION WARNING on line 2 of /sass/spec/output_styles/expanded/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a+#{5% + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/expanded/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a+ #{5% + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/expanded/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a +#{5% + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 5 of /sass/spec/output_styles/expanded/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a + #{5% + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/expanded/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5 + 2%}+a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/expanded/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5 + 2%}+ a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/expanded/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5 + 2%} +a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/expanded/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5 + 2%} + a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/expanded/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a +#{5% + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/expanded/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("*5%")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/expanded/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a +#{5% - 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/expanded/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("*5%")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/expanded/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a +#{5% / 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/expanded/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a *#{5% / 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/expanded/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a +#{5% * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/expanded/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a *#{5% * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/expanded/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5 + 2%} +a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/expanded/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("2% *a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/expanded/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5 - 2%} +a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/expanded/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("2% *a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/expanded/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5% / 2} +a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/expanded/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5% / 2} *a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/expanded/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5 * 2%} +a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/expanded/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5 * 2%} *a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 42 of /sass/spec/output_styles/expanded/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a ==#{5% == 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 43 of /sass/spec/output_styles/expanded/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a >#{5% > 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 44 of /sass/spec/output_styles/expanded/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a <#{5% < 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 45 of /sass/spec/output_styles/expanded/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a >=#{5% >= 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 46 of /sass/spec/output_styles/expanded/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a <=#{5% <= 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 47 of /sass/spec/output_styles/expanded/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a !=#{5% != 2}")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/output_styles/expanded/scss/interpolation-operators-precedence/options.yml
+++ b/spec/output_styles/expanded/scss/interpolation-operators-precedence/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/output_styles/expanded/types/error
+++ b/spec/output_styles/expanded/types/error
@@ -1,0 +1,21 @@
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/expanded/types/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2}+3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/expanded/types/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2}px")
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/expanded/types/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#abc")
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/expanded/types/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("leng#{th(a b c d)}")

--- a/spec/output_styles/expanded/types/options.yml
+++ b/spec/output_styles/expanded/types/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/parser/interpolate/00_concatenation/unspaced/error
+++ b/spec/parser/interpolate/00_concatenation/unspaced/error
@@ -1,0 +1,41 @@
+DEPRECATION WARNING on line 8 of /sass/spec/parser/interpolate/00_concatenation/unspaced/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{$input}#{$input}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/parser/interpolate/00_concatenation/unspaced/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{$input}literal")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/parser/interpolate/00_concatenation/unspaced/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('#{$input}"literal"')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/parser/interpolate/00_concatenation/unspaced/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{$input}#{$input}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/parser/interpolate/00_concatenation/unspaced/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal#{$input}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/parser/interpolate/00_concatenation/unspaced/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"literal"#{$input}')
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/parser/interpolate/00_concatenation/unspaced/options.yml
+++ b/spec/parser/interpolate/00_concatenation/unspaced/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/parser/interpolate/29_binary_operation/06_escape_interpolation/error
+++ b/spec/parser/interpolate/29_binary_operation/06_escape_interpolation/error
@@ -1,0 +1,20 @@
+DEPRECATION WARNING on line 3 of /sass/spec/parser/interpolate/29_binary_operation/06_escape_interpolation/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"[\#{" foo}#{"ba" + "r"}#{baz "}]"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/parser/interpolate/29_binary_operation/06_escape_interpolation/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"\#{" foo}#{"ba" + "r"}#{baz "}"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/parser/interpolate/29_binary_operation/06_escape_interpolation/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"['\#{" foo}#{"ba" + "r"}#{baz "}']"}")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/parser/interpolate/29_binary_operation/06_escape_interpolation/options.yml
+++ b/spec/parser/interpolate/29_binary_operation/06_escape_interpolation/options.yml
@@ -1,0 +1,3 @@
+---
+:warning_todo:
+- libsass

--- a/spec/parser/interpolate/30_base_test/06_escape_interpolation/error
+++ b/spec/parser/interpolate/30_base_test/06_escape_interpolation/error
@@ -1,0 +1,20 @@
+DEPRECATION WARNING on line 3 of /sass/spec/parser/interpolate/30_base_test/06_escape_interpolation/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"[\#{" foo}#{"ba" + "r"}#{baz "}]"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/parser/interpolate/30_base_test/06_escape_interpolation/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"\#{" foo}#{"ba" + "r"}#{baz "}"}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/parser/interpolate/30_base_test/06_escape_interpolation/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"['\#{" foo}#{"ba" + "r"}#{baz "}']"}")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/parser/interpolate/30_base_test/06_escape_interpolation/options.yml
+++ b/spec/parser/interpolate/30_base_test/06_escape_interpolation/options.yml
@@ -1,0 +1,3 @@
+---
+:warning_todo:
+- libsass

--- a/spec/parser/operations/addition/dimensions/pairs/error
+++ b/spec/parser/operations/addition/dimensions/pairs/error
@@ -1,0 +1,307 @@
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px+10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px +10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px+ 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px + 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 42 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 43 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 44 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 45 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px + 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 46 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px+10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 47 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px +10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 48 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px+ 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 49 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px + 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 74 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px+10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 75 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px +10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 76 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px+ 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 77 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px + 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 78 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px+10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 79 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px +10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 80 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px+ 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 81 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px + 10px")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/parser/operations/addition/dimensions/pairs/options.yml
+++ b/spec/parser/operations/addition/dimensions/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/parser/operations/addition/numbers/pairs/error
+++ b/spec/parser/operations/addition/numbers/pairs/error
@@ -1,0 +1,251 @@
+DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 + 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 +10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10+ 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 + 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/parser/operations/addition/numbers/pairs/options.yml
+++ b/spec/parser/operations/addition/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/parser/operations/addition/strings/pairs/error
+++ b/spec/parser/operations/addition/strings/pairs/error
@@ -1,0 +1,335 @@
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal+interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal +interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal+ interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal + interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal + lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal + lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal + lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal + lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal+litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal +litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal+ litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal + litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"+interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" +interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"+ interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" + interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" + lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" + lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" + lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" + lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"+litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" +litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"+ litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" + litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant+interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant +interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant+ interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant + interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 42 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant+lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 43 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant +lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 44 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant+ lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 45 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant + lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 46 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant+litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 47 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant +litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 48 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant+ litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 49 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant + litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 50 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp+lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 51 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp +lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 52 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp+ lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 53 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp + lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 54 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp+litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 55 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp +litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 56 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp+ litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 57 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp + litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 58 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema+litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 59 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema +litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 60 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema+ litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 61 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema + litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/parser/operations/addition/strings/pairs/options.yml
+++ b/spec/parser/operations/addition/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/parser/operations/division/dimensions/pairs/error
+++ b/spec/parser/operations/division/dimensions/pairs/error
@@ -1,0 +1,167 @@
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 42 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 43 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 44 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 45 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px / 10}px")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/parser/operations/division/dimensions/pairs/options.yml
+++ b/spec/parser/operations/division/dimensions/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/parser/operations/division/numbers/pairs/error
+++ b/spec/parser/operations/division/numbers/pairs/error
@@ -1,0 +1,27 @@
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/division/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/division/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/division/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/division/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 / 1}0")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/parser/operations/division/numbers/pairs/options.yml
+++ b/spec/parser/operations/division/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/parser/operations/division/strings/pairs/error
+++ b/spec/parser/operations/division/strings/pairs/error
@@ -1,0 +1,55 @@
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal / lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal / lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal / lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal / lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" / lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" / lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" / lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" / lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/parser/operations/division/strings/pairs/options.yml
+++ b/spec/parser/operations/division/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/parser/operations/logic_eq/numbers/pairs/error
+++ b/spec/parser/operations/logic_eq/numbers/pairs/error
@@ -1,0 +1,251 @@
+DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 ==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10== 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 == 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 == 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 == 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 == 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 == 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 ==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10== 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 == 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 ==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10== 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 == 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 ==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10== 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 == 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 ==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10== 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 == 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 ==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10== 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 == 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 ==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10== 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 == 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 ==10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10== 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 == 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/parser/operations/logic_eq/numbers/pairs/options.yml
+++ b/spec/parser/operations/logic_eq/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/parser/operations/logic_eq/strings/pairs/error
+++ b/spec/parser/operations/logic_eq/strings/pairs/error
@@ -1,0 +1,335 @@
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal==interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal ==interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal== interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal == interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal == lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal == lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal == lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal == lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal==litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal ==litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal== litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal == litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"==interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" ==interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"== interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" == interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" == lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" == lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" == lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" == lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"==litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" ==litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"== litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" == litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant==interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant ==interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant== interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant == interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 42 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant==lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 43 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant ==lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 44 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant== lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 45 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant == lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 46 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant==litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 47 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant ==litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 48 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant== litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 49 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant == litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 50 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp==lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 51 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp ==lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 52 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp== lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 53 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp == lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 54 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp==litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 55 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp ==litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 56 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp== litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 57 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp == litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 58 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema==litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 59 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema ==litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 60 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema== litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 61 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema == litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/parser/operations/logic_eq/strings/pairs/options.yml
+++ b/spec/parser/operations/logic_eq/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/parser/operations/logic_ge/numbers/pairs/error
+++ b/spec/parser/operations/logic_ge/numbers/pairs/error
@@ -1,0 +1,251 @@
+DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 >= 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 >= 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 >= 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 >= 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >= 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/parser/operations/logic_ge/numbers/pairs/options.yml
+++ b/spec/parser/operations/logic_ge/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/parser/operations/logic_ge/strings/pairs/error
+++ b/spec/parser/operations/logic_ge/strings/pairs/error
@@ -1,0 +1,167 @@
+DEPRECATION WARNING on line 2 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>=interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 3 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >=interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>= interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 5 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >= interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp>=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp >=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp>= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp >= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp>=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp >=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp>= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp >= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema>=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema >=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema>= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema >= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/parser/operations/logic_ge/strings/pairs/options.yml
+++ b/spec/parser/operations/logic_ge/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/parser/operations/logic_gt/numbers/pairs/error
+++ b/spec/parser/operations/logic_gt/numbers/pairs/error
@@ -1,0 +1,251 @@
+DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10> 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 > 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 > 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 > 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 > 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 > 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10> 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 > 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10> 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 > 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10> 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 > 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10> 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 > 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10> 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 > 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10> 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 > 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10>10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 >10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10> 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 > 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/parser/operations/logic_gt/numbers/pairs/options.yml
+++ b/spec/parser/operations/logic_gt/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/parser/operations/logic_gt/strings/pairs/error
+++ b/spec/parser/operations/logic_gt/strings/pairs/error
@@ -1,0 +1,167 @@
+DEPRECATION WARNING on line 2 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 3 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant> interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 5 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant > interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant> lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant > lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant>litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant >litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant> litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant > litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp>lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp >lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp> lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp > lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp>litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp >litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp> litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp > litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema>litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema >litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema> litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema > litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/parser/operations/logic_gt/strings/pairs/options.yml
+++ b/spec/parser/operations/logic_gt/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/parser/operations/logic_le/numbers/pairs/error
+++ b/spec/parser/operations/logic_le/numbers/pairs/error
@@ -1,0 +1,251 @@
+DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 <= 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 <= 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 <= 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 <= 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <= 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/parser/operations/logic_le/numbers/pairs/options.yml
+++ b/spec/parser/operations/logic_le/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/parser/operations/logic_le/strings/pairs/error
+++ b/spec/parser/operations/logic_le/strings/pairs/error
@@ -1,0 +1,167 @@
+DEPRECATION WARNING on line 2 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<=interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 3 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <=interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<= interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 5 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <= interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp<=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp <=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp<= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp <= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp<=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp <=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp<= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp <= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema<=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema <=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema<= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema <= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/parser/operations/logic_le/strings/pairs/options.yml
+++ b/spec/parser/operations/logic_le/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/parser/operations/logic_lt/numbers/pairs/error
+++ b/spec/parser/operations/logic_lt/numbers/pairs/error
@@ -1,0 +1,251 @@
+DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10< 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 < 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 < 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 < 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 < 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 < 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10< 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 < 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10< 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 < 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10< 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 < 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10< 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 < 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10< 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 < 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10< 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 < 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10<10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 <10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10< 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 < 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/parser/operations/logic_lt/numbers/pairs/options.yml
+++ b/spec/parser/operations/logic_lt/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/parser/operations/logic_lt/strings/pairs/error
+++ b/spec/parser/operations/logic_lt/strings/pairs/error
@@ -1,0 +1,167 @@
+DEPRECATION WARNING on line 2 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 3 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant< interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 5 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant < interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant< lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant < lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant<litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant <litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant< litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant < litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp<lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp <lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp< lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp < lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp<litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp <litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp< litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp < litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema<litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema <litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema< litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema < litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/parser/operations/logic_lt/strings/pairs/options.yml
+++ b/spec/parser/operations/logic_lt/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/parser/operations/logic_ne/numbers/pairs/error
+++ b/spec/parser/operations/logic_ne/numbers/pairs/error
@@ -1,0 +1,251 @@
+DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 !=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 != 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 != 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 != 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 != 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 != 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 !=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 != 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 !=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 != 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 !=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 != 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 !=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 != 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 !=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 != 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 !=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 != 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 !=10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10!= 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 != 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/parser/operations/logic_ne/numbers/pairs/options.yml
+++ b/spec/parser/operations/logic_ne/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/parser/operations/logic_ne/strings/pairs/error
+++ b/spec/parser/operations/logic_ne/strings/pairs/error
@@ -1,0 +1,335 @@
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal!=interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal !=interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal!= interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal != interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal != lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal != lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal != lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal != lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal!=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal !=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal!= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal != litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"!=interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" !=interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"!= interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" != interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" != lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" != lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" != lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" != lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"!=litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" !=litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"!= litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" != litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant!=interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant !=interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant!= interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant != interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 42 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant!=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 43 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant !=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 44 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant!= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 45 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant != lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 46 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant!=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 47 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant !=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 48 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant!= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 49 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant != litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 50 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp!=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 51 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp !=lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 52 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp!= lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 53 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp != lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 54 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp!=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 55 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp !=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 56 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp!= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 57 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp != litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 58 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema!=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 59 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema !=litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 60 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema!= litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 61 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema != litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/parser/operations/logic_ne/strings/pairs/options.yml
+++ b/spec/parser/operations/logic_ne/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/parser/operations/modulo/numbers/pairs/error
+++ b/spec/parser/operations/modulo/numbers/pairs/error
@@ -1,0 +1,209 @@
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10% 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 % 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10% 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 % 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10%10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10% 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10%10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10% 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10%10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10% 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10%10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10% 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10%10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10% 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 %10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 % 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/parser/operations/modulo/numbers/pairs/options.yml
+++ b/spec/parser/operations/modulo/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/parser/operations/modulo/strings/pairs/error
+++ b/spec/parser/operations/modulo/strings/pairs/error
@@ -1,0 +1,167 @@
+DEPRECATION WARNING on line 2 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant%interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 3 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant %interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant% interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 5 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant % interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant%lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant %lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant% lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant % lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant%litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant %litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant% litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant % litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp%lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp %lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp% lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp % lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp%litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp %litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp% litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp % litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema%litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema %litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema% litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema % litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/parser/operations/modulo/strings/pairs/options.yml
+++ b/spec/parser/operations/modulo/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/parser/operations/multiply/numbers/pairs/error
+++ b/spec/parser/operations/multiply/numbers/pairs/error
@@ -1,0 +1,251 @@
+DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10*10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 *10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10* 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 * 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 * 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 * 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 * 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 * 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10*10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 *10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10* 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 * 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10*10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 *10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10* 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 * 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10*10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 *10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10* 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 * 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10*10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 *10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10* 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 * 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10*10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 *10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10* 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 * 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10*10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 *10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10* 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 * 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10*10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 *10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10* 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 * 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/parser/operations/multiply/numbers/pairs/options.yml
+++ b/spec/parser/operations/multiply/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/parser/operations/multiply/strings/pairs/error
+++ b/spec/parser/operations/multiply/strings/pairs/error
@@ -1,0 +1,167 @@
+DEPRECATION WARNING on line 2 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant*interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 3 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant *interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant* interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 5 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant * interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant*lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant *lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant* lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant * lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant*litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant *litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant* litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant * litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp*lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp *lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp* lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp * lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp*litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp *litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp* litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp * litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema*litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema *litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema* litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema * litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/parser/operations/multiply/strings/pairs/options.yml
+++ b/spec/parser/operations/multiply/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/parser/operations/subtract/dimensions/pairs/error
+++ b/spec/parser/operations/subtract/dimensions/pairs/error
@@ -1,0 +1,209 @@
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10- 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 -1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 -10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 -10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px - 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px - 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px -1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px- 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px - 1}0px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px -10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px- 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 42 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 43 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px -10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 44 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px- 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 45 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10px - 10}px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 49 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px - 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 77 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px - 10px")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 81 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10px - 10px")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/parser/operations/subtract/dimensions/pairs/options.yml
+++ b/spec/parser/operations/subtract/dimensions/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/parser/operations/subtract/numbers/pairs/error
+++ b/spec/parser/operations/subtract/numbers/pairs/error
@@ -1,0 +1,125 @@
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10- 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 -1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{10 - 1}0")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10- 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10- 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10- 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10- 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10- 10")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("10 - 10")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/parser/operations/subtract/numbers/pairs/options.yml
+++ b/spec/parser/operations/subtract/numbers/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/parser/operations/subtract/strings/pairs/error
+++ b/spec/parser/operations/subtract/strings/pairs/error
@@ -1,0 +1,153 @@
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal - interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal -lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal- lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{literal - lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("literal - litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"- interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" - interpolant')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" -lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" -lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" - lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"quoted" - lschema_}ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted"- litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote('"quoted" - litlp_rschema')
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant- interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant - interpolant")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 45 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant - lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 48 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant- litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 49 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("interpolant - litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 53 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp - lschema_ritlp")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 56 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp- litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 57 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("lschema_ritlp - litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 61 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("litlp_rschema - litlp_rschema")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/parser/operations/subtract/strings/pairs/options.yml
+++ b/spec/parser/operations/subtract/strings/pairs/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/scss/function-names/error
+++ b/spec/scss/function-names/error
@@ -1,0 +1,6 @@
+DEPRECATION WARNING on line 4 of /sass/spec/scss/function-names/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{"hello" un}quote")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/scss/function-names/options.yml
+++ b/spec/scss/function-names/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/scss/interpolation-operators-precedence/error
+++ b/spec/scss/interpolation-operators-precedence/error
@@ -1,0 +1,209 @@
+DEPRECATION WARNING on line 2 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a+#{5% + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 3 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a+ #{5% + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 4 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a +#{5% + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 5 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a + #{5% + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5 + 2%}+a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 7 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5 + 2%}+ a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 8 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5 + 2%} +a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 9 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5 + 2%} + a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 10 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a +#{5% + 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 13 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("*5%")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 14 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a +#{5% - 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 17 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("*5%")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 18 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a +#{5% / 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 21 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a *#{5% / 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 22 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a +#{5% * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 25 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a *#{5% * 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 26 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5 + 2%} +a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 29 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("2% *a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 30 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5 - 2%} +a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 33 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("2% *a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 34 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5% / 2} +a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 37 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5% / 2} *a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 38 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5 * 2%} +a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 41 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{5 * 2%} *a")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 42 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a ==#{5% == 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 43 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a >#{5% > 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 44 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a <#{5% < 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 45 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a >=#{5% >= 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 46 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a <=#{5% <= 2}")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 47 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("a !=#{5% != 2}")
+
+You can use the sass-convert command to automatically fix most cases.

--- a/spec/scss/interpolation-operators-precedence/options.yml
+++ b/spec/scss/interpolation-operators-precedence/options.yml
@@ -1,2 +1,4 @@
 ---
 :end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/types/error
+++ b/spec/types/error
@@ -1,0 +1,21 @@
+DEPRECATION WARNING on line 28 of /sass/spec/types/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2}+3")
+
+You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 16 of /sass/spec/types/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#{1 + 2}px")
+
+DEPRECATION WARNING on line 20 of /sass/spec/types/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("#abc")
+
+DEPRECATION WARNING on line 22 of /sass/spec/types/input.scss: #{} interpolation near operators will be simplified
+in a future version of Sass. To preserve the current behavior, use quotes:
+
+  unquote("leng#{th(a b c d)}")

--- a/spec/types/options.yml
+++ b/spec/types/options.yml
@@ -1,3 +1,5 @@
 ---
 :start_version: '3.4'
 :end_version: '3.5'
+:warning_todo:
+- libsass


### PR DESCRIPTION
This brings warnings in line with current ruby sass warnings.

It also removes specific exclusions for not erroring for some ruby warnings. Doing so did introduce some new expected errors, but not many. I'd like to land this on top of the `language_versions` branch and add specific metadata about expecting a failure for warnings vs failing for output so that libsass can have TODOs around deprecation warnings while still avoiding output regressions. 