### PR TITLE
Adjust error for duplicate key with color keys

### DIFF
--- a/spec/libsass-closed-issues/issue_1169/error/color/error-libsass
+++ b/spec/libsass-closed-issues/issue_1169/error/color/error-libsass
@@ -1,0 +1,3 @@
+Error: Duplicate key #ff0000 in map (#ff0000: "foo", #ff0000: "bar").
+        on line 1 of /sass/spec/libsass-issues/issue_1169/error/color/input.scss
+  Use --trace for backtrace.


### PR DESCRIPTION
Needed for https://github.com/sass/libsass/pull/2594 since colors are now directly parsed and not lazy evaluated later. IMO it is even more clear this way why such a key is considered a duplicate, since it is made clear that the key is interpreted as a color.