### PR TITLE
Add specs for mixing unary and binary operators.

### DIFF
--- a/spec/parser/operations/binary-and-unary/expected_output.css
+++ b/spec/parser/operations/binary-and-unary/expected_output.css
@@ -1,0 +1,8 @@
+foo {
+  minus-before-minus: -3;
+  minus-after-minus: 3;
+  plus-before-minus: -1;
+  plus-after-minus: -1;
+  not-before-plus: false2;
+  not-after-plus: 1false;
+}

--- a/spec/parser/operations/binary-and-unary/input.scss
+++ b/spec/parser/operations/binary-and-unary/input.scss
@@ -1,0 +1,8 @@
+foo {
+  minus-before-minus: - 1 - 2;
+  minus-after-minus:  1 - - 2;
+  plus-before-minus:  + 1 - 2;
+  plus-after-minus:   1 - + 2;
+  not-before-plus:    not 1 + 2;
+  not-after-plus:     1 + not 2;
+}


### PR DESCRIPTION
This was broken on Dart Sass but there wasn't a failing spec for it yet.