### PR TITLE
Add Ruby 2.4 to Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,22 @@ matrix:
   include:
     - gemfile: Gemfile
       env: LANGUAGE_VERSION=3.4 IMPL=ruby-sass
+      rvm: 2.3.4
     - gemfile: Gemfile.sass_3_5
       env: LANGUAGE_VERSION=3.5 IMPL=ruby-sass
+      rvm: 2.3.4
     - gemfile: Gemfile.sass_4_0
       env: LANGUAGE_VERSION=4.0 IMPL=ruby-sass
+      rvm: 2.3.4
+    - gemfile: Gemfile.sass_4_0
+      env: LANGUAGE_VERSION=4.0 IMPL=ruby-sass
+      rvm: 2.4.1
     - env: LANGUAGE_VERSION=3.4 IMPL=libsass COMMAND="../sassc/bin/sassc" GITISH=3.4-stable
+      rvm: 2.3.4
     - env: LANGUAGE_VERSION=3.5 IMPL=libsass COMMAND="../sassc/bin/sassc" GITISH=master
+      rvm: 2.3.4
     - env: LANGUAGE_VERSION=4.0 IMPL=dart-sass
+      rvm: 2.3.4
 
 before_install:
   - if ./tools/skipped-for-impl.sh; then exit 0; fi


### PR DESCRIPTION
Right now the Travis test is run on Travis default Ruby (=2.3.1), seeing below Travis test on latest master branch.
I want to add Ruby 2.4 to check the behavior.

https://travis-ci.org/sass/sass-spec/builds/230385467

```
$ ruby --version
ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-linux]
```

Because I faced below error for `sass`. It is failed for only Ruby 2.4.1.
https://github.com/sass/sass/issues/2279

I want to know if it is issue of `sass-spec` or `sass`.


