### PR TITLE
Call the Ruby implementation "ruby-sass".

### DIFF
--- a/lib/sass_spec/cli.rb
+++ b/lib/sass_spec/cli.rb
@@ -5,7 +5,7 @@ module SassSpec::CLI
 
   def self.parse
     options = {
-      engine_adapter: SassEngineAdapter.new("sass"),
+      engine_adapter: SassEngineAdapter.new,
       spec_directory: nil,
       generate: false,
       tap: false,

--- a/lib/sass_spec/engine_adapter.rb
+++ b/lib/sass_spec/engine_adapter.rb
@@ -66,16 +66,8 @@ class ExecutableEngineAdapater < EngineAdapter
 end
 
 class SassEngineAdapter < EngineAdapter
-  def initialize(description)
-    @description = description
-  end
-
-  def set_description(description)
-    @description = description
-  end
-
   def describe
-    @description
+    'ruby-sass'
   end
 
   def version

--- a/spec/output_styles/compact/libsass/properties-in-media/options.yml
+++ b/spec/output_styles/compact/libsass/properties-in-media/options.yml
@@ -1,4 +1,4 @@
 ---
 :todo:
 - libsass
-- sass
+- ruby-sass

--- a/spec/output_styles/compact/scss-tests/186_test_newlines_removed_from_selectors_when_compressed/options.yml
+++ b/spec/output_styles/compact/scss-tests/186_test_newlines_removed_from_selectors_when_compressed/options.yml
@@ -1,4 +1,4 @@
 ---
 :todo:
 - libsass
-- sass
+- ruby-sass

--- a/spec/output_styles/compact/scss/media2/options.yml
+++ b/spec/output_styles/compact/scss/media2/options.yml
@@ -1,4 +1,4 @@
 ---
 :todo:
 - libsass
-- sass
+- ruby-sass

--- a/spec/output_styles/compressed/misc/mixin_content/options.yml
+++ b/spec/output_styles/compressed/misc/mixin_content/options.yml
@@ -1,4 +1,4 @@
 ---
 :todo:
 - libsass
-- sass
+- ruby-sass

--- a/spec/output_styles/compressed/scss-tests/188_test_mixin_content/options.yml
+++ b/spec/output_styles/compressed/scss-tests/188_test_mixin_content/options.yml
@@ -1,4 +1,4 @@
 ---
 :todo:
 - libsass
-- sass
+- ruby-sass

--- a/spec/output_styles/compressed/scss/color_output/options.yml
+++ b/spec/output_styles/compressed/scss/color_output/options.yml
@@ -1,4 +1,4 @@
 ---
 :todo:
 - libsass
-- sass
+- ruby-sass


### PR DESCRIPTION
Now that Dart Sass exists, just calling this "sass" is confusing.