### PR TITLE
Update Dart Sass syntax error traces

### DIFF
--- a/spec/css/unicode_range/error/ident_minus_space_ident/error
+++ b/spec/css/unicode_range/error/ident_minus_space_ident/error
@@ -1,4 +1,4 @@
 Error: Expected hex digit.
   a: U+abc- def;
            ^
-  /sass/spec/css/unicode_range/error/ident_minus_space_ident/input.scss 2:12
+  spec/css/unicode_range/error/ident_minus_space_ident/input.scss 2:12  root stylesheet

--- a/spec/css/unicode_range/error/minus_ident_minus/error
+++ b/spec/css/unicode_range/error/minus_ident_minus/error
@@ -1,4 +1,4 @@
 Error: Expected end of identifier.
   a: u+123-abc-def;
               ^
-  /sass/spec/css/unicode_range/error/minus_ident_minus/input.scss 2:15
+  spec/css/unicode_range/error/minus_ident_minus/input.scss 2:15  root stylesheet

--- a/spec/css/unicode_range/error/minus_number_minus_ident/error
+++ b/spec/css/unicode_range/error/minus_number_minus_ident/error
@@ -1,4 +1,4 @@
 Error: Expected end of identifier.
   a: U+123-456-ABC;
               ^
-  /sass/spec/css/unicode_range/error/minus_number_minus_ident/input.scss 2:15
+  spec/css/unicode_range/error/minus_number_minus_ident/input.scss 2:15  root stylesheet

--- a/spec/css/unicode_range/error/no_digits/error
+++ b/spec/css/unicode_range/error/no_digits/error
@@ -1,4 +1,4 @@
 Error: Expected hex digit or "?".
   a: U+;
        ^
-  /sass/spec/css/unicode_range/error/no_digits/input.scss 2:8
+  spec/css/unicode_range/error/no_digits/input.scss 2:8  root stylesheet

--- a/spec/css/unicode_range/error/nothing_after_minus/error
+++ b/spec/css/unicode_range/error/nothing_after_minus/error
@@ -1,4 +1,4 @@
 Error: Expected hex digit.
   a: U+abc-;
            ^
-  /sass/spec/css/unicode_range/error/nothing_after_minus/input.scss 2:12
+  spec/css/unicode_range/error/nothing_after_minus/input.scss 2:12  root stylesheet

--- a/spec/css/unicode_range/error/question_mark_after_minus/error
+++ b/spec/css/unicode_range/error/question_mark_after_minus/error
@@ -1,4 +1,4 @@
 Error: expected ";".
   a: u+abc-de?;
              ^
-  /sass/spec/css/unicode_range/error/question_mark_after_minus/input.scss 2:14
+  spec/css/unicode_range/error/question_mark_after_minus/input.scss 2:14  root stylesheet

--- a/spec/css/unicode_range/error/too_many_decimal_digits/error
+++ b/spec/css/unicode_range/error/too_many_decimal_digits/error
@@ -1,4 +1,4 @@
 Error: Expected end of identifier.
   a: U+1234567;
              ^
-  /sass/spec/css/unicode_range/error/too_many_decimal_digits/input.scss 2:14
+  spec/css/unicode_range/error/too_many_decimal_digits/input.scss 2:14  root stylesheet

--- a/spec/css/unicode_range/error/too_many_decimal_digits_after_minus/error
+++ b/spec/css/unicode_range/error/too_many_decimal_digits_after_minus/error
@@ -1,4 +1,4 @@
 Error: Expected end of identifier.
   a: U+abc-1234567;
                  ^
-  /sass/spec/css/unicode_range/error/too_many_decimal_digits_after_minus/input.scss 2:18
+  spec/css/unicode_range/error/too_many_decimal_digits_after_minus/input.scss 2:18  root stylesheet

--- a/spec/css/unicode_range/error/too_many_hex_digits/error
+++ b/spec/css/unicode_range/error/too_many_hex_digits/error
@@ -1,4 +1,4 @@
 Error: Expected end of identifier.
   a: U+ABCDEFA;
              ^
-  /sass/spec/css/unicode_range/error/too_many_hex_digits/input.scss 2:14
+  spec/css/unicode_range/error/too_many_hex_digits/input.scss 2:14  root stylesheet

--- a/spec/css/unicode_range/error/too_many_hex_digits_after_minus/error
+++ b/spec/css/unicode_range/error/too_many_hex_digits_after_minus/error
@@ -1,4 +1,4 @@
 Error: Expected end of identifier.
   a: U+abc-abcdefa;
                  ^
-  /sass/spec/css/unicode_range/error/too_many_hex_digits_after_minus/input.scss 2:18
+  spec/css/unicode_range/error/too_many_hex_digits_after_minus/input.scss 2:18  root stylesheet

--- a/spec/css/unicode_range/error/too_many_question_marks/error
+++ b/spec/css/unicode_range/error/too_many_question_marks/error
@@ -1,4 +1,4 @@
 Error: expected ";".
   a: U+???????;
              ^
-  /sass/spec/css/unicode_range/error/too_many_question_marks/input.scss 2:14
+  spec/css/unicode_range/error/too_many_question_marks/input.scss 2:14  root stylesheet

--- a/spec/errors/extend/placeholder/missing/error-dart-sass
+++ b/spec/errors/extend/placeholder/missing/error-dart-sass
@@ -2,4 +2,4 @@ Error: The target selector was not found.
 Use "@extend %foo !optional" to avoid this error.
   @extend %foo;
   ^^^^^^^^^^^^
-  /sass/spec/errors/extend/placeholder/missing/input.scss 2:3
+  spec/errors/extend/placeholder/missing/input.scss 2:3  root stylesheet

--- a/spec/errors/extend/selector/missing/error-dart-sass
+++ b/spec/errors/extend/selector/missing/error-dart-sass
@@ -2,4 +2,4 @@ Error: The target selector was not found.
 Use "@extend .foo !optional" to avoid this error.
   @extend .foo;
   ^^^^^^^^^^^^
-  /sass/spec/errors/extend/selector/missing/input.scss 2:3
+  spec/errors/extend/selector/missing/input.scss 2:3  root stylesheet

--- a/spec/errors/fn-varargs/at-start/error-dart-sass
+++ b/spec/errors/fn-varargs/at-start/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected ")".
 @function test($rest...,$param) {}
                        ^
-  /sass/spec/errors/fn-varargs/at-start/input.scss 1:24
+  spec/errors/fn-varargs/at-start/input.scss 1:24  root stylesheet

--- a/spec/errors/fn-varargs/multiple/error-dart-sass
+++ b/spec/errors/fn-varargs/multiple/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected ")".
 @function test($param...,$rest...) {}
                         ^
-  /sass/spec/errors/fn-varargs/multiple/input.scss 1:25
+  spec/errors/fn-varargs/multiple/input.scss 1:25  root stylesheet

--- a/spec/errors/fn-varargs/with-default/error-dart-sass
+++ b/spec/errors/fn-varargs/with-default/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected ")".
 @function test($param...:"default") {}
                         ^
-  /sass/spec/errors/fn-varargs/with-default/input.scss 1:25
+  spec/errors/fn-varargs/with-default/input.scss 1:25  root stylesheet

--- a/spec/errors/import/file/control-else/error-dart-sass
+++ b/spec/errors/import/file/control-else/error-dart-sass
@@ -1,4 +1,4 @@
 Error: This at-rule is not allowed here.
   @import '_include';
   ^^^^^^^^^^^^^^^^^^
