### PR TITLE
Update a Dart Sass error for extending compound selectors

### DIFF
--- a/spec/extend-tests/094_test_long_extendee_runs_unification/error-dart-sass
+++ b/spec/extend-tests/094_test_long_extendee_runs_unification/error-dart-sass
@@ -1,4 +1,7 @@
-Error: expected selector.
+Error: compound selectors may longer be extended.
+Consider `@extend .foo, .bar` instead.
+See http://bit.ly/ExtendCompound for details.
+
 a.baz {@extend .foo.bar}
                    ^
-  spec/extend-tests/094_test_long_extendee_runs_unification/input.scss 2:20  root stylesheet
+  /sass/spec/extend-tests/094_test_long_extendee_runs_unification/input.scss 2:20  root stylesheet


### PR DESCRIPTION
See sass/dart-sass#286

[skip dart-sass]