### PR TITLE
Enable one last spec for Dart Sass.

### DIFF
--- a/spec/libsass/color-functions/rgb/mix/options.yml
+++ b/spec/libsass/color-functions/rgb/mix/options.yml
@@ -1,3 +1,0 @@
----
-:todo:
-- dart-sass


### PR DESCRIPTION
This brings Dart Sass up to full sass-spec compliance, with the
exception of two UTF-16 specs that can't be supported until
dart-lang/sdk#11744 is fixed.

Skip dart-sass