### PR TITLE
[WIP] NPM packagable version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ tmp
 .sass-cache
 .DS_Store
 Gemfile.*.lock
+node_modules/
+*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 rvm:
   - "2.3.1"
+env:
+  - NODE_SASS=yes
+  - RUBY_SASS=yes
+matrix:
+  allow_failures:
+  - env: NODE_SASS=yes
 script: "./test_all_impls.sh"
 language: ruby
 sudo: false

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "mocha": "^3.0.2",
+    "object-merge": "^2.5.1",
     "read-yaml": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "node-sass": "^3.8.0"
   },
   "dependencies": {
-    "mocha": "^3.0.2"
+    "mocha": "^3.0.2",
+    "read-yaml": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "node-sass": "^3.8.0"
   },
   "dependencies": {
+    "glob": "^7.0.6",
     "mocha": "^3.0.2",
     "object-merge": "^2.5.1",
     "read-yaml": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "sass-spec",
+  "version": "3.3.3",
+  "description": "Test suite for testing compatibility with the Sass Stylesheet language.",
+  "main": "sass-spec.js",
+  "scripts": {
+    "start": "node_modules/.bin/mocha sass-spec.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sass/sass-spec.git"
+  },
+  "keywords": [
+    "sass"
+  ],
+  "author": "Michael Mifsud <xzyfer@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/sass/sass-spec/issues"
+  },
+  "homepage": "https://github.com/sass/sass-spec#readme",
+  "devDependencies": {
+    "node-sass": "^3.8.0"
+  },
+  "dependencies": {
+    "mocha": "^3.0.2"
+  }
+}

--- a/sass-spec.js
+++ b/sass-spec.js
@@ -7,101 +7,95 @@ var assert = require('assert'),
     sass = require('node-sass'),
     readYaml = require('read-yaml'),
     objectMerge = require('object-merge'),
+    glob = require('glob'),
     version = 3.4;
 
