### PR TITLE
@import ... supports(...) is supposed to allow bare support declarations.

### DIFF
--- a/spec/sass_3_4_x/README.md
+++ b/spec/sass_3_4_x/README.md
@@ -1,0 +1,1 @@
+This is where bug fixes at the language level in 3.4.x are spec'd.

--- a/spec/sass_3_4_x/options.yml
+++ b/spec/sass_3_4_x/options.yml
@@ -1,0 +1,2 @@
+---
+:start_version: '3.4'

--- a/spec/sass_3_4_x/simple_supports_clause_in_import/expected_output.css
+++ b/spec/sass_3_4_x/simple_supports_clause_in_import/expected_output.css
@@ -1,0 +1,4 @@
+@import "mystyle.css" supports((display: flex));
+@import "mystyle.css" supports((display: flex) and (all: initial));
+@import "morestyles.css" supports((all: initial));
+@import "morestyles.css" supports((all: initial));

--- a/spec/sass_3_4_x/simple_supports_clause_in_import/input.scss
+++ b/spec/sass_3_4_x/simple_supports_clause_in_import/input.scss
@@ -1,0 +1,6 @@
+$name: all;
+$value: initial;
+@import "mystyle.css" supports(display: flex);
+@import "mystyle.css" supports((display: flex) and ($name: $value));
+@import "morestyles.css" supports($name: $value);
+@import "morestyles.css" supports(($name: $value));

--- a/spec/sass_3_4_x/simple_supports_clause_in_import/options.yml
+++ b/spec/sass_3_4_x/simple_supports_clause_in_import/options.yml
@@ -1,0 +1,3 @@
+---
+:todo:
+- libsass


### PR DESCRIPTION
This spec is for a bug in the sass parser for CSS compatiblity: https://github.com/sass/sass/issues/1967

It is marked as TODO for libsass at this time, I will open a bug against libsass for the entire import supports clause feature which was added a few releases ago.