### PR TITLE
Remove :nuke option as it was redundant

### DIFF
--- a/lib/sass_spec/cli.rb
+++ b/lib/sass_spec/cli.rb
@@ -102,10 +102,6 @@ Make sure the command you provide prints to stdout.
         # Note: --skip is no longer necessary as this is now the default behavior, since we test for errors
       end
 
-      opts.on("--nuke", "Write a new expected_output for every test from whichever engine we are using") do
-        options[:nuke] = true
-      end
-
       opts.on("--migrate", "Copy tests that fail and make them pass for the current version.") do
         options[:migrate] = true
       end

--- a/lib/sass_spec/test_case.rb
+++ b/lib/sass_spec/test_case.rb
@@ -114,7 +114,7 @@ class SassSpec::TestCase
   end
 
   def overwrite?
-    @options[:generate] || @options[:nuke]
+    @options[:generate]
   end
 
   def output


### PR DESCRIPTION
`:generate` and `:nuke` ended up being identical after my recent work. This removes `:nuke`