### PR TITLE
Add specs for deprecating hex alpha colors.

### DIFF
--- a/spec/sass_3_5/alpha_hex/error
+++ b/spec/sass_3_5/alpha_hex/error
@@ -1,0 +1,15 @@
+DEPRECATION WARNING on line 5, column 24 of /sass/spec/sass_3_5/alpha_hex/input.scss:
+The value "#AbCd" is currently parsed as a string, but it will be parsed as a color in
+future versions of Sass. Use "unquote('#AbCd')" to continue parsing it as a string.
+
+DEPRECATION WARNING on line 6, column 27 of /sass/spec/sass_3_5/alpha_hex/input.scss:
+The value "#aBcDeFaB" is currently parsed as a string, but it will be parsed as a color in
+future versions of Sass. Use "unquote('#aBcDeFaB')" to continue parsing it as a string.
+
+DEPRECATION WARNING on line 7, column 28 of /sass/spec/sass_3_5/alpha_hex/input.scss:
+The value "#abcd" is currently parsed as a string, but it will be parsed as a color in
+future versions of Sass. Use "unquote('#abcd')" to continue parsing it as a string.
+
+DEPRECATION WARNING on line 8, column 31 of /sass/spec/sass_3_5/alpha_hex/input.scss:
+The value "#abcdefab" is currently parsed as a string, but it will be parsed as a color in
+future versions of Sass. Use "unquote('#abcdefab')" to continue parsing it as a string.

--- a/spec/sass_3_5/alpha_hex/expected_output.css
+++ b/spec/sass_3_5/alpha_hex/expected_output.css
@@ -1,0 +1,11 @@
+.alpha-hex {
+  short-letters: #AbCd;
+  long-letters: #aBcDeFaB;
+  short-type: string;
+  long-type: string;
+  five-letters: #abcde;
+  seven-letters: #abcdefa;
+  nine-letters: #abcdefabc;
+  non-hex-short: #axcd;
+  non-hex-long: #abcxdefa;
+}

--- a/spec/sass_3_5/alpha_hex/input.scss
+++ b/spec/sass_3_5/alpha_hex/input.scss
@@ -1,0 +1,17 @@
+.alpha-hex {
+  // For Sass 3.5, we just deprecate the previous parsing of hex alpha colors
+  // that were previously parsed as IDs. They'll be parsed as colors in 3.6. See
+  // sass#2179.
+  short-letters: (#AbCd);
+  long-letters: (#aBcDeFaB);
+  short-type: type-of(#abcd);
+  long-type: type-of(#abcdefab);
+
+  // These should still be parsed as ID strings and thus not emit deprecation
+  // warnings.
+  five-letters:  #abcde;
+  seven-letters: #abcdefa;
+  nine-letters:  #abcdefabc;
+  non-hex-short: #axcd;
+  non-hex-long:  #abcxdefa;
+}

--- a/spec/sass_3_5/alpha_hex/options.yml
+++ b/spec/sass_3_5/alpha_hex/options.yml
@@ -1,0 +1,4 @@
+---
+:end_version: '3.5'
+:todo:
+- libsass


### PR DESCRIPTION
Skip ruby-sass