-  /sass/spec/errors/import/file/control-else/input.scss 3:3
+  spec/errors/import/file/control-else/input.scss 3:3  root stylesheet

--- a/spec/errors/import/file/control-if/error-dart-sass
+++ b/spec/errors/import/file/control-if/error-dart-sass
@@ -1,4 +1,4 @@
 Error: This at-rule is not allowed here.
   @import '_include';
   ^^^^^^^^^^^^^^^^^^
-  /sass/spec/errors/import/file/control-if/input.scss 2:3
+  spec/errors/import/file/control-if/input.scss 2:3  root stylesheet

--- a/spec/errors/import/file/loop/each/error-dart-sass
+++ b/spec/errors/import/file/loop/each/error-dart-sass
@@ -1,4 +1,4 @@
 Error: This at-rule is not allowed here.
   @import '_include';
   ^^^^^^^^^^^^^^^^^^
-  /sass/spec/errors/import/file/loop/each/input.scss 2:3
+  spec/errors/import/file/loop/each/input.scss 2:3  root stylesheet

--- a/spec/errors/import/file/loop/for/error-dart-sass
+++ b/spec/errors/import/file/loop/for/error-dart-sass
@@ -1,4 +1,4 @@
 Error: This at-rule is not allowed here.
   @import '_include';
   ^^^^^^^^^^^^^^^^^^
-  /sass/spec/errors/import/file/loop/for/input.scss 2:3
+  spec/errors/import/file/loop/for/input.scss 2:3  root stylesheet

--- a/spec/errors/import/file/loop/while/error-dart-sass
+++ b/spec/errors/import/file/loop/while/error-dart-sass
@@ -1,4 +1,4 @@
 Error: This at-rule is not allowed here.
   @import '_include';
   ^^^^^^^^^^^^^^^^^^
-  /sass/spec/errors/import/file/loop/while/input.scss 3:3
+  spec/errors/import/file/loop/while/input.scss 3:3  root stylesheet

--- a/spec/errors/import/file/mixin/control-else/inside/error-dart-sass
+++ b/spec/errors/import/file/mixin/control-else/inside/error-dart-sass
@@ -1,4 +1,4 @@
 Error: This at-rule is not allowed here.
     @import '_include';
     ^^^^^^^^^^^^^^^^^^
-  /sass/spec/errors/import/file/mixin/control-else/inside/input.scss 4:5
+  spec/errors/import/file/mixin/control-else/inside/input.scss 4:5  root stylesheet

--- a/spec/errors/import/file/mixin/control-else/outside/error-dart-sass
+++ b/spec/errors/import/file/mixin/control-else/outside/error-dart-sass
@@ -1,4 +1,4 @@
 Error: This at-rule is not allowed here.
   @import '_include';
   ^^^^^^^^^^^^^^^^^^
-  /sass/spec/errors/import/file/mixin/control-else/outside/input.scss 2:3
+  spec/errors/import/file/mixin/control-else/outside/input.scss 2:3  root stylesheet

--- a/spec/errors/import/file/mixin/control-if/inside/error-dart-sass
+++ b/spec/errors/import/file/mixin/control-if/inside/error-dart-sass
@@ -1,4 +1,4 @@
 Error: This at-rule is not allowed here.
     @import '_include';
     ^^^^^^^^^^^^^^^^^^
-  /sass/spec/errors/import/file/mixin/control-if/inside/input.scss 3:5
+  spec/errors/import/file/mixin/control-if/inside/input.scss 3:5  root stylesheet

--- a/spec/errors/import/file/mixin/control-if/outside/error-dart-sass
+++ b/spec/errors/import/file/mixin/control-if/outside/error-dart-sass
@@ -1,4 +1,4 @@
 Error: This at-rule is not allowed here.
   @import '_include';
   ^^^^^^^^^^^^^^^^^^
-  /sass/spec/errors/import/file/mixin/control-if/outside/input.scss 2:3
+  spec/errors/import/file/mixin/control-if/outside/input.scss 2:3  root stylesheet

--- a/spec/errors/import/miss/control-else/error-dart-sass
+++ b/spec/errors/import/miss/control-else/error-dart-sass
@@ -1,4 +1,4 @@
 Error: This at-rule is not allowed here.
   @import '_include';
   ^^^^^^^^^^^^^^^^^^
-  /sass/spec/errors/import/miss/control-else/input.scss 3:3
+  spec/errors/import/miss/control-else/input.scss 3:3  root stylesheet

--- a/spec/errors/import/miss/control-if/error-dart-sass
+++ b/spec/errors/import/miss/control-if/error-dart-sass
@@ -1,4 +1,4 @@
 Error: This at-rule is not allowed here.
   @import '_include';
   ^^^^^^^^^^^^^^^^^^
-  /sass/spec/errors/import/miss/control-if/input.scss 2:3
+  spec/errors/import/miss/control-if/input.scss 2:3  root stylesheet

--- a/spec/errors/import/miss/loop/each/error-dart-sass
+++ b/spec/errors/import/miss/loop/each/error-dart-sass
@@ -1,4 +1,4 @@
 Error: This at-rule is not allowed here.
   @import '_include';
   ^^^^^^^^^^^^^^^^^^
-  /sass/spec/errors/import/miss/loop/each/input.scss 2:3
+  spec/errors/import/miss/loop/each/input.scss 2:3  root stylesheet

--- a/spec/errors/import/miss/loop/for/error-dart-sass
+++ b/spec/errors/import/miss/loop/for/error-dart-sass
@@ -1,4 +1,4 @@
 Error: This at-rule is not allowed here.
   @import '_include';
   ^^^^^^^^^^^^^^^^^^
-  /sass/spec/errors/import/miss/loop/for/input.scss 2:3
+  spec/errors/import/miss/loop/for/input.scss 2:3  root stylesheet

--- a/spec/errors/import/miss/loop/while/error-dart-sass
+++ b/spec/errors/import/miss/loop/while/error-dart-sass
@@ -1,4 +1,4 @@
 Error: This at-rule is not allowed here.
   @import '_include';
   ^^^^^^^^^^^^^^^^^^
-  /sass/spec/errors/import/miss/loop/while/input.scss 3:3
+  spec/errors/import/miss/loop/while/input.scss 3:3  root stylesheet

--- a/spec/errors/import/miss/mixin/control-else/inside/error-dart-sass
+++ b/spec/errors/import/miss/mixin/control-else/inside/error-dart-sass
@@ -1,4 +1,4 @@
 Error: This at-rule is not allowed here.
     @import '_include';
     ^^^^^^^^^^^^^^^^^^
-  /sass/spec/errors/import/miss/mixin/control-else/inside/input.scss 4:5
+  spec/errors/import/miss/mixin/control-else/inside/input.scss 4:5  root stylesheet

--- a/spec/errors/import/miss/mixin/control-else/outside/error-dart-sass
+++ b/spec/errors/import/miss/mixin/control-else/outside/error-dart-sass
@@ -1,4 +1,4 @@
 Error: This at-rule is not allowed here.
   @import '_include';
   ^^^^^^^^^^^^^^^^^^
-  /sass/spec/errors/import/miss/mixin/control-else/outside/input.scss 2:3
+  spec/errors/import/miss/mixin/control-else/outside/input.scss 2:3  root stylesheet

