### PR TITLE
Make Sass Spec npm installable

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  dirname: __dirname,
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "sass-spec",
+  "version": "3.4.0-0",
+  "description": "Test suite for testing compatibility with the Sass Stylesheet language.",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sass/sass-spec.git"
+  },
+  "keywords": [
+    "sass"
+  ],
+  "files": [
+    "spec",
+    "index.js"
+  ],
+  "author": "Michael Mifsud <xzyfer@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/sass/sass-spec/issues"
+  },
+  "homepage": "https://github.com/sass/sass-spec#readme"
+}


### PR DESCRIPTION
Node Sass to have Sass Spec specs as dependency for inclusion in
the node-citgm. The requirement for being the citgm is that a
packages tests should be executable via `npm install`.

This means Node Sass needs to publish it's tests to npm. That
includes Sass Spec. At the moment Sass Spec is a git submodule so
we'd need to publish the entire repo. This is a [problem](https://twitter.com/nodkz/status/773103622678798336) as
Sass Spec weighs in at 69M.

Size aside some users have experienced issues with some unicode
[file names](https://github.com/sass/node-sass/issues/1699) and [long paths](https://github.com/sass/node-sass/issues/1701). To get around these issues
we want remove the git submodule and instead `npm install` the
Sass Spec spec files. We'd do this a `devDependency` so regular
users won't install them which avoids the previously mentioned issues.
Having only the specs files in npm package will also hugely reduce
the package size.

---

Supersedes the remainder of #898. The spec runner part is being moved into sass/node-sass#1698.

/cc @nschonni
