### PR TITLE
Fix and disable str-slice spec

### DIFF
--- a/spec/libsass-closed-issues/issue_2132/expected_output.css
+++ b/spec/libsass-closed-issues/issue_2132/expected_output.css
@@ -15,8 +15,8 @@ foo {
   test-13: "";
   test-14: "";
   test-15: "";
-  test-16: "a";
-  test-17: "a";
+  test-16: "";
+  test-17: "";
   test-18: "";
   test-19: "";
   test-20: "";

--- a/spec/libsass-closed-issues/issue_2132/options.yml
+++ b/spec/libsass-closed-issues/issue_2132/options.yml
@@ -1,3 +1,5 @@
 ---
 :todo:
 - dart-sass
+- ruby-sass
+- libsass


### PR DESCRIPTION
The spec was updated in #997 with incorrect output generated by a
big in Ruby Sass https://github.com/sass/sass/issues/2211.

This updates the expected output and disables the spec since all
implemenations are now failing.