### PR TITLE
Activate 3.5 call with string deprecation specs for LibSass

### DIFF
--- a/spec/basic/60_call-3.5/options.yml
+++ b/spec/basic/60_call-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/libsass-closed-issues/issue_1075-3.5/options.yml
+++ b/spec/libsass-closed-issues/issue_1075-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/libsass-closed-issues/issue_1133/normal-3.5/options.yml
+++ b/spec/libsass-closed-issues/issue_1133/normal-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/libsass-closed-issues/issue_1133/vararg-3.5/options.yml
+++ b/spec/libsass-closed-issues/issue_1133/vararg-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/libsass-closed-issues/issue_1266/max-3.5/options.yml
+++ b/spec/libsass-closed-issues/issue_1266/max-3.5/options.yml
@@ -2,5 +2,3 @@
 :start_version: '3.5'
 :warning_todo:
 - dart-sass
-:todo:
-- libsass

--- a/spec/libsass-closed-issues/issue_1266/min-3.5/options.yml
+++ b/spec/libsass-closed-issues/issue_1266/min-3.5/options.yml
@@ -2,5 +2,3 @@
 :start_version: '3.5'
 :warning_todo:
 - dart-sass
-:todo:
-- libsass

--- a/spec/libsass-closed-issues/issue_1305-3.5/options.yml
+++ b/spec/libsass-closed-issues/issue_1305-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/libsass-closed-issues/issue_1417-3.5/options.yml
+++ b/spec/libsass-closed-issues/issue_1417-3.5/options.yml
@@ -2,4 +2,3 @@
 :start_version: '3.5'
 :todo:
 - dart-sass
-- libsass

--- a/spec/libsass-closed-issues/issue_1418/dynamic-3.5/options.yml
+++ b/spec/libsass-closed-issues/issue_1418/dynamic-3.5/options.yml
@@ -1,5 +1,3 @@
 ---
 :start_version: '3.5'
 :end_version: '3.5'
-:warning_todo:
-- libsass

--- a/spec/libsass-closed-issues/issue_1488-3.5/options.yml
+++ b/spec/libsass-closed-issues/issue_1488-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/libsass-closed-issues/issue_1566-3.5/options.yml
+++ b/spec/libsass-closed-issues/issue_1566-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/libsass-closed-issues/issue_1579-3.5/options.yml
+++ b/spec/libsass-closed-issues/issue_1579-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/libsass-closed-issues/issue_1622-3.5/options.yml
+++ b/spec/libsass-closed-issues/issue_1622-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/libsass-closed-issues/issue_1634-3.5/options.yml
+++ b/spec/libsass-closed-issues/issue_1634-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/libsass-closed-issues/issue_1645-3.5/options.yml
+++ b/spec/libsass-closed-issues/issue_1645-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compact/basic/60_call-3.5/options.yml
+++ b/spec/output_styles/compact/basic/60_call-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1075-3.5/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1075-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1133/normal-3.5/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1133/normal-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1133/vararg-3.5/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1133/vararg-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1305-3.5/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1305-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1417-3.5/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1417-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1488-3.5/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1488-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1566-3.5/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1566-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1579-3.5/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1579-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1622-3.5/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1622-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1634-3.5/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1634-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1645-3.5/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1645-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compressed/basic/60_call-3.5/options.yml
+++ b/spec/output_styles/compressed/basic/60_call-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1075-3.5/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1075-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1133/normal-3.5/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1133/normal-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1133/vararg-3.5/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1133/vararg-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1305-3.5/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1305-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1417-3.5/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1417-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1488-3.5/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1488-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1566-3.5/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1566-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1579-3.5/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1579-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1622-3.5/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1622-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1634-3.5/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1634-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1645-3.5/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1645-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/nested/basic/60_call-3.5/options.yml
+++ b/spec/output_styles/nested/basic/60_call-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/nested/libsass-closed-issues/issue_1075-3.5/options.yml
+++ b/spec/output_styles/nested/libsass-closed-issues/issue_1075-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/nested/libsass-closed-issues/issue_1133/normal-3.5/options.yml
+++ b/spec/output_styles/nested/libsass-closed-issues/issue_1133/normal-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/nested/libsass-closed-issues/issue_1133/vararg-3.5/options.yml
+++ b/spec/output_styles/nested/libsass-closed-issues/issue_1133/vararg-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/nested/libsass-closed-issues/issue_1305-3.5/options.yml
+++ b/spec/output_styles/nested/libsass-closed-issues/issue_1305-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/nested/libsass-closed-issues/issue_1417-3.5/options.yml
+++ b/spec/output_styles/nested/libsass-closed-issues/issue_1417-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/nested/libsass-closed-issues/issue_1488-3.5/options.yml
+++ b/spec/output_styles/nested/libsass-closed-issues/issue_1488-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/nested/libsass-closed-issues/issue_1566-3.5/options.yml
+++ b/spec/output_styles/nested/libsass-closed-issues/issue_1566-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/nested/libsass-closed-issues/issue_1579-3.5/options.yml
+++ b/spec/output_styles/nested/libsass-closed-issues/issue_1579-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/nested/libsass-closed-issues/issue_1622-3.5/options.yml
+++ b/spec/output_styles/nested/libsass-closed-issues/issue_1622-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/nested/libsass-closed-issues/issue_1634-3.5/options.yml
+++ b/spec/output_styles/nested/libsass-closed-issues/issue_1634-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/nested/libsass-closed-issues/issue_1645-3.5/options.yml
+++ b/spec/output_styles/nested/libsass-closed-issues/issue_1645-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/sass_3_5/functions/get-function/local-scope/options.yml
+++ b/spec/sass_3_5/functions/get-function/local-scope/options.yml
@@ -1,3 +1,0 @@
----
-:todo:
-- libsass


### PR DESCRIPTION
Activates ~50 specs that were failing due to this missing deprecation notice. Most of these were deactivated in https://github.com/sass/sass-spec/pull/1042 so that we could get LibSass master building against 3.5 language specs.