### PR TITLE
Add libsass 3.5 testing and update master target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ matrix:
       env: LANGUAGE_VERSION=3.5 IMPL=ruby-sass
     - gemfile: Gemfile.sass_4_0
       env: LANGUAGE_VERSION=4.0 IMPL=ruby-sass
-    - env: LANGUAGE_VERSION=3.4 IMPL=libsass COMMAND="../sassc/bin/sassc" GITISH=master
+    - env: LANGUAGE_VERSION=3.4 IMPL=libsass COMMAND="../sassc/bin/sassc" GITISH=3.4
+    - env: LANGUAGE_VERSION=3.5 IMPL=libsass COMMAND="../sassc/bin/sassc" GITISH=master
     - env: LANGUAGE_VERSION=4.0 IMPL=dart-sass
 
 before_install:


### PR DESCRIPTION
Note there is a bunch of failures for libsass and 3.5 right now. These are primarily about error messages, but there are a few functional ones that might need some TODOs added