### PR TITLE
Increase spec timeout

### DIFF
--- a/lib/sass_spec/engine_adapter.rb
+++ b/lib/sass_spec/engine_adapter.rb
@@ -33,7 +33,7 @@ class ExecutableEngineAdapater < EngineAdapter
 
   def initialize(command, description = nil)
     @command = command
-    @timeout = 10
+    @timeout = 20
     @description = description || command
   end
 


### PR DESCRIPTION
LibSass builds on AppVeyor are failing due to `spec/scss/huge`
timing out.