### PR TITLE
Add spec for invisible custom property

### DIFF
--- a/spec/css/custom_properties/simple/input.scss
+++ b/spec/css/custom_properties/simple/input.scss
@@ -9,6 +9,7 @@
 
   // The whitespace here DOES count as a token and needs to be preserved.
   --empty: ;
+  --empty-no-space:;
 
   // Single-line comments are not supported in variables.
   --single-line: // (


### PR DESCRIPTION
This highlighted a bug in LibSass.

@nex3 do think custom properties be invisible? My feeling is that they should be output regardless.

Note this currently causes an error in Ruby Sass

```
NoMethodError: undefined method `size' for nil:NilClass
  Use --trace for backtrace.
```

[skip ruby-sass]
[skip libsass]