### PR TITLE
Remove and and todo for libsass

### DIFF
--- a/lib/sass_spec/test_case.rb
+++ b/lib/sass_spec/test_case.rb
@@ -230,7 +230,7 @@ class SassSpec::TestCase
     err.gsub(/(?:\/todo_|_todo\/)/, "/") # hide todo pre/suffix
        .gsub(/\/libsass\-[a-z]+\-tests\//, "/") # hide test directory
        .gsub(/\/libsass\-[a-z]+\-issues\//, "/libsass-issues/") # normalize issue specs
-       .gsub(/[\w\/.\-\\:]+?[\/\\]spec[\/\\]+/, "/sass/spec/") # normalize abs paths
+       .gsub(/(([\w\/.\-\\:]+?[\/\\])|([\/\\]|(?!:\s)))spec[\/\\]+/, "/sass/spec/") # normalize abs paths
        .sub(/(?:\r?\n)*\z/, "\n") # make sure we have exactly one trailing linefeed
        .sub(/\A(?:\r?\s)+\z/, "") # clear the whole file if only whitespace
   end

--- a/spec/parser/and_and/options.yml
+++ b/spec/parser/and_and/options.yml
@@ -1,3 +1,0 @@
----
-:warning_todo:
-- libsass


### PR DESCRIPTION
See https://github.com/sass/libsass/pull/2530

Additionally fix error normalization for dart-sass as the reference for error messages.