+var normalize = function(str) {
+  return str.replace(/\s+/g, '').replace('{', '{\n').replace(';', ';\n');
+};
+
+var specPath = join(__dirname, 'spec')
+var inputs = glob.sync(specPath + "/**/input.*");
+
+var initialize = function(folder, options) {
+  var testCase = {};
+  testCase.folder = folder;
+  testCase.name = path.basename(folder);
+  var inputScss = join(folder, 'input.scss')
+  testCase.inputPath = exists(inputScss) ? inputScss : join(folder, 'input.sass');
+  testCase.expectedPath = join(folder, 'expected_output.css');
+  testCase.errorPath = join(folder, 'error');
+  testCase.statusPath = join(folder, 'status');
+  testCase.optionsPath = join(folder, 'options.yml');
+  if (exists(testCase.optionsPath)) {
+    options = objectMerge(options, readYaml.sync(testCase.optionsPath));
+  }
+  testCase.includePaths = [
+    folder,
+    join(folder, 'sub')
+  ]
+  testCase.precision = parseFloat(options[':precision']) || 5;
+  testCase.outputStyle = options[':output_style'] ? options[':output_style'].replace(':', '') : 'nested';;
+  testCase.todo = options[':todo'] != null && options[':todo'].indexOf('libsass') != -1;
+  testCase.warningTodo = options[':warning_todo'] != null && options[':warning_todo'].indexOf('libsass') != -1;
+  testCase.startVersion = parseFloat(options[':start_version']) || 0;
+  testCase.endVersion = parseFloat(options[':end_version']) || 99;
+  testCase.options = options;
+  testCase.result = false;
+
+  // Probe filesystem once and cache the results
+  testCase.shouldFail = exists(testCase.statusPath) && !fs.statSync(testCase.statusPath).isDirectory();
+  testCase.verifyStderr = exists(testCase.errorPath) && !fs.statSync(testCase.errorPath).isDirectory();
+  return testCase;
+}
+
 describe('spec', function() {
-  var normalize = function(str) {
-    return str.replace(/\s+/g, '').replace('{', '{\n').replace(';', ';\n');
-  };
-  var suites = function() {
-    var ret = {};
-    var spec = join(__dirname, 'spec');
-    var suites = fs.readdirSync(spec);
+  inputs.forEach(function(input) {
+    var folder = path.dirname(input)
+    var options = {};
+    var optionsPath = specPath;
+    // Try and walk the directory and merge the options
+    var walkDirs = folder.replace(specPath + '/', '').split('/')
+    while (walkDirs.length > 0) {
+      optionsPath = join(optionsPath, walkDirs.shift())
+      var optionsFile = join(optionsPath, 'options.yml');
 
-    suites.forEach(function(suite) {
-      var suitePath = join(spec, suite);
-      var suiteOptions = {};
-      var suiteOptionsPath = join(suitePath, 'options.yml');
-      if (fs.existsSync(suiteOptionsPath)) {
-        suiteOptions = readYaml.sync(suiteOptionsPath);
+      if (exists(optionsFile)) {
+        options = objectMerge(options, readYaml.sync(optionsFile));
       }
+    }
 
-      var tests = fs.readdirSync(suitePath);
+    var test = initialize(folder, options);
 
-      ret[suite] = {};
-
-      tests.forEach(function(test) {
-        var testPath = join(suitePath, test);
-        var testOptions = suiteOptions;
-        var testOptionsPath = join(testPath, 'options.yml');
-        if (fs.existsSync(testOptionsPath)) {
-          testOptions = objectMerge(testOptions, readYaml.sync(testOptionsPath));
-        }
-        var hasErrorFile = fs.existsSync(join(testPath, 'error')) && !fs.statSync(join(testPath, 'error')).isDirectory();
-        var hasError = false;
-        if (hasErrorFile) {
-          var errorFileContents = fs.readFileSync(join(testPath, 'error')).toString();
-          hasError = !(
-            errorFileContents.match(/^DEPRECATION WARNING/) ||
-            errorFileContents.match(/^WARNING:/) ||
-            errorFileContents.match(/^.*?\/input.scss:\d+ DEBUG:/)
-          );
-        }
-
-        ret[suite][test] = {};
-        ret[suite][test].src = join(testPath, 'input.scss');
-        ret[suite][test].error = hasErrorFile && hasError;
-        ret[suite][test].expected = join(testPath, 'expected_output.css');
-        ret[suite][test].paths = [
-          testPath,
-          join(testPath, 'sub')
-        ];
-        ret[suite][test].options = testOptions;
-      });
-    });
-
-    return ret;
-  }();
-
-  Object.keys(suites).forEach(function(suite) {
-    var tests = Object.keys(suites[suite]);
-
-    describe(suite, function() {
-
-      tests.forEach(function(test) {
-        var t = suites[suite][test];
-        var isTodo = t.options[':todo'] != null && t.options[':todo'].indexOf('libsass') != -1;
-        var isWarningTodo = t.options[':warning_todo'] != null && t.options[':warning_todo'].indexOf('libsass') != -1;
-        var minVersion = parseFloat(t.options[':start_version']) || 0;
-        var maxVersion = parseFloat(t.options[':end_version']) || 99;
-        if (exists(t.src)) {
-          it(test, function(done) {
-            if (isTodo || isWarningTodo) {
-              this.skip("Test marked with TODO");
-            } else if (version < minVersion) {
-              this.skip("Tests marked for newer Sass versions only");
-            } else if (version > maxVersion) {
-              this.skip("Tests marked for older Sass versions only");
-            } else {
-              var expected = normalize(read(t.expected, 'utf8'));
-              sass.render({
-                file: t.src,
-                includePaths: t.paths
-              }, function(error, result) {
-                if (t.error) {
-                  assert(error);
-                } else {
-                  assert(!error);
-                }
-                if (expected) {
-                  assert.equal(normalize(result.css.toString()), expected);
-                }
-                done();
-              });
+    it(test.folder, function(done) {
+      if (test.todo || test.warningTodo) {
+        this.skip("Test marked with TODO");
+      } else if (version < test.startVersion) {
+        this.skip("Tests marked for newer Sass versions only");
+      } else if (version > test.endVersion) {
+        this.skip("Tests marked for older Sass versions only");
+      } else {
+        var expected = normalize(read(test.expectedPath, 'utf8'));
+        sass.render({
+            file: test.inputPath,
+            includePaths: test.includePaths,
+            precision: test.precision,
+            outputStyle: test.outputStyle
+          }, function(error, result) {
+            if (test.verifyStatus) {
+              assert(error);
             }
-          });
-        }
-      });
+            if (test.verifyStderr) {
+              assert(error, 'Should Error with options ' + JSON.stringify(test.options))
+            } else {
+              assert(!error, 'Shouldn\'t have an error with options ' + JSON.stringify(test.options))
+            }
+            if (expected) {
+              assert.equal(normalize(result.css.toString()), expected, 'Should equal with options ' + JSON.stringify(test.options));
+            }
+            done();
+        });
+      }
     });
   });
 });

--- a/sass-spec.js
+++ b/sass-spec.js
@@ -5,7 +5,8 @@ var assert = require('assert'),
     join = require('path').join,
     read = fs.readFileSync,
     sass = require('node-sass'),
-    readYaml = require('read-yaml');
+    readYaml = require('read-yaml'),
+    version = 3.4;
 
 describe('spec', function() {
   var normalize = function(str) {
@@ -64,6 +65,8 @@ describe('spec', function() {
       var s = suites[suite];
       var isTodo = s.options[':todo'] != null && s.options[':todo'].indexOf('libsass') != -1;
       var isWarningTodo = s.options[':warning_todo'] != null && s.options[':warning_todo'].indexOf('libsass') != -1;
+      var minVersion = parseFloat(s.options[':start_version']) || 0;
+      var maxVersion = parseFloat(s.options[':end_version']) || 99;
 
       tests.forEach(function(test) {
         var t = suites[suite][test];
@@ -71,6 +74,10 @@ describe('spec', function() {
           it(test, function(done) {
             if (isTodo || isWarningTodo) {
               this.skip("Test marked with TODO");
+            } else if (version < minVersion) {
+              this.skip("Tests marked for newer Sass versions only");
+            } else if (version > maxVersion) {
+              this.skip("Tests marked for older Sass versions only");
             } else {
               var expected = normalize(read(t.expected, 'utf8'));
               sass.render({

--- a/sass-spec.js
+++ b/sass-spec.js
@@ -1,0 +1,89 @@
+var assert = require('assert'),
+    fs = require('fs'),
+    exists = fs.existsSync,
+    path = require('path'),
+    join = require('path').join,
+    read = fs.readFileSync,
+    sass = require('node-sass');
+
+describe('spec', function() {
+  var normalize = function(str) {
+    return str.replace(/\s+/g, '').replace('{', '{\n').replace(';', ';\n');
+  };
+  var suites = function() {
+    var ret = {};
+    var spec = join(__dirname, 'spec');
+    var suites = fs.readdirSync(spec);
+    var ignoreSuites = [
+      'libsass-todo-issues',
+      'libsass-todo-tests'
+    ];
+
+    suites.forEach(function(suite) {
+      if (ignoreSuites.indexOf(suite) !== -1) {
+        return;
+      }
+
+      var suitePath = join(spec, suite);
+      var tests = fs.readdirSync(suitePath);
+
+      ret[suite] = {};
+
+      tests.forEach(function(test) {
+        var testPath = join(suitePath, test);
+        var hasErrorFile = fs.existsSync(join(testPath, 'error')) && !fs.statSync(join(testPath, 'error')).isDirectory();
+        var hasError = false;
+        if (hasErrorFile) {
+          var errorFileContents = fs.readFileSync(join(testPath, 'error')).toString();
+          hasError = !(
+            errorFileContents.match(/^DEPRECATION WARNING/) ||
+            errorFileContents.match(/^WARNING:/) ||
+            errorFileContents.match(/^.*?\/input.scss:\d+ DEBUG:/)
+          );
+        }
+
+        ret[suite][test] = {};
+        ret[suite][test].src = join(testPath, 'input.scss');
+        ret[suite][test].error = hasErrorFile && hasError;
+        ret[suite][test].expected = join(testPath, 'expected_output.css');
+        ret[suite][test].paths = [
+          testPath,
+          join(testPath, 'sub')
+        ];
+      });
+    });
+
+    return ret;
+  }();
+
+  Object.keys(suites).forEach(function(suite) {
+    var tests = Object.keys(suites[suite]);
+
+    describe(suite, function() {
+      tests.forEach(function(test) {
+        var t = suites[suite][test];
+
+        if (exists(t.src)) {
+          it(test, function(done) {
+            var expected = normalize(read(t.expected, 'utf8'));
+
+            sass.render({
+              file: t.src,
+              includePaths: t.paths
+            }, function(error, result) {
+              if (t.error) {
+                assert(error);
+              } else {
+                assert(!error);
+              }
+              if (expected) {
+                assert.equal(normalize(result.css.toString()), expected);
+              }
+              done();
+            });
+          });
+        }
+      });
+    });
+  });
+});

--- a/test_all_impls.sh
+++ b/test_all_impls.sh
@@ -2,6 +2,11 @@
 set -v
 export DIR=`dirname $0`
 
+if [ "x$NODE_SASS" == "xyes" ]; then
+  npm install
+  npm run start
+  exit 0
+fi
 
 for GEMFILE in `ls $DIR/Gemfile*`
 do
@@ -13,5 +18,3 @@ do
     bundle exec sass-spec.rb || exit 1
   fi
 done
-
-# TODO: Test libsass here

--- a/test_all_impls.sh
+++ b/test_all_impls.sh
@@ -7,7 +7,7 @@ if [ "x$NODE_SASS" == "xyes" ]; then
   npm run start || exit 1
 fi
 
-if [ "x$RUBY_SASS" == "xyes" ];
+if [ "x$RUBY_SASS" == "xyes" ]; then
   for GEMFILE in `ls $DIR/Gemfile*`
   do
     if [[ $GEMFILE != *"lock"* ]]

--- a/test_all_impls.sh
+++ b/test_all_impls.sh
@@ -3,18 +3,19 @@ set -v
 export DIR=`dirname $0`
 
 if [ "x$NODE_SASS" == "xyes" ]; then
-  npm install
-  npm run start
-  exit 0
+  npm install || exit 1
+  npm run start || exit 1
 fi
 
-for GEMFILE in `ls $DIR/Gemfile*`
-do
-  if [[ $GEMFILE != *"lock"* ]]
-  then
-    export BUNDLE_GEMFILE=$GEMFILE
-    bundle install --no-deployment || exit 1
-    bundle update sass || exit 1
-    bundle exec sass-spec.rb || exit 1
-  fi
-done
+if [ "x$RUBY_SASS" == "xyes" ];
+  for GEMFILE in `ls $DIR/Gemfile*`
+  do
+    if [[ $GEMFILE != *"lock"* ]]
+    then
+      export BUNDLE_GEMFILE=$GEMFILE
+      bundle install --no-deployment || exit 1
+      bundle update sass || exit 1
+      bundle exec sass-spec.rb || exit 1
+    fi
+  done
+fi


### PR DESCRIPTION
This isn't meant to replace the Ruby version, but as a helper for https://github.com/sass/node-sass/issues/1686
 - [x] Port node-sass spec runner
 - [x] Teach it to read the options.yml
 - [x] Teach it the `todo` syntax
 - [x] Teach it about version ranges
 - [x] Fix `error` syntax
 - [x] Teach it the new `status` outputs
 - [x] Fix recursive "suites", i.e. nested folders
 - [ ] Group tests into suites by folders
 - [ ] Fix hard-coded `utf-8` assumption that fails some tests

This can always get split out to a separate repo with a submodule if preferred.

/cc @xzyfer these are the remaining failures right now https://gist.github.com/nschonni/5ec9cbc20b3f9747c84c9e9e3625cfda