### PR TITLE
Enable the troublesom str-slice spec for libsass

### DIFF
--- a/spec/libsass-closed-issues/issue_2132/options.yml
+++ b/spec/libsass-closed-issues/issue_2132/options.yml
@@ -2,4 +2,3 @@
 :todo:
 - dart-sass
 - ruby-sass
-- libsass


### PR DESCRIPTION
This spec was updated with incorrect output in #997 due to a Ruby
Sass bug. In #1004 the output was updated to be correct and the spec
disabled for all implementations because they all suffered from the
original bug.

This PR enables it for LibSass which is now passing with correct output.