### PR TITLE
Disable interpolation-operators-precedence spec for LibSass

### DIFF
--- a/spec/output_styles/compact/scss/interpolation-operators-precedence/options.yml
+++ b/spec/output_styles/compact/scss/interpolation-operators-precedence/options.yml
@@ -1,4 +1,6 @@
 ---
 :end_version: '3.5'
+:todo:
+- libsass
 :warning_todo:
 - libsass

--- a/spec/output_styles/compressed/scss/interpolation-operators-precedence/options.yml
+++ b/spec/output_styles/compressed/scss/interpolation-operators-precedence/options.yml
@@ -1,4 +1,6 @@
 ---
 :end_version: '3.5'
+:todo:
+- libsass
 :warning_todo:
 - libsass

--- a/spec/output_styles/expanded/scss/interpolation-operators-precedence/options.yml
+++ b/spec/output_styles/expanded/scss/interpolation-operators-precedence/options.yml
@@ -1,4 +1,6 @@
 ---
 :end_version: '3.5'
+:todo:
+- libsass
 :warning_todo:
 - libsass

--- a/spec/scss/interpolation-operators-precedence/options.yml
+++ b/spec/scss/interpolation-operators-precedence/options.yml
@@ -1,4 +1,6 @@
 ---
 :end_version: '3.5'
+:todo:
+- libsass
 :warning_todo:
 - libsass


### PR DESCRIPTION
LibSass is no more or less inconsistent than Ruby Sass, but it is
different. LibSass will address the differences to Ruby Sass when
sass/sass#2160 is resolved.