### PR TITLE
Use valid media rules in specs.

### DIFF
--- a/spec/extend-tests/193_test_media_in_placeholder_selector/input.scss
+++ b/spec/extend-tests/193_test_media_in_placeholder_selector/input.scss
@@ -1,2 +1,2 @@
-%foo {bar {@media screen {a: b}}}
+%foo {bar {@media screen {a {b: c}}}}
 .baz {c: d}

--- a/spec/libsass/variables_in_media/expected_output.css
+++ b/spec/libsass/variables_in_media/expected_output.css
@@ -1,3 +1,5 @@
 @media screen and (-webkit-min-device-pixel-ratio: 20), only print {
-  a: b;
+  a {
+    b: c;
+  }
 }

--- a/spec/libsass/variables_in_media/input.scss
+++ b/spec/libsass/variables_in_media/input.scss
@@ -2,4 +2,4 @@ $media1: screen;
 $media2: print;
 $var: -webkit-min-device-pixel-ratio;
 $val: 20;
-@media #{$media1} and ($var: $val), only #{$media2} {a: b}
+@media #{$media1} and ($var: $val), only #{$media2} {a {b: c}}

--- a/spec/libsass/variables_in_media/options.yml
+++ b/spec/libsass/variables_in_media/options.yml
@@ -1,3 +1,0 @@
----
-:todo:
-- dart-sass

--- a/spec/misc/media_interpolation/expected_output.css
+++ b/spec/misc/media_interpolation/expected_output.css
@@ -1,3 +1,5 @@
 @media bar12 {
-  a: b;
+  a {
+    b: c;
+  }
 }

--- a/spec/misc/media_interpolation/input.scss
+++ b/spec/misc/media_interpolation/input.scss
@@ -1,2 +1,2 @@
 $baz: 12;
-@media bar#{$baz} {a: b}
+@media bar#{$baz} {a {b: c}}

--- a/spec/misc/media_interpolation/options.yml
+++ b/spec/misc/media_interpolation/options.yml
@@ -1,3 +1,0 @@
----
-:todo:
-- dart-sass

--- a/spec/scss-tests/123_test_media_interpolation/expected_output.css
+++ b/spec/scss-tests/123_test_media_interpolation/expected_output.css
@@ -1,3 +1,5 @@
 @media bar12 {
-  a: b;
+  a {
+    b: c;
+  }
 }

--- a/spec/scss-tests/123_test_media_interpolation/input.scss
+++ b/spec/scss-tests/123_test_media_interpolation/input.scss
@@ -1,2 +1,2 @@
 $baz: 12;
-@media bar#{$baz} {a: b}
+@media bar#{$baz} {a {b: c}}

--- a/spec/scss-tests/123_test_media_interpolation/options.yml
+++ b/spec/scss-tests/123_test_media_interpolation/options.yml
@@ -1,3 +1,0 @@
----
-:todo:
-- dart-sass

--- a/spec/scss-tests/124_test_script_in_media/expected_output.css
+++ b/spec/scss-tests/124_test_script_in_media/expected_output.css
@@ -1,3 +1,5 @@
 @media screen and (-webkit-min-device-pixel-ratio: 20), only print {
-  a: b;
+  a {
+    b: c;
+  }
 }

--- a/spec/scss-tests/124_test_script_in_media/input.scss
+++ b/spec/scss-tests/124_test_script_in_media/input.scss
@@ -2,4 +2,4 @@ $media1: screen;
 $media2: print;
 $var: -webkit-min-device-pixel-ratio;
 $val: 20;
-@media #{$media1} and ($var: $val), only #{$media2} {a: b}
+@media #{$media1} and ($var: $val), only #{$media2} {a {b: c}}

--- a/spec/scss-tests/124_test_script_in_media/options.yml
+++ b/spec/scss-tests/124_test_script_in_media/options.yml
@@ -1,3 +1,0 @@
----
-:todo:
-- dart-sass

--- a/spec/scss-tests/125_test_script_in_media/expected_output.css
+++ b/spec/scss-tests/125_test_script_in_media/expected_output.css
@@ -1,3 +1,5 @@
 @media screen and (-webkit-min-device-pixel-ratio: 13) {
-  a: b;
+  a {
+    b: c;
+  }
 }

--- a/spec/scss-tests/125_test_script_in_media/input.scss
+++ b/spec/scss-tests/125_test_script_in_media/input.scss
@@ -1,2 +1,2 @@
 $vals: 1 2 3;
-@media screen and (-webkit-min-device-pixel-ratio: 5 + 6 + nth($vals, 2)) {a: b}
+@media screen and (-webkit-min-device-pixel-ratio: 5 + 6 + nth($vals, 2)) {a {b: c}}

--- a/spec/scss-tests/125_test_script_in_media/options.yml
+++ b/spec/scss-tests/125_test_script_in_media/options.yml
@@ -1,3 +1,0 @@
----
-:todo:
-- dart-sass

--- a/spec/scss-tests/126_test_media_interpolation_with_reparse/expected_output.css
+++ b/spec/scss-tests/126_test_media_interpolation_with_reparse/expected_output.css
@@ -1,12 +1,20 @@
 @media screen and (max-width: 300px) {
-  a: b;
+  a {
+    b: c;
+  }
 }
 @media screen and (max-width: 300px) {
-  a: b;
+  a {
+    b: c;
+  }
 }
 @media screen and (max-width: 300px) {
-  a: b;
+  a {
+    b: c;
+  }
 }
 @media screen and (max-width: 300px), print and (max-width: 300px) {
-  a: b;
+  a {
+    b: c;
+  }
 }

--- a/spec/scss-tests/126_test_media_interpolation_with_reparse/input.scss
+++ b/spec/scss-tests/126_test_media_interpolation_with_reparse/input.scss
@@ -1,11 +1,11 @@
 $constraint: "(max-width: 300px)";
 $fragment: "nd #{$constraint}";
 $comma: "een, pri";
-@media screen and #{$constraint} {a: b}
+@media screen and #{$constraint} {a {b: c}}
 @media screen {
-  @media #{$constraint} {a: b}
+  @media #{$constraint} {a {b: c}}
 }
-@media screen a#{$fragment} {a: b}
+@media screen a#{$fragment} {a {b: c}}
 @media scr#{$comma}nt {
-  @media #{$constraint} {a: b}
+  @media #{$constraint} {a {b: c}}
 }

--- a/spec/scss-tests/126_test_media_interpolation_with_reparse/options.yml
+++ b/spec/scss-tests/126_test_media_interpolation_with_reparse/options.yml
@@ -1,3 +1,0 @@
----
-:todo:
-- dart-sass


### PR DESCRIPTION
A number of specs were using "@media ... {a: b}", which produces invalid
CSS. This updates them to use "@media ... {a {b: c}}" instead.