### PR TITLE
Update deprecation messages for interpolation near operators.

### DIFF
--- a/spec/basic/23_basic_value_interpolation/error
+++ b/spec/basic/23_basic_value_interpolation/error
@@ -1,9 +1,11 @@
-DEPRECATION WARNING on line 5 of /sass/spec/basic/23_basic_value_interpolation/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 5 of /sass/spec/basic/23_basic_value_interpolation/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("123")
 
-DEPRECATION WARNING on line 7 of /sass/spec/basic/23_basic_value_interpolation/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 7 of /sass/spec/basic/23_basic_value_interpolation/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{12 + 111}")

--- a/spec/libsass-closed-issues/issue_1333/error
+++ b/spec/libsass-closed-issues/issue_1333/error
@@ -1,5 +1,6 @@
-DEPRECATION WARNING on line 6 of /sass/spec/libsass-issues/issue_1333/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 6 of /sass/spec/libsass-issues/issue_1333/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('#{baz()}" !important"')
 

--- a/spec/libsass-closed-issues/issue_1396/error
+++ b/spec/libsass-closed-issues/issue_1396/error
@@ -1,5 +1,6 @@
-DEPRECATION WARNING on line 2 of /sass/spec/libsass-issues/issue_1396/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 2 of /sass/spec/libsass-issues/issue_1396/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{foo "bar"}baz")
 

--- a/spec/libsass-closed-issues/issue_1413/error
+++ b/spec/libsass-closed-issues/issue_1413/error
@@ -1,175 +1,191 @@
-DEPRECATION WARNING on line 2 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 2 of /sass/spec/libsass-issues/issue_1413/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"A"B')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 4 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 4 of /sass/spec/libsass-issues/issue_1413/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"A"B"C"')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 7 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 7 of /sass/spec/libsass-issues/issue_1413/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"A"BC')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 9 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 9 of /sass/spec/libsass-issues/issue_1413/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"A"B#{C "D"}')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 10 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
-
-  unquote("#{"A" B}C#{D "E"}")
-
-You can use the sass-convert command to automatically fix most cases.
-
-DEPRECATION WARNING on line 11 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 11 of /sass/spec/libsass-issues/issue_1413/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{A "B"}C#{D "E"}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 16 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 16 of /sass/spec/libsass-issues/issue_1413/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"A"B')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 18 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 18 of /sass/spec/libsass-issues/issue_1413/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"A"B"C"')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 21 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 21 of /sass/spec/libsass-issues/issue_1413/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"A"BC')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 23 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 23 of /sass/spec/libsass-issues/issue_1413/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"A"B#{C "D"}')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 24 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
-
-  unquote("#{"A" B}C#{D "E"}")
-
-You can use the sass-convert command to automatically fix most cases.
-
-DEPRECATION WARNING on line 25 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 25 of /sass/spec/libsass-issues/issue_1413/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{A "B"}C#{D "E"}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 30 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 30 of /sass/spec/libsass-issues/issue_1413/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"A"B')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 32 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 32 of /sass/spec/libsass-issues/issue_1413/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"A"B"C"')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 35 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 35 of /sass/spec/libsass-issues/issue_1413/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"A"BC')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 37 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 37 of /sass/spec/libsass-issues/issue_1413/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"A"B#{C "D"}')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 38 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
-
-  unquote("#{"A" B}C#{D "E"}")
-
-You can use the sass-convert command to automatically fix most cases.
-
-DEPRECATION WARNING on line 39 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 39 of /sass/spec/libsass-issues/issue_1413/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{A "B"}C#{D "E"}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 17 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 17 of /sass/spec/libsass-issues/issue_1413/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('A"B"')
 
-DEPRECATION WARNING on line 19 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 19 of /sass/spec/libsass-issues/issue_1413/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('A"B"C')
 
-DEPRECATION WARNING on line 20 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 20 of /sass/spec/libsass-issues/issue_1413/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('AB"C"')
 
-DEPRECATION WARNING on line 22 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 22 of /sass/spec/libsass-issues/issue_1413/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("A#{B "C"}")
 
-DEPRECATION WARNING on line 26 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 24 of /sass/spec/libsass-issues/issue_1413/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
+
+  unquote("#{"A" B}C#{D "E"}")
+
+DEPRECATION WARNING on line 26 of /sass/spec/libsass-issues/issue_1413/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("A#{"B" C "D" "E"}")
 
-DEPRECATION WARNING on line 31 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 31 of /sass/spec/libsass-issues/issue_1413/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('A"B"')
 
-DEPRECATION WARNING on line 33 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 33 of /sass/spec/libsass-issues/issue_1413/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('A"B"C')
 
-DEPRECATION WARNING on line 34 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 34 of /sass/spec/libsass-issues/issue_1413/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('AB"C"')
 
-DEPRECATION WARNING on line 36 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 36 of /sass/spec/libsass-issues/issue_1413/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("A#{B "C"}")
 
-DEPRECATION WARNING on line 40 of /sass/spec/libsass-issues/issue_1413/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 38 of /sass/spec/libsass-issues/issue_1413/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
+
+  unquote("#{"A" B}C#{D "E"}")
+
+DEPRECATION WARNING on line 40 of /sass/spec/libsass-issues/issue_1413/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("A#{"B" C "D" "E"}")

