### PR TITLE
Add more specs for custom property interpolation

### DIFF
--- a/spec/css/custom_properties/name_interpolation/expected_output.css
+++ b/spec/css/custom_properties/name_interpolation/expected_output.css
@@ -1,0 +1,9 @@
+.name-interpolation {
+  --entire: 3;
+  --first-hyphen: 3;
+  --only-name: 1 + 2;
+  --initial-interp: 1 + 2;
+  --middle-interp: 1 + 2;
+  --final-interp: 1 + 2;
+  --double-interp: 1 + 2;
+}

--- a/spec/css/custom_properties/name_interpolation/input.scss
+++ b/spec/css/custom_properties/name_interpolation/input.scss
@@ -1,0 +1,17 @@
+.name-interpolation {
+  // If the entire name is interpolated, SassScript is allowed on the
+  // right-hand side because we don't know it's a custom property at parse time.
+  #{--entire}: 1 + 2;
+
+  // Same if the first hyphen is interpolated.
+  -#{-first-hyphen}: 1 + 2;
+
+  // But if the name is interpolated, the right-hand side is static.
+  --#{only-name}: 1 + 2;
+
+  // The name can also be partially interpolated.
+  --#{initial}-interp: 1 + 2;
+  --midd#{le-int}erp: 1 + 2;
+  --final-#{interp}: 1 + 2;
+  --#{doub}le-int#{erp}: 1 + 2;
+}

--- a/spec/css/custom_properties/name_interpolation/options.yml
+++ b/spec/css/custom_properties/name_interpolation/options.yml
@@ -1,0 +1,3 @@
+---
+:todo:
+- libsass

--- a/spec/css/custom_properties/value_interpolation/expected_output.css
+++ b/spec/css/custom_properties/value_interpolation/expected_output.css
@@ -1,4 +1,4 @@
-.interpolation {
+.value-interpolation {
   --alone: 3;
   --in-list: a 3 c;
   --in-ident: foo3bar;

--- a/spec/css/custom_properties/value_interpolation/input.scss
+++ b/spec/css/custom_properties/value_interpolation/input.scss
@@ -1,4 +1,4 @@
-.interpolation {
+.value-interpolation {
   // Interpolation is the only Sass construct that's supported in custom
   // variables.
   --alone: #{1 + 2};


### PR DESCRIPTION
This adds specs for interpolating the name of the property.

See sass/sass#2383
Skip ruby-sass
Skip dart-sass