### PR TITLE
Add deprecation messages for compound extends.

### DIFF
--- a/spec/extend-tests/092_test_long_extendee/error
+++ b/spec/extend-tests/092_test_long_extendee/error
@@ -1,0 +1,3 @@
+DEPRECATION WARNING on line 2 of /sass/spec/extend-tests/092_test_long_extendee/input.scss:
+Extending a compound selector, .foo.bar, is deprecated and will not be supported in a future release.
+See https://github.com/sass/sass/issues/1599 for details.

--- a/spec/extend-tests/092_test_long_extendee/options.yml
+++ b/spec/extend-tests/092_test_long_extendee/options.yml
@@ -1,3 +1,4 @@
 ---
-:ignore_for:
-- dart-sass
+:end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/extend-tests/093_test_long_extendee_matches_supersets/error
+++ b/spec/extend-tests/093_test_long_extendee_matches_supersets/error
@@ -1,0 +1,3 @@
+DEPRECATION WARNING on line 2 of /sass/spec/extend-tests/093_test_long_extendee_matches_supersets/input.scss:
+Extending a compound selector, .foo.bar, is deprecated and will not be supported in a future release.
+See https://github.com/sass/sass/issues/1599 for details.

--- a/spec/extend-tests/093_test_long_extendee_matches_supersets/options.yml
+++ b/spec/extend-tests/093_test_long_extendee_matches_supersets/options.yml
@@ -1,3 +1,4 @@
 ---
-:ignore_for:
-- dart-sass
+:end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/libsass-closed-issues/issue_1654/nested/error
+++ b/spec/libsass-closed-issues/issue_1654/nested/error
@@ -1,0 +1,3 @@
+DEPRECATION WARNING on line 14 of /sass/spec/libsass-issues/issue_1654/nested/input.scss:
+Extending a compound selector, moo%foobar, is deprecated and will not be supported in a future release.
+See https://github.com/sass/sass/issues/1599 for details.

--- a/spec/libsass-closed-issues/issue_1654/nested/options.yml
+++ b/spec/libsass-closed-issues/issue_1654/nested/options.yml
@@ -1,3 +1,4 @@
 ---
-:ignore_for:
-- dart-sass
+:end_version: '3.5'
+:warning_todo:
+- libsass

--- a/spec/libsass/inheritance/error
+++ b/spec/libsass/inheritance/error
@@ -1,0 +1,3 @@
+DEPRECATION WARNING on line 28 of /sass/spec/libsass/inheritance/input.scss:
+Extending a compound selector, mammal.quadruped, is deprecated and will not be supported in a future release.
+See https://github.com/sass/sass/issues/1599 for details.

--- a/spec/libsass/inheritance/options.yml
+++ b/spec/libsass/inheritance/options.yml
@@ -1,3 +1,4 @@
 ---
-:ignore_for:
-- dart-sass
+:end_version: '3.5'
+:warning_todo:
+- libsass


### PR DESCRIPTION
See sass/sass#1599
Skip ruby-sass