### PR TITLE
Activate a bunch of call specs for LibSass

### DIFF
--- a/spec/basic/60_call-3.5/options.yml
+++ b/spec/basic/60_call-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/libsass-closed-issues/issue_1075-3.5/options.yml
+++ b/spec/libsass-closed-issues/issue_1075-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/libsass-closed-issues/issue_1133/normal-3.5/options.yml
+++ b/spec/libsass-closed-issues/issue_1133/normal-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/libsass-closed-issues/issue_1133/vararg-3.5/options.yml
+++ b/spec/libsass-closed-issues/issue_1133/vararg-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/libsass-closed-issues/issue_1266/max-3.5/options.yml
+++ b/spec/libsass-closed-issues/issue_1266/max-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/libsass-closed-issues/issue_1266/min-3.5/options.yml
+++ b/spec/libsass-closed-issues/issue_1266/min-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/libsass-closed-issues/issue_1305-3.5/options.yml
+++ b/spec/libsass-closed-issues/issue_1305-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/libsass-closed-issues/issue_1417-3.5/options.yml
+++ b/spec/libsass-closed-issues/issue_1417-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/libsass-closed-issues/issue_1418/dynamic-3.5/options.yml
+++ b/spec/libsass-closed-issues/issue_1418/dynamic-3.5/options.yml
@@ -1,5 +1,3 @@
 ---
 :start_version: '3.5'
 :end_version: '3.5'
-:warning_todo:
-- libsass

--- a/spec/libsass-closed-issues/issue_1488-3.5/options.yml
+++ b/spec/libsass-closed-issues/issue_1488-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/libsass-closed-issues/issue_1566-3.5/options.yml
+++ b/spec/libsass-closed-issues/issue_1566-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/libsass-closed-issues/issue_1578/options.yml
+++ b/spec/libsass-closed-issues/issue_1578/options.yml
@@ -1,3 +1,0 @@
----
-:warning_todo:
-- libsass

--- a/spec/libsass-closed-issues/issue_1579-3.5/options.yml
+++ b/spec/libsass-closed-issues/issue_1579-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/libsass-closed-issues/issue_1622-3.5/options.yml
+++ b/spec/libsass-closed-issues/issue_1622-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/libsass-closed-issues/issue_1634-3.5/options.yml
+++ b/spec/libsass-closed-issues/issue_1634-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/libsass-closed-issues/issue_1645-3.5/options.yml
+++ b/spec/libsass-closed-issues/issue_1645-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/libsass-closed-issues/issue_308/options.yml
+++ b/spec/libsass-closed-issues/issue_308/options.yml
@@ -1,3 +1,0 @@
----
-:warning_todo:
-- libsass

--- a/spec/output_styles/compact/basic/60_call-3.5/options.yml
+++ b/spec/output_styles/compact/basic/60_call-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1075-3.5/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1075-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1133/normal-3.5/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1133/normal-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1133/vararg-3.5/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1133/vararg-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1305-3.5/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1305-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1417-3.5/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1417-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1488-3.5/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1488-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1566-3.5/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1566-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1578/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1578/options.yml
@@ -1,3 +1,0 @@
----
-:warning_todo:
-- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1579-3.5/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1579-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1622-3.5/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1622-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1634-3.5/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1634-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1645-3.5/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1645-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compact/libsass-closed-issues/issue_308/options.yml
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_308/options.yml
@@ -1,3 +1,0 @@
----
-:warning_todo:
-- libsass

--- a/spec/output_styles/compressed/basic/60_call-3.5/options.yml
+++ b/spec/output_styles/compressed/basic/60_call-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1075-3.5/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1075-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1133/normal-3.5/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1133/normal-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1133/vararg-3.5/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1133/vararg-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1305-3.5/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1305-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1417-3.5/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1417-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1488-3.5/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1488-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1566-3.5/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1566-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1578/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1578/options.yml
@@ -1,3 +1,0 @@
----
-:warning_todo:
-- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1579-3.5/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1579-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1622-3.5/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1622-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1634-3.5/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1634-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1645-3.5/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1645-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_308/options.yml
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_308/options.yml
@@ -1,3 +1,0 @@
----
-:warning_todo:
-- libsass

--- a/spec/output_styles/nested/basic/60_call-3.5/options.yml
+++ b/spec/output_styles/nested/basic/60_call-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/nested/libsass-closed-issues/issue_1075-3.5/options.yml
+++ b/spec/output_styles/nested/libsass-closed-issues/issue_1075-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/nested/libsass-closed-issues/issue_1133/normal-3.5/options.yml
+++ b/spec/output_styles/nested/libsass-closed-issues/issue_1133/normal-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/nested/libsass-closed-issues/issue_1133/vararg-3.5/options.yml
+++ b/spec/output_styles/nested/libsass-closed-issues/issue_1133/vararg-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/nested/libsass-closed-issues/issue_1305-3.5/options.yml
+++ b/spec/output_styles/nested/libsass-closed-issues/issue_1305-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/nested/libsass-closed-issues/issue_1417-3.5/options.yml
+++ b/spec/output_styles/nested/libsass-closed-issues/issue_1417-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/nested/libsass-closed-issues/issue_1488-3.5/options.yml
+++ b/spec/output_styles/nested/libsass-closed-issues/issue_1488-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/nested/libsass-closed-issues/issue_1566-3.5/options.yml
+++ b/spec/output_styles/nested/libsass-closed-issues/issue_1566-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/nested/libsass-closed-issues/issue_1578/options.yml
+++ b/spec/output_styles/nested/libsass-closed-issues/issue_1578/options.yml
@@ -1,3 +1,0 @@
----
-:warning_todo:
-- libsass

--- a/spec/output_styles/nested/libsass-closed-issues/issue_1579-3.5/options.yml
+++ b/spec/output_styles/nested/libsass-closed-issues/issue_1579-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/nested/libsass-closed-issues/issue_1622-3.5/options.yml
+++ b/spec/output_styles/nested/libsass-closed-issues/issue_1622-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/nested/libsass-closed-issues/issue_1634-3.5/options.yml
+++ b/spec/output_styles/nested/libsass-closed-issues/issue_1634-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/nested/libsass-closed-issues/issue_1645-3.5/options.yml
+++ b/spec/output_styles/nested/libsass-closed-issues/issue_1645-3.5/options.yml
@@ -1,4 +1,2 @@
 ---
 :start_version: '3.5'
-:todo:
-- libsass

--- a/spec/output_styles/nested/libsass-closed-issues/issue_308/options.yml
+++ b/spec/output_styles/nested/libsass-closed-issues/issue_308/options.yml
@@ -1,3 +1,0 @@
----
-:warning_todo:
-- libsass


### PR DESCRIPTION
These were failing because of a missing deprecation warning
introduced in 3.5. The deprecation warning landed in
https://github.com/sass/libsass/pull/2373