--- a/spec/errors/import/miss/mixin/control-if/inside/error-dart-sass
+++ b/spec/errors/import/miss/mixin/control-if/inside/error-dart-sass
@@ -1,4 +1,4 @@
 Error: This at-rule is not allowed here.
     @import '_include';
     ^^^^^^^^^^^^^^^^^^
-  /sass/spec/errors/import/miss/mixin/control-if/inside/input.scss 3:5
+  spec/errors/import/miss/mixin/control-if/inside/input.scss 3:5  root stylesheet

--- a/spec/errors/import/miss/mixin/control-if/outside/error-dart-sass
+++ b/spec/errors/import/miss/mixin/control-if/outside/error-dart-sass
@@ -1,4 +1,4 @@
 Error: This at-rule is not allowed here.
   @import '_include';
   ^^^^^^^^^^^^^^^^^^
-  /sass/spec/errors/import/miss/mixin/control-if/outside/input.scss 2:3
+  spec/errors/import/miss/mixin/control-if/outside/input.scss 2:3  root stylesheet

--- a/spec/errors/interpolation/error-1/error-dart-sass
+++ b/spec/errors/interpolation/error-1/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Expected expression.
 '#{)'{
  ^^
-  /sass/spec/errors/interpolation/error-1/input.scss 1:2
+  spec/errors/interpolation/error-1/input.scss 1:2  root stylesheet

--- a/spec/errors/invalid-parent/function-in-each/error-dart-sass
+++ b/spec/errors/invalid-parent/function-in-each/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Functions may not be declared in control directives.
   @function foo() {}
   ^^^^^^^^^^^^^^^
-  /sass/spec/errors/invalid-parent/function-in-each/input.scss 2:3
+  spec/errors/invalid-parent/function-in-each/input.scss 2:3  root stylesheet

--- a/spec/errors/invalid-parent/function-in-for/error-dart-sass
+++ b/spec/errors/invalid-parent/function-in-for/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Functions may not be declared in control directives.
   @function foo() {}
   ^^^^^^^^^^^^^^^
-  /sass/spec/errors/invalid-parent/function-in-for/input.scss 2:3
+  spec/errors/invalid-parent/function-in-for/input.scss 2:3  root stylesheet

--- a/spec/errors/invalid-parent/function-in-function/error-dart-sass
+++ b/spec/errors/invalid-parent/function-in-function/error-dart-sass
@@ -1,4 +1,4 @@
 Error: This at-rule is not allowed here.
   @function bar() {}
   ^^^^^^^^^^^^^^^^
-  /sass/spec/errors/invalid-parent/function-in-function/input.scss 2:3
+  spec/errors/invalid-parent/function-in-function/input.scss 2:3  root stylesheet

--- a/spec/errors/invalid-parent/function-in-if/error-dart-sass
+++ b/spec/errors/invalid-parent/function-in-if/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Functions may not be declared in control directives.
   @function foo() {}
   ^^^^^^^^^^^^^^^
-  /sass/spec/errors/invalid-parent/function-in-if/input.scss 2:3
+  spec/errors/invalid-parent/function-in-if/input.scss 2:3  root stylesheet

--- a/spec/errors/invalid-parent/function-in-mixin/error-dart-sass
+++ b/spec/errors/invalid-parent/function-in-mixin/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Mixins may not contain function declarations.
   @function foo() {}
   ^^^^^^^^^^^^^^^
-  /sass/spec/errors/invalid-parent/function-in-mixin/input.scss 2:3
+  spec/errors/invalid-parent/function-in-mixin/input.scss 2:3  root stylesheet

--- a/spec/errors/invalid-parent/function-in-while/error-dart-sass
+++ b/spec/errors/invalid-parent/function-in-while/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Functions may not be declared in control directives.
   @function foo() {}
   ^^^^^^^^^^^^^^^
-  /sass/spec/errors/invalid-parent/function-in-while/input.scss 2:3
+  spec/errors/invalid-parent/function-in-while/input.scss 2:3  root stylesheet

--- a/spec/errors/invalid-parent/mixin-in-each/error-dart-sass
+++ b/spec/errors/invalid-parent/mixin-in-each/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Mixins may not be declared in control directives.
   @mixin foo() {}
   ^^^^^^^^^^^^
-  /sass/spec/errors/invalid-parent/mixin-in-each/input.scss 2:3
+  spec/errors/invalid-parent/mixin-in-each/input.scss 2:3  root stylesheet

--- a/spec/errors/invalid-parent/mixin-in-for/error-dart-sass
+++ b/spec/errors/invalid-parent/mixin-in-for/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Mixins may not be declared in control directives.
   @mixin foo() {}
   ^^^^^^^^^^^^
-  /sass/spec/errors/invalid-parent/mixin-in-for/input.scss 2:3
+  spec/errors/invalid-parent/mixin-in-for/input.scss 2:3  root stylesheet

--- a/spec/errors/invalid-parent/mixin-in-function/error-dart-sass
+++ b/spec/errors/invalid-parent/mixin-in-function/error-dart-sass
@@ -1,4 +1,4 @@
 Error: This at-rule is not allowed here.
   @mixin bar() {}
   ^^^^^^^^^^^^^
-  /sass/spec/errors/invalid-parent/mixin-in-function/input.scss 2:3
+  spec/errors/invalid-parent/mixin-in-function/input.scss 2:3  root stylesheet

--- a/spec/errors/invalid-parent/mixin-in-if/error-dart-sass
+++ b/spec/errors/invalid-parent/mixin-in-if/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Mixins may not be declared in control directives.
   @mixin foo() {}
   ^^^^^^^^^^^^
-  /sass/spec/errors/invalid-parent/mixin-in-if/input.scss 2:3
+  spec/errors/invalid-parent/mixin-in-if/input.scss 2:3  root stylesheet

--- a/spec/errors/invalid-parent/mixin-in-mixin/error-dart-sass
+++ b/spec/errors/invalid-parent/mixin-in-mixin/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Mixins may not contain mixin declarations.
   @mixin foo() {}
   ^^^^^^^^^^^^
-  /sass/spec/errors/invalid-parent/mixin-in-mixin/input.scss 2:3
+  spec/errors/invalid-parent/mixin-in-mixin/input.scss 2:3  root stylesheet

--- a/spec/errors/invalid-parent/mixin-in-while/error-dart-sass
+++ b/spec/errors/invalid-parent/mixin-in-while/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Mixins may not be declared in control directives.
   @mixin foo() {}
   ^^^^^^^^^^^^
-  /sass/spec/errors/invalid-parent/mixin-in-while/input.scss 2:3
+  spec/errors/invalid-parent/mixin-in-while/input.scss 2:3  root stylesheet

--- a/spec/errors/invalid-parent/return-in-mixin/error-dart-sass
+++ b/spec/errors/invalid-parent/return-in-mixin/error-dart-sass
@@ -1,4 +1,4 @@
 Error: This at-rule is not allowed here.
   @return 42;
   ^^^^^^^^^^
-  /sass/spec/errors/invalid-parent/return-in-mixin/input.scss 2:3
+  spec/errors/invalid-parent/return-in-mixin/input.scss 2:3  root stylesheet

--- a/spec/errors/invalid-parent/return-in-root/error-dart-sass
+++ b/spec/errors/invalid-parent/return-in-root/error-dart-sass
@@ -1,4 +1,4 @@
 Error: This at-rule is not allowed here.
 @return 42;
 ^^^^^^^^^^
-  /sass/spec/errors/invalid-parent/return-in-root/input.scss 1:1
+  spec/errors/invalid-parent/return-in-root/input.scss 1:1  root stylesheet

--- a/spec/errors/invalid-parent/return-in-ruleset/error-dart-sass
+++ b/spec/errors/invalid-parent/return-in-ruleset/error-dart-sass
@@ -1,4 +1,4 @@
 Error: This at-rule is not allowed here.
   @return 42;
   ^^^^^^^^^^
-  /sass/spec/errors/invalid-parent/return-in-ruleset/input.scss 2:3
+  spec/errors/invalid-parent/return-in-ruleset/input.scss 2:3  root stylesheet

--- a/spec/errors/unicode/report/after/error-dart-sass
+++ b/spec/errors/unicode/report/after/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected "{".
 foo{;öüäöüäöü
              ^
-  /sass/spec/errors/unicode/report/after/input.scss 1:14
+  spec/errors/unicode/report/after/input.scss 1:14  root stylesheet

--- a/spec/errors/unicode/report/before/error-dart-sass
+++ b/spec/errors/unicode/report/before/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected "{".
 öüäöüäöü{a:c
             ^
-  /sass/spec/errors/unicode/report/before/input.scss 1:13
+  spec/errors/unicode/report/before/input.scss 1:13  root stylesheet

--- a/spec/libsass-closed-issues/issue_1060/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_1060/error-dart-sass
@@ -1,4 +1,4 @@
 Error: This at-rule is not allowed here.
   } @else {
     ^^^^^^
-  /sass/spec/libsass-issues/issue_1060/input.scss 6:5
+  spec/libsass-issues/issue_1060/input.scss 6:5  root stylesheet

--- a/spec/libsass-closed-issues/issue_1093/argument/function-4.0/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_1093/argument/function-4.0/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Expected expression.
 @function foo($bar:#{}) {
                    ^^
-  /sass/spec/libsass-issues/issue_1093/argument/function-4.0/input.scss 1:20
+  spec/libsass-issues/issue_1093/argument/function-4.0/input.scss 1:20  root stylesheet

--- a/spec/libsass-closed-issues/issue_1093/argument/mixin-4.0/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_1093/argument/mixin-4.0/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Expected expression.
 @mixin foo($bar:#{}) {
                 ^^
-  /sass/spec/libsass-issues/issue_1093/argument/mixin-4.0/input.scss 1:17
+  spec/libsass-issues/issue_1093/argument/mixin-4.0/input.scss 1:17  root stylesheet

--- a/spec/libsass-closed-issues/issue_1093/assignment/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_1093/assignment/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Expected expression.
 $foo: #{};
       ^^
-  /sass/spec/libsass-issues/issue_1093/assignment/input.scss 1:7
+  spec/libsass-issues/issue_1093/assignment/input.scss 1:7  root stylesheet

--- a/spec/libsass-closed-issues/issue_1093/parameter/function/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_1093/parameter/function/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Expected expression.
 $foo: foo(#{});
           ^^
-  /sass/spec/libsass-issues/issue_1093/parameter/function/input.scss 5:11
+  spec/libsass-issues/issue_1093/parameter/function/input.scss 5:11  root stylesheet

--- a/spec/libsass-closed-issues/issue_1093/parameter/mixin/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_1093/parameter/mixin/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Expected expression.
   @include foo(#{});
                ^^
-  /sass/spec/libsass-issues/issue_1093/parameter/mixin/input.scss 6:16
+  spec/libsass-issues/issue_1093/parameter/mixin/input.scss 6:16  root stylesheet

--- a/spec/libsass-closed-issues/issue_1093/property/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_1093/property/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Expected expression.
   bar: #{};
        ^^
-  /sass/spec/libsass-issues/issue_1093/property/input.scss 2:8
+  spec/libsass-issues/issue_1093/property/input.scss 2:8  root stylesheet

--- a/spec/libsass-closed-issues/issue_1355/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_1355/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Expected expression.
   @return;
          ^
-  /sass/spec/libsass-issues/issue_1355/input.scss 2:10
+  spec/libsass-issues/issue_1355/input.scss 2:10  root stylesheet

--- a/spec/libsass-closed-issues/issue_1484/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_1484/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected "{".
 
 ^
-  /sass/spec/libsass-issues/issue_1484/input.scss 2:1
+  spec/libsass-issues/issue_1484/input.scss 2:1  root stylesheet

--- a/spec/libsass-closed-issues/issue_1537/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_1537/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected ":".
   a: 1, two, 3,
            ^
-  /sass/spec/libsass-issues/issue_1537/input.scss 2:12
+  spec/libsass-issues/issue_1537/input.scss 2:12  root stylesheet

--- a/spec/libsass-closed-issues/issue_1550/each_embedded/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_1550/each_embedded/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Functions may not be declared in control directives.
   @function foo() {
   ^^^^^^^^^^^^^^^
-  /sass/spec/libsass-issues/issue_1550/each_embedded/input.scss 2:3
+  spec/libsass-issues/issue_1550/each_embedded/input.scss 2:3  root stylesheet

--- a/spec/libsass-closed-issues/issue_1550/for_embedded/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_1550/for_embedded/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Functions may not be declared in control directives.
   @function foo() {
   ^^^^^^^^^^^^^^^
-  /sass/spec/libsass-issues/issue_1550/for_embedded/input.scss 2:3
+  spec/libsass-issues/issue_1550/for_embedded/input.scss 2:3  root stylesheet

--- a/spec/libsass-closed-issues/issue_1550/if_embedded/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_1550/if_embedded/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Functions may not be declared in control directives.
   @function foo() {
   ^^^^^^^^^^^^^^^
-  /sass/spec/libsass-issues/issue_1550/if_embedded/input.scss 2:3
+  spec/libsass-issues/issue_1550/if_embedded/input.scss 2:3  root stylesheet

--- a/spec/libsass-closed-issues/issue_1550/mixin_embedded/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_1550/mixin_embedded/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Mixins may not contain function declarations.
   @function foo() {
   ^^^^^^^^^^^^^^^
-  /sass/spec/libsass-issues/issue_1550/mixin_embedded/input.scss 2:3
+  spec/libsass-issues/issue_1550/mixin_embedded/input.scss 2:3  root stylesheet

--- a/spec/libsass-closed-issues/issue_1550/while_embedded/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_1550/while_embedded/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Functions may not be declared in control directives.
   @function foo() {
   ^^^^^^^^^^^^^^^
-  /sass/spec/libsass-issues/issue_1550/while_embedded/input.scss 3:3
+  spec/libsass-issues/issue_1550/while_embedded/input.scss 3:3  root stylesheet

--- a/spec/libsass-closed-issues/issue_1648/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_1648/error-dart-sass
@@ -1,4 +1,4 @@
 Error: This at-rule is not allowed here.
 @else/* middle 3 */if/* pre 3  */$x == 3px/* post 3 */{
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  /sass/spec/libsass-issues/issue_1648/input.scss 11:1
+  spec/libsass-issues/issue_1648/input.scss 11:1  root stylesheet

--- a/spec/libsass-closed-issues/issue_1658/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_1658/error-dart-sass
@@ -1,4 +1,4 @@
 Error: This at-rule is not allowed here.
 @else{}
 ^^^^^
-  /sass/spec/libsass-issues/issue_1658/input.scss 1:1
+  spec/libsass-issues/issue_1658/input.scss 1:1  root stylesheet

--- a/spec/libsass-closed-issues/issue_1670/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_1670/error-dart-sass
@@ -2,4 +2,4 @@ Error: The target selector was not found.
 Use "@extend %an-undefined-placeholder !optional" to avoid this error.
   @extend %an-undefined-placeholder;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  /sass/spec/libsass-issues/issue_1670/input.scss 2:3
+  spec/libsass-issues/issue_1670/input.scss 2:3  root stylesheet

--- a/spec/libsass-closed-issues/issue_1681/calc/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_1681/calc/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Invalid function name.
 @function calc() {
 ^^^^^^^^^^^^^^^^
-  /sass/spec/libsass-issues/issue_1681/calc/input.scss 1:1
+  spec/libsass-issues/issue_1681/calc/input.scss 1:1  root stylesheet

--- a/spec/libsass-closed-issues/issue_1681/element/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_1681/element/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Invalid function name.
 @function element() {
 ^^^^^^^^^^^^^^^^^^^
-  /sass/spec/libsass-issues/issue_1681/element/input.scss 1:1
+  spec/libsass-issues/issue_1681/element/input.scss 1:1  root stylesheet

--- a/spec/libsass-closed-issues/issue_1681/expression/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_1681/expression/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Invalid function name.
 @function expression() {
 ^^^^^^^^^^^^^^^^^^^^^^
-  /sass/spec/libsass-issues/issue_1681/expression/input.scss 1:1
+  spec/libsass-issues/issue_1681/expression/input.scss 1:1  root stylesheet

--- a/spec/libsass-closed-issues/issue_1681/url/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_1681/url/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Invalid function name.
 @function url() {
 ^^^^^^^^^^^^^^^
-  /sass/spec/libsass-issues/issue_1681/url/input.scss 1:1
+  spec/libsass-issues/issue_1681/url/input.scss 1:1  root stylesheet

--- a/spec/libsass-closed-issues/issue_1706/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_1706/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Invalid function name.
 @function calc($e) { @return custom; }
 ^^^^^^^^^^^^^^^^^^
-  /sass/spec/libsass-issues/issue_1706/input.scss 1:1
+  spec/libsass-issues/issue_1706/input.scss 1:1  root stylesheet

--- a/spec/libsass-closed-issues/issue_1803/nested/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_1803/nested/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected ":".
     c {
       ^
-  /sass/spec/libsass-issues/issue_1803/nested/input.scss 5:7
+  spec/libsass-issues/issue_1803/nested/input.scss 5:7  root stylesheet

--- a/spec/libsass-closed-issues/issue_1916/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_1916/error-dart-sass
@@ -2,4 +2,4 @@ Error: The target selector was not found.
 Use "@extend .z-depth-half-1 !optional" to avoid this error.
     @extend .z-depth-half-1;
     ^^^^^^^^^^^^^^^^^^^^^^^
-  /sass/spec/libsass-issues/issue_1916/input.scss 13:5
+  spec/libsass-issues/issue_1916/input.scss 13:5  root stylesheet

--- a/spec/libsass-closed-issues/issue_1923/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_1923/error-dart-sass
@@ -4,4 +4,4 @@ Error: From line 1, column 1 of spec/libsass-issues/issue_1923/input.scss:
 You may not @extend selectors across media queries.
     @extend %btnBase;
     ^^^^^^^^^^^^^^^^
-  /sass/spec/libsass-issues/issue_1923/input.scss 13:5
+  spec/libsass-issues/issue_1923/input.scss 13:5  root stylesheet

--- a/spec/libsass-closed-issues/issue_1941/function_function/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_1941/function_function/error-dart-sass
@@ -1,4 +1,4 @@
 Error: This at-rule is not allowed here.
   @function nested() {
   ^^^^^^^^^^^^^^^^^^^
-  /sass/spec/libsass-issues/issue_1941/function_function/input.scss 2:3
+  spec/libsass-issues/issue_1941/function_function/input.scss 2:3  root stylesheet

--- a/spec/libsass-closed-issues/issue_1941/function_mixin/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_1941/function_mixin/error-dart-sass
@@ -1,4 +1,4 @@
 Error: This at-rule is not allowed here.
   @mixin nested {
   ^^^^^^^^^^^^^^
-  /sass/spec/libsass-issues/issue_1941/function_mixin/input.scss 2:3
+  spec/libsass-issues/issue_1941/function_mixin/input.scss 2:3  root stylesheet

--- a/spec/libsass-closed-issues/issue_1941/mixin_function/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_1941/mixin_function/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Mixins may not contain function declarations.
   @function nested() {
   ^^^^^^^^^^^^^^^^^^
-  /sass/spec/libsass-issues/issue_1941/mixin_function/input.scss 2:3
+  spec/libsass-issues/issue_1941/mixin_function/input.scss 2:3  root stylesheet

--- a/spec/libsass-closed-issues/issue_1941/mixin_mixin/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_1941/mixin_mixin/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Mixins may not contain mixin declarations.
   @mixin nested {
   ^^^^^^^^^^^^^^
-  /sass/spec/libsass-issues/issue_1941/mixin_mixin/input.scss 2:3
+  spec/libsass-issues/issue_1941/mixin_mixin/input.scss 2:3  root stylesheet

--- a/spec/libsass-closed-issues/issue_2081/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_2081/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected "}".
 $foo: #{bar();};
              ^
-  /sass/spec/libsass-issues/issue_2081/input.scss 1:14
+  spec/libsass-issues/issue_2081/input.scss 1:14  root stylesheet

--- a/spec/libsass-closed-issues/issue_2143/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_2143/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Expected expression.
 $map:;
      ^
-  /sass/spec/libsass-issues/issue_2143/input.scss 1:6
+  spec/libsass-issues/issue_2143/input.scss 1:6  root stylesheet

--- a/spec/libsass-closed-issues/issue_2307/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_2307/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected "{".
 
 ^
-  /sass/spec/libsass-issues/issue_2307/input.scss 3:1
+  spec/libsass-issues/issue_2307/input.scss 3:1  root stylesheet

--- a/spec/libsass-closed-issues/issue_2369/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_2369/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Expected expression.
 @a(#{url(\#{})}
           ^^
-  /sass/spec/libsass-issues/issue_2369/input.scss 1:11
+  spec/libsass-issues/issue_2369/input.scss 1:11  root stylesheet

--- a/spec/libsass-closed-issues/issue_2371/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_2371/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected "{".
 
 ^
-  /sass/spec/libsass-issues/issue_2371/input.scss 2:1
+  spec/libsass-issues/issue_2371/input.scss 2:1  root stylesheet

--- a/spec/libsass-closed-issues/issue_673/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_673/error-dart-sass
@@ -4,4 +4,4 @@ Error: From line 1, column 1 of spec/libsass-issues/issue_673/input.scss:
 You may not @extend selectors across media queries.
             @extend .example;
             ^^^^^^^^^^^^^^^^
-  /sass/spec/libsass-issues/issue_673/input.scss 9:13
+  spec/libsass-issues/issue_673/input.scss 9:13  root stylesheet

--- a/spec/libsass-closed-issues/issue_674/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_674/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Invalid function name.
 @function url($src, $path:''){
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  /sass/spec/libsass-issues/issue_674/input.scss 5:1
+  spec/libsass-issues/issue_674/input.scss 5:1  root stylesheet

--- a/spec/libsass-closed-issues/issue_712/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_712/error-dart-sass
@@ -4,4 +4,4 @@ Error: From line 1, column 1 of spec/libsass-issues/issue_712/input.scss:
 You may not @extend selectors across media queries.
     @extend .foo;
     ^^^^^^^^^^^^
-  /sass/spec/libsass-issues/issue_712/input.scss 7:5
+  spec/libsass-issues/issue_712/input.scss 7:5  root stylesheet

--- a/spec/libsass-closed-issues/issue_713/and/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_713/and/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Invalid function name.
 @function and() {
 ^^^^^^^^^^^^^^^
-  /sass/spec/libsass-issues/issue_713/and/input.scss 1:1
+  spec/libsass-issues/issue_713/and/input.scss 1:1  root stylesheet

--- a/spec/libsass-closed-issues/issue_713/not/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_713/not/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Invalid function name.
 @function not() {
 ^^^^^^^^^^^^^^^
-  /sass/spec/libsass-issues/issue_713/not/input.scss 1:1
+  spec/libsass-issues/issue_713/not/input.scss 1:1  root stylesheet

--- a/spec/libsass-closed-issues/issue_713/or/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_713/or/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Invalid function name.
 @function or() {
 ^^^^^^^^^^^^^^
-  /sass/spec/libsass-issues/issue_713/or/input.scss 1:1
+  spec/libsass-issues/issue_713/or/input.scss 1:1  root stylesheet

--- a/spec/libsass-closed-issues/issue_871/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_871/error-dart-sass
@@ -2,4 +2,4 @@ Error: The target selector was not found.
 Use "@extend .foo !optional" to avoid this error.
   @extend .foo;
   ^^^^^^^^^^^^
-  /sass/spec/libsass-issues/issue_871/input.scss 2:3
+  spec/libsass-issues/issue_871/input.scss 2:3  root stylesheet

--- a/spec/libsass-closed-issues/issue_945/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_945/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Expected expression.
 }
 ^
-  /sass/spec/libsass-issues/issue_945/input.scss 4:1
+  spec/libsass-issues/issue_945/input.scss 4:1  root stylesheet

--- a/spec/libsass-todo-issues/issue_1096/error-dart-sass
+++ b/spec/libsass-todo-issues/issue_1096/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Expected ".
 @import url("foo
                 ^
-  /sass/spec/libsass-issues/issue_1096/input.scss 4:17
+  spec/libsass-issues/issue_1096/input.scss 4:17  root stylesheet

--- a/spec/libsass-todo-issues/issue_1694/quoted-right-paren/error-dart-sass
+++ b/spec/libsass-todo-issues/issue_1694/quoted-right-paren/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected ")".
   filter: progid:DXImageTransform.Microsoft.Alpha(opacity=20\);
                                                               ^
-  /sass/spec/libsass-issues/issue_1694/quoted-right-paren/input.scss 2:63
+  spec/libsass-issues/issue_1694/quoted-right-paren/input.scss 2:63  root stylesheet

--- a/spec/libsass-todo-issues/issue_1720/error-dart-sass
+++ b/spec/libsass-todo-issues/issue_1720/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected "{".
 
 ^
-  /sass/spec/libsass-issues/issue_1720/input.scss 4:1
+  spec/libsass-issues/issue_1720/input.scss 4:1  root stylesheet

--- a/spec/libsass-todo-issues/issue_1732/invalid/ruleset/error-dart-sass
+++ b/spec/libsass-todo-issues/issue_1732/invalid/ruleset/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected "{".
 color: green;
             ^
-  /sass/spec/libsass-issues/issue_1732/invalid/ruleset/input.scss 1:13
+  spec/libsass-issues/issue_1732/invalid/ruleset/input.scss 1:13  root stylesheet

--- a/spec/libsass-todo-issues/issue_2016/error-dart-sass
+++ b/spec/libsass-todo-issues/issue_2016/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Expected digit.
 $_: ___((Classes and IDs must follow a specific grammar. And this thing here doesn’t.));
                                                         ^
-  /sass/spec/libsass-issues/issue_2016/input.scss 1:57
+  spec/libsass-issues/issue_2016/input.scss 1:57  root stylesheet

--- a/spec/libsass-todo-issues/issue_2051/error-dart-sass
+++ b/spec/libsass-todo-issues/issue_2051/error-dart-sass
@@ -2,4 +2,4 @@ Error: The target selector was not found.
 Use "@extend .thing !optional" to avoid this error.
     @extend .thing;
     ^^^^^^^^^^^^^^
-  /sass/spec/libsass-issues/issue_2051/input.scss 6:5
+  spec/libsass-issues/issue_2051/input.scss 6:5  root stylesheet

--- a/spec/libsass-todo-issues/issue_2295/error/basic/error-dart-sass
+++ b/spec/libsass-todo-issues/issue_2295/error/basic/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected "{".
 display: none;
              ^
-  /sass/spec/libsass-issues/issue_2295/error/basic/include.scss 1:14
+  spec/libsass-issues/issue_2295/error/basic/include.scss 1:14  root stylesheet

--- a/spec/libsass-todo-issues/issue_2295/error/wrapped/error-dart-sass
+++ b/spec/libsass-todo-issues/issue_2295/error/wrapped/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected "{".
   display: none;
                ^
-  /sass/spec/libsass-issues/issue_2295/error/wrapped/include.scss 2:16
+  spec/libsass-issues/issue_2295/error/wrapped/include.scss 2:16  root stylesheet

--- a/spec/libsass-todo-tests/errors/unicode/invalid/after/error-dart-sass
+++ b/spec/libsass-todo-tests/errors/unicode/invalid/after/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Invalid UTF-8.
 foo{;��������
      ^
-  /sass/spec/errors/unicode/invalid/after/input.scss 1:6
+  spec/errors/unicode/invalid/after/input.scss 1:6  root stylesheet

--- a/spec/libsass-todo-tests/errors/unicode/invalid/before/error-dart-sass
+++ b/spec/libsass-todo-tests/errors/unicode/invalid/before/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Invalid UTF-8.
 ��������{a:c
 ^
-  /sass/spec/errors/unicode/invalid/before/input.scss 1:1
+  spec/errors/unicode/invalid/before/input.scss 1:1  root stylesheet

--- a/spec/libsass-todo-tests/extend-tests/203_test_extend_with_subject_transfers_subject_to_target/error-dart-sass
+++ b/spec/libsass-todo-tests/extend-tests/203_test_extend_with_subject_transfers_subject_to_target/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected "{".
 .bip .bap! {@extend .foo}
          ^
-  /sass/spec/extend-tests/203_test_extend_with_subject_transfers_subject_to_target/input.scss 2:10
+  spec/extend-tests/203_test_extend_with_subject_transfers_subject_to_target/input.scss 2:10  root stylesheet

--- a/spec/libsass/properties-in-media/error-dart-sass
+++ b/spec/libsass/properties-in-media/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected "{".
   color: red;
             ^
-  /sass/spec/libsass/properties-in-media/input.scss 3:13
+  spec/libsass/properties-in-media/input.scss 3:13  root stylesheet

--- a/spec/maps/errors/error-dart-sass
+++ b/spec/maps/errors/error-dart-sass
@@ -1,4 +1,4 @@
 Error: (foo: bar) isn't a valid CSS value.
 test { baz: $map; }
             ^^^^
-  /sass/spec/maps/errors/input.scss 2:13
+  spec/maps/errors/input.scss 2:13  root stylesheet

--- a/spec/maps/invalid-key/error-dart-sass
+++ b/spec/maps/invalid-key/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected ")".
 $id: inspect((a,b:c)...)
                  ^
-  /sass/spec/maps/invalid-key/input.scss 1:18
+  spec/maps/invalid-key/input.scss 1:18  root stylesheet

--- a/spec/parser/interpolate/44_selector/colon_twice_todo/error-dart-sass
+++ b/spec/parser/interpolate/44_selector/colon_twice_todo/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected "(".
   filter: progid:DXImageTransform.Microsoft.#{Alpha(opacity=20)};
                                             ^
-  /sass/spec/parser/interpolate/44_selector/colon_twice/input.scss 2:45
+  spec/parser/interpolate/44_selector/colon_twice/input.scss 2:45  root stylesheet

--- a/spec/parser/malformed_expressions/at-debug/incomplete-expression/error-dart-sass
+++ b/spec/parser/malformed_expressions/at-debug/incomplete-expression/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected ")".
 @debug("foo";
             ^
-  /sass/spec/parser/malformed_expressions/at-debug/incomplete-expression/input.scss 1:13
+  spec/parser/malformed_expressions/at-debug/incomplete-expression/input.scss 1:13  root stylesheet

--- a/spec/parser/malformed_expressions/at-debug/no-argument/error-dart-sass
+++ b/spec/parser/malformed_expressions/at-debug/no-argument/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Expected expression.
 @debug;
       ^
-  /sass/spec/parser/malformed_expressions/at-debug/no-argument/input.scss 1:7
+  spec/parser/malformed_expressions/at-debug/no-argument/input.scss 1:7  root stylesheet

--- a/spec/parser/malformed_expressions/at-error/incomplete-expression/error-dart-sass
+++ b/spec/parser/malformed_expressions/at-error/incomplete-expression/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected ")".
 @error("foo";
             ^
-  /sass/spec/parser/malformed_expressions/at-error/incomplete-expression/input.scss 1:13
+  spec/parser/malformed_expressions/at-error/incomplete-expression/input.scss 1:13  root stylesheet

--- a/spec/parser/malformed_expressions/at-error/no-argument/error-dart-sass
+++ b/spec/parser/malformed_expressions/at-error/no-argument/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Expected expression.
 @error;
       ^
-  /sass/spec/parser/malformed_expressions/at-error/no-argument/input.scss 1:7
+  spec/parser/malformed_expressions/at-error/no-argument/input.scss 1:7  root stylesheet

--- a/spec/parser/malformed_expressions/at-warn/incomplete-expression/error-dart-sass
+++ b/spec/parser/malformed_expressions/at-warn/incomplete-expression/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected ")".
 @warn("foo";
            ^
-  /sass/spec/parser/malformed_expressions/at-warn/incomplete-expression/input.scss 1:12
+  spec/parser/malformed_expressions/at-warn/incomplete-expression/input.scss 1:12  root stylesheet

--- a/spec/parser/malformed_expressions/at-warn/no-argument/error-dart-sass
+++ b/spec/parser/malformed_expressions/at-warn/no-argument/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Expected expression.
 @warn;
      ^
-  /sass/spec/parser/malformed_expressions/at-warn/no-argument/input.scss 1:6
+  spec/parser/malformed_expressions/at-warn/no-argument/input.scss 1:6  root stylesheet

--- a/spec/sass/inconsistent_indentation/error-dart-sass
+++ b/spec/sass/inconsistent_indentation/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Inconsistent indentation, expected 4 spaces.
  d: e
 ^
-  /sass/spec/sass/inconsistent_indentation/input.sass 3:1
+  spec/sass/inconsistent_indentation/input.sass 3:1  root stylesheet

--- a/spec/sass_3_5/arglists/can-end-with-comma/error-call-1/error-dart-sass
+++ b/spec/sass_3_5/arglists/can-end-with-comma/error-call-1/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected ")".
   e: double-comma-error($a,,$b);
                            ^
-  /sass/spec/sass_3_5/arglists/can-end-with-comma/error-call-1/input.scss 3:28
+  spec/sass_3_5/arglists/can-end-with-comma/error-call-1/input.scss 3:28  root stylesheet

--- a/spec/sass_3_5/arglists/can-end-with-comma/error-call-2/error-dart-sass
+++ b/spec/sass_3_5/arglists/can-end-with-comma/error-call-2/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected ")".
   a: double-comma-error($a,$b,,);
                               ^
-  /sass/spec/sass_3_5/arglists/can-end-with-comma/error-call-2/input.scss 3:31
+  spec/sass_3_5/arglists/can-end-with-comma/error-call-2/input.scss 3:31  root stylesheet

--- a/spec/sass_3_5/arglists/can-end-with-comma/error-call-3/error-dart-sass
+++ b/spec/sass_3_5/arglists/can-end-with-comma/error-call-3/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected ")".
   a: incorrectly-terminated($a,$b,;
                                   ^
-  /sass/spec/sass_3_5/arglists/can-end-with-comma/error-call-3/input.scss 3:35
+  spec/sass_3_5/arglists/can-end-with-comma/error-call-3/input.scss 3:35  root stylesheet

--- a/spec/sass_3_5/arglists/can-end-with-comma/error-function-1/error-dart-sass
+++ b/spec/sass_3_5/arglists/can-end-with-comma/error-function-1/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected ")".
 @function double-comma-error($a,,$b) {
                                 ^
-  /sass/spec/sass_3_5/arglists/can-end-with-comma/error-function-1/input.scss 2:33
+  spec/sass_3_5/arglists/can-end-with-comma/error-function-1/input.scss 2:33  root stylesheet

--- a/spec/sass_3_5/arglists/can-end-with-comma/error-function-2/error-dart-sass
+++ b/spec/sass_3_5/arglists/can-end-with-comma/error-function-2/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected ")".
 @function double-comma-error($a,$b,,) {
                                    ^
-  /sass/spec/sass_3_5/arglists/can-end-with-comma/error-function-2/input.scss 2:36
+  spec/sass_3_5/arglists/can-end-with-comma/error-function-2/input.scss 2:36  root stylesheet

--- a/spec/sass_3_5/arglists/can-end-with-comma/error-function-3/error-dart-sass
+++ b/spec/sass_3_5/arglists/can-end-with-comma/error-function-3/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected ")".
 @function missing-paren-error($a,$b, {
                                      ^
-  /sass/spec/sass_3_5/arglists/can-end-with-comma/error-function-3/input.scss 2:38
+  spec/sass_3_5/arglists/can-end-with-comma/error-function-3/input.scss 2:38  root stylesheet

--- a/spec/sass_3_5/arglists/can-end-with-comma/error-include-1/error-dart-sass
+++ b/spec/sass_3_5/arglists/can-end-with-comma/error-include-1/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected ")".
   @include double-comma-error($a,,$b);
                                  ^
-  /sass/spec/sass_3_5/arglists/can-end-with-comma/error-include-1/input.scss 3:34
+  spec/sass_3_5/arglists/can-end-with-comma/error-include-1/input.scss 3:34  root stylesheet

--- a/spec/sass_3_5/arglists/can-end-with-comma/error-include-2/error-dart-sass
+++ b/spec/sass_3_5/arglists/can-end-with-comma/error-include-2/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected ")".
   @include double-comma-error($a,$b,,);
                                     ^
-  /sass/spec/sass_3_5/arglists/can-end-with-comma/error-include-2/input.scss 3:37
+  spec/sass_3_5/arglists/can-end-with-comma/error-include-2/input.scss 3:37  root stylesheet

--- a/spec/sass_3_5/arglists/can-end-with-comma/error-include-3/error-dart-sass
+++ b/spec/sass_3_5/arglists/can-end-with-comma/error-include-3/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected ")".
   @include incorrectly-terminated($a,$b,;
                                         ^
-  /sass/spec/sass_3_5/arglists/can-end-with-comma/error-include-3/input.scss 3:41
+  spec/sass_3_5/arglists/can-end-with-comma/error-include-3/input.scss 3:41  root stylesheet

--- a/spec/sass_3_5/arglists/can-end-with-comma/error-mixin-1/error-dart-sass
+++ b/spec/sass_3_5/arglists/can-end-with-comma/error-mixin-1/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected ")".
 @mixin double-comma-error($a,,$b) {
                              ^
-  /sass/spec/sass_3_5/arglists/can-end-with-comma/error-mixin-1/input.scss 2:30
+  spec/sass_3_5/arglists/can-end-with-comma/error-mixin-1/input.scss 2:30  root stylesheet

--- a/spec/sass_3_5/arglists/can-end-with-comma/error-mixin-2/error-dart-sass
+++ b/spec/sass_3_5/arglists/can-end-with-comma/error-mixin-2/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected ")".
 @mixin double-comma-error($a,$b,,) {
                                 ^
-  /sass/spec/sass_3_5/arglists/can-end-with-comma/error-mixin-2/input.scss 2:33
+  spec/sass_3_5/arglists/can-end-with-comma/error-mixin-2/input.scss 2:33  root stylesheet

--- a/spec/sass_3_5/arglists/can-end-with-comma/error-mixin-3/error-dart-sass
+++ b/spec/sass_3_5/arglists/can-end-with-comma/error-mixin-3/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected ")".
 @mixin missing-paren-error($a,$b, {
                                   ^
-  /sass/spec/sass_3_5/arglists/can-end-with-comma/error-mixin-3/input.scss 2:35
+  spec/sass_3_5/arglists/can-end-with-comma/error-mixin-3/input.scss 2:35  root stylesheet

--- a/spec/sass_3_5/custom_properties/error/bang_in_ident/error-dart-sass
+++ b/spec/sass_3_5/custom_properties/error/bang_in_ident/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected ";".
   --prop: foo!bar;
              ^
-  /sass/spec/sass_3_5/custom_properties/error/bang_in_ident/input.scss 2:14
+  spec/sass_3_5/custom_properties/error/bang_in_ident/input.scss 2:14  root stylesheet

--- a/spec/sass_3_5/custom_properties/error/no_nesting/error-dart-sass
+++ b/spec/sass_3_5/custom_properties/error/no_nesting/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Nothing may be indented beneath a custom property.
     bar: baz
     ^
-  /sass/spec/sass_3_5/custom_properties/error/no_nesting/input.sass 3:5
+  spec/sass_3_5/custom_properties/error/no_nesting/input.sass 3:5  root stylesheet

--- a/spec/sass_3_5/custom_properties/error/top_level_bang/error-dart-sass
+++ b/spec/sass_3_5/custom_properties/error/top_level_bang/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected ";".
   --prop: !;
           ^
-  /sass/spec/sass_3_5/custom_properties/error/top_level_bang/input.scss 2:11
+  spec/sass_3_5/custom_properties/error/top_level_bang/input.scss 2:11  root stylesheet

--- a/spec/sass_3_5/custom_properties/error/unmatched_brackets/curly/error-dart-sass
+++ b/spec/sass_3_5/custom_properties/error/unmatched_brackets/curly/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected "{".
 }
 ^
-  /sass/spec/sass_3_5/custom_properties/error/unmatched_brackets/curly/input.scss 3:1
+  spec/sass_3_5/custom_properties/error/unmatched_brackets/curly/input.scss 3:1  root stylesheet

--- a/spec/sass_3_5/custom_properties/error/unmatched_brackets/curly_in_square/error-dart-sass
+++ b/spec/sass_3_5/custom_properties/error/unmatched_brackets/curly_in_square/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected "}".
   --prop: [{];
             ^
-  /sass/spec/sass_3_5/custom_properties/error/unmatched_brackets/curly_in_square/input.scss 2:13
+  spec/sass_3_5/custom_properties/error/unmatched_brackets/curly_in_square/input.scss 2:13  root stylesheet

--- a/spec/sass_3_5/custom_properties/error/unmatched_brackets/paren/error-dart-sass
+++ b/spec/sass_3_5/custom_properties/error/unmatched_brackets/paren/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected ";".
   --prop: );
           ^
-  /sass/spec/sass_3_5/custom_properties/error/unmatched_brackets/paren/input.scss 2:11
+  spec/sass_3_5/custom_properties/error/unmatched_brackets/paren/input.scss 2:11  root stylesheet

--- a/spec/sass_3_5/custom_properties/error/unmatched_brackets/paren_in_curly/error-dart-sass
+++ b/spec/sass_3_5/custom_properties/error/unmatched_brackets/paren_in_curly/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected ")".
   --prop: {(};
             ^
-  /sass/spec/sass_3_5/custom_properties/error/unmatched_brackets/paren_in_curly/input.scss 2:13
+  spec/sass_3_5/custom_properties/error/unmatched_brackets/paren_in_curly/input.scss 2:13  root stylesheet

--- a/spec/sass_3_5/custom_properties/error/unmatched_brackets/square/error-dart-sass
+++ b/spec/sass_3_5/custom_properties/error/unmatched_brackets/square/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected ";".
   --prop: ];
           ^
-  /sass/spec/sass_3_5/custom_properties/error/unmatched_brackets/square/input.scss 2:11
+  spec/sass_3_5/custom_properties/error/unmatched_brackets/square/input.scss 2:11  root stylesheet

--- a/spec/sass_3_5/custom_properties/error/unmatched_brackets/square_in_paren/error-dart-sass
+++ b/spec/sass_3_5/custom_properties/error/unmatched_brackets/square_in_paren/error-dart-sass
@@ -1,4 +1,4 @@
 Error: expected "]".
   --prop: ([);
             ^
-  /sass/spec/sass_3_5/custom_properties/error/unmatched_brackets/square_in_paren/input.scss 2:13
+  spec/sass_3_5/custom_properties/error/unmatched_brackets/square_in_paren/input.scss 2:13  root stylesheet

--- a/spec/scss/feature-queries/without-query/error-dart-sass
+++ b/spec/scss/feature-queries/without-query/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Expected "not".
 @supports {
           ^
-  /sass/spec/scss/feature-queries/without-query/input.scss 1:11
+  spec/scss/feature-queries/without-query/input.scss 1:11  root stylesheet

--- a/spec/scss/while_without_condition/error-dart-sass
+++ b/spec/scss/while_without_condition/error-dart-sass
@@ -1,4 +1,4 @@
 Error: Expected expression.
 @while {
        ^
-  /sass/spec/scss/while_without_condition/input.scss 1:8
+  spec/scss/while_without_condition/input.scss 1:8  root stylesheet


### PR DESCRIPTION
This output formatting is changed slightly by sass/dart-sass#166.

Skip dart-sass