### PR TITLE
Update libsass error for invalid utf8 spec

### DIFF
--- a/spec/libsass-closed-issues/issue_2446/error-libsass
+++ b/spec/libsass-closed-issues/issue_2446/error-libsass
@@ -1,3 +1,4 @@
-Error:  isn't a valid CSS value.
+Error: Invalid UTF-8 sequence
         on line 1 of /sass/spec/libsass-issues/issue_2446/input.scss
-  Use --trace for backtrace.
+>> $�:D&(22#222222%0:/2222-2%22%222/2-2%22%2222-2%22%22)/22
+   -^


### PR DESCRIPTION
Corresponding to https://github.com/sass/libsass/pull/2543