--- a/spec/libsass-closed-issues/issue_152/error
+++ b/spec/libsass-closed-issues/issue_152/error
@@ -1,19 +1,22 @@
-DEPRECATION WARNING on line 5 of /sass/spec/libsass-issues/issue_152/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 5 of /sass/spec/libsass-issues/issue_152/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10% 100%")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 6 of /sass/spec/libsass-issues/issue_152/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 6 of /sass/spec/libsass-issues/issue_152/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 % 100%")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 7 of /sass/spec/libsass-issues/issue_152/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 7 of /sass/spec/libsass-issues/issue_152/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 %100%")
 

--- a/spec/libsass-closed-issues/issue_1709/error
+++ b/spec/libsass-closed-issues/issue_1709/error
@@ -1,5 +1,6 @@
-DEPRECATION WARNING on line 14 of /sass/spec/libsass-issues/issue_1709/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 14 of /sass/spec/libsass-issues/issue_1709/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{$prefix}#{$transition}")
 

--- a/spec/libsass-closed-issues/issue_1739/interpolate/both/error
+++ b/spec/libsass-closed-issues/issue_1739/interpolate/both/error
@@ -1,96 +1,110 @@
-DEPRECATION WARNING on line 9 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 9 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{1 + 2}+#{1 + 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 10 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 10 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{1 + 2}+ #{1 + 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 11 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 11 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{1 + 2} +#{1 + 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 12 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 12 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{1 + 2} + #{1 + 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 17 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 17 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{1 - 2}- #{1 - 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 19 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 19 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{1 - 2} - #{1 - 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 23 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 23 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{1 * 2}*#{1 * 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 24 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 24 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{1 * 2}* #{1 * 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 25 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 25 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{1 * 2} *#{1 * 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 26 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 26 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{1 * 2} * #{1 * 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 30 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 30 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{1% 2}%#{1% 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 31 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 31 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{1% 2}% #{1% 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 32 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 32 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{1 % 2} %#{1 % 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 33 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 33 of /sass/spec/libsass-issues/issue_1739/interpolate/both/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{1 % 2} % #{1 % 2}")
 

--- a/spec/libsass-closed-issues/issue_1739/interpolate/left/error
+++ b/spec/libsass-closed-issues/issue_1739/interpolate/left/error
@@ -1,89 +1,102 @@
-DEPRECATION WARNING on line 9 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 9 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{1 + 2}+3")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 10 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 10 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{1 + 2}+ 3")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 11 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 11 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{1 + 2} +3")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 12 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 12 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{1 + 2} + 3")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 19 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 19 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{1 - 2} - 3")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 23 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 23 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{1 * 2}*3")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 24 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 24 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{1 * 2}* 3")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 25 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 25 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{1 * 2} *3")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 26 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 26 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{1 * 2} * 3")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 30 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 30 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{1% 2}%3")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 31 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 31 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{1% 2}% 3")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 32 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 32 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{1 % 2} %3")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 33 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 33 of /sass/spec/libsass-issues/issue_1739/interpolate/left/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{1 % 2} % 3")
 

--- a/spec/libsass-closed-issues/issue_1739/interpolate/right/error
+++ b/spec/libsass-closed-issues/issue_1739/interpolate/right/error
@@ -1,82 +1,94 @@
-DEPRECATION WARNING on line 9 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 9 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("3+#{1 + 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 10 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 10 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("3+ #{1 + 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 11 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 11 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("3 +#{1 + 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 12 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 12 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("3 + #{1 + 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 17 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 17 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("3- #{1 - 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 19 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 19 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("3 - #{1 - 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 23 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 23 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("3*#{1 * 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 24 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 24 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("3* #{1 * 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 25 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 25 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("3 *#{1 * 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 26 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 26 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("3 * #{1 * 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 32 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 32 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("3 %#{1 % 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 33 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 33 of /sass/spec/libsass-issues/issue_1739/interpolate/right/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("3 % #{1 % 2}")
 

--- a/spec/libsass-closed-issues/issue_442/error
+++ b/spec/libsass-closed-issues/issue_442/error
@@ -1,5 +1,6 @@
-DEPRECATION WARNING on line 1 of /sass/spec/libsass-issues/issue_442/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 1 of /sass/spec/libsass-issues/issue_442/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{100 / 10}rem")
 

--- a/spec/libsass-closed-issues/issue_870/error
+++ b/spec/libsass-closed-issues/issue_870/error
@@ -1,12 +1,14 @@
-DEPRECATION WARNING on line 9 of /sass/spec/libsass-issues/issue_870/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 9 of /sass/spec/libsass-issues/issue_870/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"["#{$quoted-strings-csv}"]"')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 19 of /sass/spec/libsass-issues/issue_870/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 19 of /sass/spec/libsass-issues/issue_870/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"["#{$quoted-strings-ssv}"]"')
 

--- a/spec/libsass-closed-issues/issue_948/error
+++ b/spec/libsass-closed-issues/issue_948/error
@@ -1,5 +1,6 @@
-DEPRECATION WARNING on line 1 of /sass/spec/libsass-issues/issue_948/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 1 of /sass/spec/libsass-issues/issue_948/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 * 5}px")
 

