### PR TITLE
Activate LibSass specs for 3.5 alpha hex deprecation warning

### DIFF
--- a/spec/sass_3_5/alpha_hex/options.yml
+++ b/spec/sass_3_5/alpha_hex/options.yml
@@ -1,4 +1,2 @@
 ---
 :end_version: '3.5'
-:todo:
-- libsass


### PR DESCRIPTION
Best to get this out sooner rather than later so people have time
to upgrade.

[skip libsass]