### PR TITLE
Add SassC to the CI build setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ tmp
 .sass-cache
 .DS_Store
 Gemfile.*.lock
+
+sassc/
+
+libsass/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 rvm:
   - "2.3.1"
+env:
+  - RUBY_SASS=yes
+  - SASSC_SASS=yes LANGUAGE_VERSION=3.4
 script: "./test_all_impls.sh"
 language: ruby
 sudo: false

--- a/test_all_impls.sh
+++ b/test_all_impls.sh
@@ -1,17 +1,28 @@
 #!/bin/bash
 set -v
-export DIR=`dirname $0`
+export DIR=`pwd`
 
+if [ "x$RUBY_SASS" = "xyes" ]; then
+  for GEMFILE in `ls $DIR/Gemfile*`
+  do
+    if [[ $GEMFILE != *"lock"* ]]
+    then
+      export BUNDLE_GEMFILE=$GEMFILE
+      bundle install --no-deployment || exit 1
+      bundle update sass || exit 1
+      bundle exec sass-spec.rb || exit 1
+    fi
+  done
+fi
 
-for GEMFILE in `ls $DIR/Gemfile*`
-do
-  if [[ $GEMFILE != *"lock"* ]]
-  then
-    export BUNDLE_GEMFILE=$GEMFILE
-    bundle install --no-deployment || exit 1
-    bundle update sass || exit 1
-    bundle exec sass-spec.rb || exit 1
-  fi
-done
-
-# TODO: Test libsass here
+if [ "x$SASSC_SASS" = "xyes" ]; then
+  export SASS_SPEC_PATH=$DIR
+  git clone https://github.com/sass/libsass.git
+  cd libsass && git submodule init && git submodule update && cd ..
+  export SASS_LIBSASS_PATH=$DIR/libsass
+  git clone https://github.com/sass/sassc.git
+  cd sassc && git submodule init && git submodule update
+  make || exit 1
+  cd ..
+  ruby sass-spec.rb -V $LANGUAGE_VERSION -c './sassc/bin/sassc' --impl 'libsass' || exit 1
+fi


### PR DESCRIPTION
Uses the same build logic as the SassC CI setup, and adds an extra
build to the Travis matrix. Currently the Sass Language for SassC is
pinned to 3.4 to match libsass testing.