--- a/spec/libsass/arithmetic/error
+++ b/spec/libsass/arithmetic/error
@@ -1,41 +1,87 @@
-DEPRECATION WARNING on line 12 of /sass/spec/libsass/arithmetic/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 12 of /sass/spec/libsass/arithmetic/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{3 + un}quo#{te("hello")}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 25 of /sass/spec/libsass/arithmetic/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 25 of /sass/spec/libsass/arithmetic/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{3 - un}quo#{te("hello")}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 55 of /sass/spec/libsass/arithmetic/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 55 of /sass/spec/libsass/arithmetic/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{3 / un}quo#{te("hello")}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 80 of /sass/spec/libsass/arithmetic/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 80 of /sass/spec/libsass/arithmetic/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{50% + un}quo#{te("hello")}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 91 of /sass/spec/libsass/arithmetic/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 91 of /sass/spec/libsass/arithmetic/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{50% - un}quo#{te("hello")}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 113 of /sass/spec/libsass/arithmetic/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 113 of /sass/spec/libsass/arithmetic/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{50% / un}quo#{te("hello")}")
 
 You can use the sass-convert command to automatically fix most cases.
+
+DEPRECATION WARNING on line 6 of /sass/spec/libsass/arithmetic/input.scss:
+The operation `3 plus #111111` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 19 of /sass/spec/libsass/arithmetic/input.scss:
+The operation `3 minus #111111` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 32 of /sass/spec/libsass/arithmetic/input.scss:
+The operation `3 times #111111` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 49 of /sass/spec/libsass/arithmetic/input.scss:
+The operation `3 div #111111` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 87 of /sass/spec/libsass/arithmetic/input.scss:
+The operation `50% minus #111111` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 109 of /sass/spec/libsass/arithmetic/input.scss:
+The operation `50% div #111111` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 130 of /sass/spec/libsass/arithmetic/input.scss:
+The operation `20 div #abc` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 141 of /sass/spec/libsass/arithmetic/input.scss:
+The operation `#abc div #111` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions

--- a/spec/libsass/interpolated-function-call/error
+++ b/spec/libsass/interpolated-function-call/error
@@ -1,5 +1,6 @@
-DEPRECATION WARNING on line 4 of /sass/spec/libsass/interpolated-function-call/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 4 of /sass/spec/libsass/interpolated-function-call/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{$f}#{a, 1 + 2, c}")
 

--- a/spec/libsass/interpolated-urls/error
+++ b/spec/libsass/interpolated-urls/error
@@ -1,12 +1,14 @@
-DEPRECATION WARNING on line 3 of /sass/spec/libsass/interpolated-urls/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 3 of /sass/spec/libsass/interpolated-urls/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"url("#{$base_url}"img/beta.png)"')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 11 of /sass/spec/libsass/interpolated-urls/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 11 of /sass/spec/libsass/interpolated-urls/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{blix "fludge"}#{hey now}123")
 

--- a/spec/parser/interpolate/00_concatenation/unspaced/error
+++ b/spec/parser/interpolate/00_concatenation/unspaced/error
@@ -1,40 +1,46 @@
-DEPRECATION WARNING on line 8 of /sass/spec/parser/interpolate/00_concatenation/unspaced/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 8 of /sass/spec/parser/interpolate/00_concatenation/unspaced/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{$input}#{$input}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 9 of /sass/spec/parser/interpolate/00_concatenation/unspaced/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 9 of /sass/spec/parser/interpolate/00_concatenation/unspaced/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{$input}literal")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 10 of /sass/spec/parser/interpolate/00_concatenation/unspaced/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 10 of /sass/spec/parser/interpolate/00_concatenation/unspaced/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('#{$input}"literal"')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 12 of /sass/spec/parser/interpolate/00_concatenation/unspaced/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 12 of /sass/spec/parser/interpolate/00_concatenation/unspaced/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{$input}#{$input}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 17 of /sass/spec/parser/interpolate/00_concatenation/unspaced/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 17 of /sass/spec/parser/interpolate/00_concatenation/unspaced/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("literal#{$input}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 22 of /sass/spec/parser/interpolate/00_concatenation/unspaced/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 22 of /sass/spec/parser/interpolate/00_concatenation/unspaced/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"literal"#{$input}')
 

--- a/spec/parser/operations/addition/dimensions/pairs/error
+++ b/spec/parser/operations/addition/dimensions/pairs/error
@@ -1,306 +1,350 @@
-DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10+10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 +10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10+ 10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 + 10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 + 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 + 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 + 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 + 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 + 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 + 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 + 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 + 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 + 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 + 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 + 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 + 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px+10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px +10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px+ 10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px + 10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px + 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px + 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px + 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px + 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px + 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px + 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px + 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px + 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 42 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 42 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px + 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 43 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 43 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px + 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 44 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 44 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px + 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 45 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 45 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px + 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 46 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 46 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px+10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 47 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 47 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px +10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 48 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 48 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px+ 10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 49 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 49 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px + 10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 74 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 74 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px+10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 75 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 75 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px +10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 76 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 76 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px+ 10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 77 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 77 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px + 10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 78 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 78 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px+10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 79 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 79 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px +10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 80 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 80 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px+ 10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 81 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 81 of /sass/spec/parser/operations/addition/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px + 10px")
 

--- a/spec/parser/operations/addition/numbers/pairs/error
+++ b/spec/parser/operations/addition/numbers/pairs/error
@@ -1,250 +1,286 @@
-DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10+10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 +10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10+ 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 + 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 + 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 + 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 + 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 + 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10+10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 +10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10+ 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 + 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10+10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 +10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10+ 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 + 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10+10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 +10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10+ 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 + 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10+10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 +10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10+ 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 + 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10+10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 +10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10+ 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 + 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10+10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 +10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10+ 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 + 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10+10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 +10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10+ 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/addition/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 + 10")
 

--- a/spec/parser/operations/addition/strings/pairs/error
+++ b/spec/parser/operations/addition/strings/pairs/error
@@ -1,334 +1,382 @@
-DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("literal+interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("literal +interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("literal+ interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("literal + interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{literal + lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{literal + lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{literal + lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{literal + lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("literal+litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("literal +litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("literal+ litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("literal + litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"quoted"+interpolant')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"quoted" +interpolant')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"quoted"+ interpolant')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"quoted" + interpolant')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{"quoted" + lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{"quoted" + lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{"quoted" + lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{"quoted" + lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"quoted"+litlp_rschema')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"quoted" +litlp_rschema')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"quoted"+ litlp_rschema')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"quoted" + litlp_rschema')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant+interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant +interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant+ interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant + interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 42 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 42 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant+lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 43 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 43 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant +lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 44 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 44 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant+ lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 45 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 45 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant + lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 46 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 46 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant+litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 47 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 47 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant +litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 48 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 48 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant+ litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 49 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 49 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant + litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 50 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 50 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp+lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 51 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 51 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp +lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 52 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 52 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp+ lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 53 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 53 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp + lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 54 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 54 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp+litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 55 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 55 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp +litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 56 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 56 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp+ litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 57 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 57 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp + litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 58 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 58 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema+litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 59 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 59 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema +litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 60 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 60 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema+ litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 61 of /sass/spec/parser/operations/addition/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 61 of /sass/spec/parser/operations/addition/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema + litlp_rschema")
 

--- a/spec/parser/operations/division/dimensions/pairs/error
+++ b/spec/parser/operations/division/dimensions/pairs/error
@@ -1,166 +1,190 @@
-DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 / 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 / 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 / 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 / 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 / 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 / 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 / 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 / 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 / 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 / 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 / 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 / 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px / 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px / 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px / 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px / 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px / 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px / 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px / 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px / 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 42 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 42 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px / 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 43 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 43 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px / 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 44 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 44 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px / 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 45 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 45 of /sass/spec/parser/operations/division/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px / 10}px")
 

--- a/spec/parser/operations/division/numbers/pairs/error
+++ b/spec/parser/operations/division/numbers/pairs/error
@@ -1,26 +1,30 @@
-DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/division/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/division/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 / 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/division/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/division/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 / 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/division/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/division/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 / 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/division/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/division/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 / 1}0")
 

--- a/spec/parser/operations/division/strings/pairs/error
+++ b/spec/parser/operations/division/strings/pairs/error
@@ -1,54 +1,62 @@
-DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/division/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{literal / lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/division/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{literal / lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/division/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{literal / lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/division/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{literal / lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/division/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{"quoted" / lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/division/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{"quoted" / lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/division/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{"quoted" / lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/division/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/division/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{"quoted" / lschema_}ritlp")
 

--- a/spec/parser/operations/logic_eq/dimensions/pairs/error
+++ b/spec/parser/operations/logic_eq/dimensions/pairs/error
@@ -1,306 +1,350 @@
-DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10==10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 ==10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10== 10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 == 10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 == 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 == 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 == 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 == 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 == 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 == 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 == 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 == 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 == 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 == 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 == 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 == 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px==10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px ==10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px== 10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px == 10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px == 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px == 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px == 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px == 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px == 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px == 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px == 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px == 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 42 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 42 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px == 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 43 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 43 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px == 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 44 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 44 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px == 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 45 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 45 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px == 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 46 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 46 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px==10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 47 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 47 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px ==10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 48 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 48 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px== 10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 49 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 49 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px == 10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 74 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 74 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px==10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 75 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 75 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px ==10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 76 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 76 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px== 10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 77 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 77 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px == 10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 78 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 78 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px==10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 79 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 79 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px ==10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 80 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 80 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px== 10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 81 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 81 of /sass/spec/parser/operations/logic_eq/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px == 10px")
 

--- a/spec/parser/operations/logic_eq/mixed/pairs/error
+++ b/spec/parser/operations/logic_eq/mixed/pairs/error
@@ -1,138 +1,158 @@
-DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10==itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 ==itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10== itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 == itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10%==itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10% ==itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10%== itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10% == itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 46 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 46 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px==itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 47 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 47 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px ==itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 48 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 48 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px== itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 49 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 49 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px == itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 54 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 54 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#AAA==itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 55 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 55 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#AAA ==itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 56 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 56 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#AAA== itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 57 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 57 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#AAA == itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 58 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 58 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("itpl==itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 59 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 59 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("itpl ==itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 60 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 60 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("itpl== itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 61 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 61 of /sass/spec/parser/operations/logic_eq/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("itpl == itpl")
 

--- a/spec/parser/operations/logic_eq/numbers/pairs/error
+++ b/spec/parser/operations/logic_eq/numbers/pairs/error
@@ -1,250 +1,286 @@
-DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10==10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 ==10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10== 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 == 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 == 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 == 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 == 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 == 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10==10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 ==10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10== 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 == 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10==10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 ==10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10== 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 == 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10==10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 ==10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10== 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 == 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10==10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 ==10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10== 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 == 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10==10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 ==10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10== 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 == 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10==10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 ==10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10== 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 == 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10==10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 ==10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10== 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/logic_eq/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 == 10")
 

--- a/spec/parser/operations/logic_eq/strings/pairs/error
+++ b/spec/parser/operations/logic_eq/strings/pairs/error
@@ -1,334 +1,382 @@
-DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("literal==interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("literal ==interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("literal== interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("literal == interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{literal == lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{literal == lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{literal == lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{literal == lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("literal==litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("literal ==litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("literal== litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("literal == litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"quoted"==interpolant')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"quoted" ==interpolant')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"quoted"== interpolant')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"quoted" == interpolant')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{"quoted" == lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{"quoted" == lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{"quoted" == lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{"quoted" == lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"quoted"==litlp_rschema')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"quoted" ==litlp_rschema')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"quoted"== litlp_rschema')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"quoted" == litlp_rschema')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant==interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant ==interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant== interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant == interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 42 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 42 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant==lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 43 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 43 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant ==lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 44 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 44 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant== lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 45 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 45 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant == lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 46 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 46 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant==litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 47 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 47 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant ==litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 48 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 48 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant== litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 49 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 49 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant == litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 50 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 50 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp==lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 51 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 51 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp ==lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 52 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 52 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp== lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 53 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 53 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp == lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 54 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 54 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp==litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 55 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 55 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp ==litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 56 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 56 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp== litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 57 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 57 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp == litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 58 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 58 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema==litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 59 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 59 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema ==litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 60 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 60 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema== litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 61 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 61 of /sass/spec/parser/operations/logic_eq/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema == litlp_rschema")
 

--- a/spec/parser/operations/logic_ge/numbers/pairs/error
+++ b/spec/parser/operations/logic_ge/numbers/pairs/error
@@ -1,250 +1,286 @@
-DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10>=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 >=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10>= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 >= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 >= 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 >= 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 >= 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 >= 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10>=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 >=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10>= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 >= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10>=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 >=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10>= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 >= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10>=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 >=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10>= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 >= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10>=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 >=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10>= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 >= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10>=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 >=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10>= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 >= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10>=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 >=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10>= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 >= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10>=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 >=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10>= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/logic_ge/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 >= 10")
 

--- a/spec/parser/operations/logic_ge/strings/pairs/error
+++ b/spec/parser/operations/logic_ge/strings/pairs/error
@@ -1,166 +1,190 @@
-DEPRECATION WARNING on line 2 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 2 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant>=interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 3 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 3 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant >=interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 4 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 4 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant>= interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 5 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 5 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant >= interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant>=lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant >=lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant>= lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant >= lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant>=litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant >=litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant>= litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant >= litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp>=lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp >=lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp>= lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp >= lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp>=litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp >=litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp>= litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp >= litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema>=litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema >=litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema>= litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_ge/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema >= litlp_rschema")
 

--- a/spec/parser/operations/logic_gt/numbers/pairs/error
+++ b/spec/parser/operations/logic_gt/numbers/pairs/error
@@ -1,250 +1,286 @@
-DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10>10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 >10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10> 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 > 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 > 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 > 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 > 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 > 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10>10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 >10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10> 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 > 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10>10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 >10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10> 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 > 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10>10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 >10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10> 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 > 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10>10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 >10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10> 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 > 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10>10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 >10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10> 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 > 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10>10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 >10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10> 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 > 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10>10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 >10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10> 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/logic_gt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 > 10")
 

--- a/spec/parser/operations/logic_gt/strings/pairs/error
+++ b/spec/parser/operations/logic_gt/strings/pairs/error
@@ -1,166 +1,190 @@
-DEPRECATION WARNING on line 2 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 2 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant>interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 3 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 3 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant >interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 4 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 4 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant> interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 5 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 5 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant > interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant>lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant >lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant> lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant > lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant>litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant >litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant> litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant > litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp>lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp >lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp> lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp > lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp>litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp >litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp> litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp > litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema>litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema >litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema> litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_gt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema > litlp_rschema")
 

--- a/spec/parser/operations/logic_le/numbers/pairs/error
+++ b/spec/parser/operations/logic_le/numbers/pairs/error
@@ -1,250 +1,286 @@
-DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10<=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 <=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10<= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 <= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 <= 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 <= 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 <= 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 <= 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10<=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 <=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10<= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 <= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10<=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 <=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10<= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 <= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10<=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 <=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10<= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 <= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10<=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 <=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10<= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 <= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10<=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 <=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10<= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 <= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10<=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 <=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10<= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 <= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10<=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 <=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10<= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/logic_le/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 <= 10")
 

--- a/spec/parser/operations/logic_le/strings/pairs/error
+++ b/spec/parser/operations/logic_le/strings/pairs/error
@@ -1,166 +1,190 @@
-DEPRECATION WARNING on line 2 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 2 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant<=interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 3 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 3 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant <=interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 4 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 4 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant<= interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 5 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 5 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant <= interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant<=lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant <=lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant<= lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant <= lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant<=litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant <=litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant<= litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant <= litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp<=lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp <=lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp<= lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp <= lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp<=litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp <=litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp<= litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp <= litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema<=litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema <=litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema<= litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_le/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema <= litlp_rschema")
 

--- a/spec/parser/operations/logic_lt/numbers/pairs/error
+++ b/spec/parser/operations/logic_lt/numbers/pairs/error
@@ -1,250 +1,286 @@
-DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10<10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 <10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10< 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 < 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 < 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 < 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 < 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 < 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10<10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 <10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10< 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 < 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10<10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 <10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10< 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 < 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10<10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 <10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10< 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 < 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10<10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 <10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10< 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 < 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10<10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 <10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10< 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 < 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10<10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 <10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10< 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 < 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10<10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 <10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10< 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/logic_lt/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 < 10")
 

--- a/spec/parser/operations/logic_lt/strings/pairs/error
+++ b/spec/parser/operations/logic_lt/strings/pairs/error
@@ -1,166 +1,190 @@
-DEPRECATION WARNING on line 2 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 2 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant<interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 3 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 3 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant <interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 4 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 4 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant< interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 5 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 5 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant < interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant<lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant <lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant< lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant < lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant<litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant <litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant< litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant < litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp<lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp <lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp< lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp < lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp<litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp <litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp< litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp < litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema<litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema <litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema< litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_lt/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema < litlp_rschema")
 

--- a/spec/parser/operations/logic_ne/dimensions/pairs/error
+++ b/spec/parser/operations/logic_ne/dimensions/pairs/error
@@ -1,306 +1,350 @@
-DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10!=10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 !=10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10!= 10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 != 10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 != 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 != 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 != 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 != 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 != 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 != 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 != 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 != 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 != 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 != 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 != 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 != 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px!=10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px !=10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px!= 10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px != 10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px != 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px != 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px != 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px != 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px != 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px != 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px != 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px != 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 42 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 42 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px != 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 43 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 43 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px != 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 44 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 44 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px != 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 45 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 45 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px != 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 46 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 46 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px!=10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 47 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 47 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px !=10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 48 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 48 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px!= 10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 49 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 49 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px != 10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 74 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 74 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px!=10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 75 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 75 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px !=10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 76 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 76 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px!= 10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 77 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 77 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px != 10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 78 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 78 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px!=10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 79 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 79 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px !=10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 80 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 80 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px!= 10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 81 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 81 of /sass/spec/parser/operations/logic_ne/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px != 10px")
 

--- a/spec/parser/operations/logic_ne/mixed/pairs/error
+++ b/spec/parser/operations/logic_ne/mixed/pairs/error
@@ -1,138 +1,158 @@
-DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10!=itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 !=itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10!= itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 != itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10%!=itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10% !=itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10%!= itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10% != itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 46 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 46 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px!=itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 47 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 47 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px !=itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 48 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 48 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px!= itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 49 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 49 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px != itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 54 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 54 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#AAA!=itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 55 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 55 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#AAA !=itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 56 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 56 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#AAA!= itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 57 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 57 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#AAA != itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 58 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 58 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("itpl!=itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 59 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 59 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("itpl !=itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 60 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 60 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("itpl!= itpl")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 61 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 61 of /sass/spec/parser/operations/logic_ne/mixed/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("itpl != itpl")
 

--- a/spec/parser/operations/logic_ne/numbers/pairs/error
+++ b/spec/parser/operations/logic_ne/numbers/pairs/error
@@ -1,250 +1,286 @@
-DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10!=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 !=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10!= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 != 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 != 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 != 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 != 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 != 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10!=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 !=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10!= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 != 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10!=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 !=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10!= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 != 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10!=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 !=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10!= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 != 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10!=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 !=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10!= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 != 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10!=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 !=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10!= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 != 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10!=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 !=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10!= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 != 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10!=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 !=10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10!= 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/logic_ne/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 != 10")
 

--- a/spec/parser/operations/logic_ne/strings/pairs/error
+++ b/spec/parser/operations/logic_ne/strings/pairs/error
@@ -1,334 +1,382 @@
-DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("literal!=interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("literal !=interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("literal!= interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("literal != interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{literal != lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{literal != lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{literal != lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{literal != lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("literal!=litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("literal !=litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("literal!= litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("literal != litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"quoted"!=interpolant')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"quoted" !=interpolant')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"quoted"!= interpolant')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"quoted" != interpolant')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{"quoted" != lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{"quoted" != lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{"quoted" != lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{"quoted" != lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"quoted"!=litlp_rschema')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"quoted" !=litlp_rschema')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"quoted"!= litlp_rschema')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"quoted" != litlp_rschema')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant!=interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant !=interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant!= interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant != interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 42 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 42 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant!=lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 43 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 43 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant !=lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 44 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 44 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant!= lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 45 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 45 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant != lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 46 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 46 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant!=litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 47 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 47 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant !=litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 48 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 48 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant!= litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 49 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 49 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant != litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 50 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 50 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp!=lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 51 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 51 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp !=lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 52 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 52 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp!= lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 53 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 53 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp != lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 54 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 54 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp!=litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 55 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 55 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp !=litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 56 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 56 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp!= litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 57 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 57 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp != litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 58 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 58 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema!=litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 59 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 59 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema !=litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 60 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 60 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema!= litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 61 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 61 of /sass/spec/parser/operations/logic_ne/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema != litlp_rschema")
 

--- a/spec/parser/operations/modulo/numbers/pairs/error
+++ b/spec/parser/operations/modulo/numbers/pairs/error
@@ -1,208 +1,222 @@
-DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 %10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 % 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
-
-  unquote("#{10% 1}0")
-
-You can use the sass-convert command to automatically fix most cases.
-
-DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 % 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
-
-  unquote("#{10% 1}0")
-
-You can use the sass-convert command to automatically fix most cases.
-
-DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 % 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 %10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 % 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10%10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 %10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10% 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 % 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10%10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 %10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10% 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 % 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10%10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 %10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10% 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 % 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10%10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 %10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10% 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 % 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10%10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 %10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10% 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 % 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 %10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/modulo/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 % 10")
 

--- a/spec/parser/operations/modulo/strings/pairs/error
+++ b/spec/parser/operations/modulo/strings/pairs/error
@@ -1,166 +1,190 @@
-DEPRECATION WARNING on line 2 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 2 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant%interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 3 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 3 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant %interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 4 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 4 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant% interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 5 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 5 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant % interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant%lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant %lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant% lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant % lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant%litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant %litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant% litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant % litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp%lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp %lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp% lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp % lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp%litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp %litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp% litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp % litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema%litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema %litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema% litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/modulo/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema % litlp_rschema")
 

--- a/spec/parser/operations/multiply/numbers/pairs/error
+++ b/spec/parser/operations/multiply/numbers/pairs/error
@@ -1,250 +1,286 @@
-DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10*10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 *10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10* 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 * 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 * 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 * 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 * 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 * 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10*10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 *10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10* 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 * 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10*10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 *10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10* 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 * 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10*10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 *10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10* 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 * 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 26 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10*10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 27 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 *10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10* 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 * 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10*10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 *10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10* 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 * 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10*10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 *10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10* 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 * 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10*10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 *10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10* 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/multiply/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 * 10")
 

--- a/spec/parser/operations/multiply/strings/pairs/error
+++ b/spec/parser/operations/multiply/strings/pairs/error
@@ -1,166 +1,190 @@
-DEPRECATION WARNING on line 2 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 2 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant*interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 3 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 3 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant *interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 4 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 4 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant* interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 5 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 5 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant * interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 6 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant*lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 7 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant *lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant* lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant * lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant*litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant *litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant* litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant * litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp*lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp *lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp* lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp * lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp*litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp *litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp* litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp * litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema*litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema *litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema* litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/multiply/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema * litlp_rschema")
 

--- a/spec/parser/operations/subtract/dimensions/pairs/error
+++ b/spec/parser/operations/subtract/dimensions/pairs/error
@@ -1,208 +1,166 @@
-DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10- 10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 - 10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 14 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 - 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
-
-  unquote("#{10 -1}0px")
-
-You can use the sass-convert command to automatically fix most cases.
-
-DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 - 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 - 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 18 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 - 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 19 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
-
-  unquote("#{10 -10}px")
-
-You can use the sass-convert command to automatically fix most cases.
-
-DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 - 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 - 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 22 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 - 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 23 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
-
-  unquote("#{10 -10}px")
-
-You can use the sass-convert command to automatically fix most cases.
-
-DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 24 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 - 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 - 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px - 10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 34 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px - 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 35 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
-
-  unquote("#{10px -1}0px")
-
-You can use the sass-convert command to automatically fix most cases.
-
-DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
-
-  unquote("#{10px- 1}0px")
-
-You can use the sass-convert command to automatically fix most cases.
-
-DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px - 1}0px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 38 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px - 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 39 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
-
-  unquote("#{10px -10}px")
-
-You can use the sass-convert command to automatically fix most cases.
-
-DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
-
-  unquote("#{10px- 10}px")
-
-You can use the sass-convert command to automatically fix most cases.
-
-DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px - 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 42 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 42 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px - 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 43 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
-
-  unquote("#{10px -10}px")
-
-You can use the sass-convert command to automatically fix most cases.
-
-DEPRECATION WARNING on line 44 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
-
-  unquote("#{10px- 10}px")
-
-You can use the sass-convert command to automatically fix most cases.
-
-DEPRECATION WARNING on line 45 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 45 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10px - 10}px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 49 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 49 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px - 10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 77 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 77 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px - 10px")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 81 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 81 of /sass/spec/parser/operations/subtract/dimensions/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10px - 10px")
 

--- a/spec/parser/operations/subtract/numbers/pairs/error
+++ b/spec/parser/operations/subtract/numbers/pairs/error
@@ -1,124 +1,134 @@
-DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 8 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10- 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 9 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 - 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 10 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 - 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 11 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
-
-  unquote("#{10 -1}0")
-
-You can use the sass-convert command to automatically fix most cases.
-
-DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 12 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 - 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{10 - 1}0")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10- 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 - 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 20 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10- 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 - 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 25 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 - 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10- 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 - 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 - 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10- 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 - 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10- 10")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/subtract/numbers/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("10 - 10")
 

--- a/spec/parser/operations/subtract/strings/pairs/error
+++ b/spec/parser/operations/subtract/strings/pairs/error
@@ -1,152 +1,142 @@
-DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 13 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("literal - interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 15 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
-
-  unquote("#{literal -lschema_}ritlp")
-
-You can use the sass-convert command to automatically fix most cases.
-
-DEPRECATION WARNING on line 16 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
-
-  unquote("#{literal- lschema_}ritlp")
-
-You can use the sass-convert command to automatically fix most cases.
-
-DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 17 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{literal - lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 21 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("literal - litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 28 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"quoted"- interpolant')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 29 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"quoted" - interpolant')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 30 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
-
-  unquote("#{"quoted" -lschema_}ritlp")
-
-You can use the sass-convert command to automatically fix most cases.
-
-DEPRECATION WARNING on line 31 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
-
-  unquote("#{"quoted" -lschema_}ritlp")
-
-You can use the sass-convert command to automatically fix most cases.
-
-DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 32 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{"quoted" - lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 33 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{"quoted" - lschema_}ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 36 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"quoted"- litlp_rschema')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 37 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote('"quoted" - litlp_rschema')
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 40 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant- interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 41 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant - interpolant")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 45 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 45 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant - lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 48 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 48 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant- litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 49 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 49 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("interpolant - litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 53 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 53 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp - lschema_ritlp")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 56 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 56 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp- litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 57 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 57 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("lschema_ritlp - litlp_rschema")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 61 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 61 of /sass/spec/parser/operations/subtract/strings/pairs/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("litlp_rschema - litlp_rschema")
 

--- a/spec/scss/interpolation-operators-precedence/error
+++ b/spec/scss/interpolation-operators-precedence/error
@@ -1,208 +1,238 @@
-DEPRECATION WARNING on line 2 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 2 of /sass/spec/scss/interpolation-operators-precedence/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("a+#{5% + 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 3 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 3 of /sass/spec/scss/interpolation-operators-precedence/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("a+ #{5% + 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 4 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 4 of /sass/spec/scss/interpolation-operators-precedence/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("a +#{5% + 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 5 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 5 of /sass/spec/scss/interpolation-operators-precedence/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("a + #{5% + 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 6 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 6 of /sass/spec/scss/interpolation-operators-precedence/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{5 + 2%}+a")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 7 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 7 of /sass/spec/scss/interpolation-operators-precedence/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{5 + 2%}+ a")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 8 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 8 of /sass/spec/scss/interpolation-operators-precedence/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{5 + 2%} +a")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 9 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 9 of /sass/spec/scss/interpolation-operators-precedence/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{5 + 2%} + a")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 10 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 10 of /sass/spec/scss/interpolation-operators-precedence/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("a +#{5% + 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 13 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 13 of /sass/spec/scss/interpolation-operators-precedence/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("*5%")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 14 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 14 of /sass/spec/scss/interpolation-operators-precedence/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("a +#{5% - 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 17 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 17 of /sass/spec/scss/interpolation-operators-precedence/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("*5%")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 18 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 18 of /sass/spec/scss/interpolation-operators-precedence/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("a +#{5% / 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 21 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 21 of /sass/spec/scss/interpolation-operators-precedence/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("a *#{5% / 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 22 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 22 of /sass/spec/scss/interpolation-operators-precedence/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("a +#{5% * 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 25 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 25 of /sass/spec/scss/interpolation-operators-precedence/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("a *#{5% * 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 26 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 26 of /sass/spec/scss/interpolation-operators-precedence/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{5 + 2%} +a")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 29 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 29 of /sass/spec/scss/interpolation-operators-precedence/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("2% *a")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 30 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 30 of /sass/spec/scss/interpolation-operators-precedence/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{5 - 2%} +a")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 33 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 33 of /sass/spec/scss/interpolation-operators-precedence/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("2% *a")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 34 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 34 of /sass/spec/scss/interpolation-operators-precedence/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{5% / 2} +a")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 37 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 37 of /sass/spec/scss/interpolation-operators-precedence/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{5% / 2} *a")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 38 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 38 of /sass/spec/scss/interpolation-operators-precedence/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{5 * 2%} +a")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 41 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 41 of /sass/spec/scss/interpolation-operators-precedence/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{5 * 2%} *a")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 42 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 42 of /sass/spec/scss/interpolation-operators-precedence/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("a ==#{5% == 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 43 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 43 of /sass/spec/scss/interpolation-operators-precedence/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("a >#{5% > 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 44 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 44 of /sass/spec/scss/interpolation-operators-precedence/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("a <#{5% < 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 45 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 45 of /sass/spec/scss/interpolation-operators-precedence/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("a >=#{5% >= 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 46 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 46 of /sass/spec/scss/interpolation-operators-precedence/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("a <=#{5% <= 2}")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 47 of /sass/spec/scss/interpolation-operators-precedence/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 47 of /sass/spec/scss/interpolation-operators-precedence/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("a !=#{5% != 2}")
 

--- a/spec/types/error
+++ b/spec/types/error
@@ -1,21 +1,30 @@
-DEPRECATION WARNING on line 28 of /sass/spec/types/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 28 of /sass/spec/types/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{1 + 2}+3")
 
 You can use the sass-convert command to automatically fix most cases.
 
-DEPRECATION WARNING on line 16 of /sass/spec/types/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 16 of /sass/spec/types/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#{1 + 2}px")
 
-DEPRECATION WARNING on line 20 of /sass/spec/types/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 20 of /sass/spec/types/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("#abc")
 
-DEPRECATION WARNING on line 22 of /sass/spec/types/input.scss: #{} interpolation near operators will be simplified
-in a future version of Sass. To preserve the current behavior, use quotes:
+DEPRECATION WARNING on line 22 of /sass/spec/types/input.scss:
+#{} interpolation near operators will be simplified in a future version of Sass.
+To preserve the current behavior, use quotes:
 
   unquote("leng#{th(a b c d)}")
+
+DEPRECATION WARNING on line 26 of /sass/spec/types/input.scss:
+The operation `aqua plus #000000` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions


### PR DESCRIPTION
Skip ruby-sass