### PR TITLE
Enable colour math deprecation warning specs for LibSass

### DIFF
--- a/spec/basic/16_hex_arithmetic/options.yml
+++ b/spec/basic/16_hex_arithmetic/options.yml
@@ -1,4 +1,2 @@
 ---
 :end_version: '3.5'
-:warning_todo:
-- libsass

--- a/spec/colors/basic/options.yml
+++ b/spec/colors/basic/options.yml
@@ -1,4 +1,2 @@
 ---
 :end_version: '3.5'
-:warning_todo:
-- libsass

--- a/spec/errors/invalid-operation/mod/error
+++ b/spec/errors/invalid-operation/mod/error
@@ -1,3 +1,4 @@
 Error: Undefined operation: "2px mod red".
-        on line 2 of /sass/spec/errors/invalid-operation/mod/input.scss
-  Use --trace for backtrace.
+        on line 2:8 of /sass/spec/errors/invalid-operation/mod/input.scss
+>>   err: 2px % red;
+   -------^

--- a/spec/libsass/color-names/options.yml
+++ b/spec/libsass/color-names/options.yml
@@ -1,4 +1,2 @@
 ---
 :end_version: '3.5'
-:warning_todo:
-- libsass

--- a/spec/output_styles/compact/basic/16_hex_arithmetic/error
+++ b/spec/output_styles/compact/basic/16_hex_arithmetic/error
@@ -1,0 +1,94 @@
+DEPRECATION WARNING on line 5 of /sass/spec/output_styles/compact/basic/16_hex_arithmetic/input.scss:
+The operation `#AbC plus 1` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compact/basic/16_hex_arithmetic/input.scss:
+The operation `#AbC plus #001` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compact/basic/16_hex_arithmetic/input.scss:
+The operation `#0000ff plus 1` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compact/basic/16_hex_arithmetic/input.scss:
+The operation `#0000ff plus #000001` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compact/basic/16_hex_arithmetic/input.scss:
+The operation `#00ffff plus #000101` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compact/basic/16_hex_arithmetic/input.scss:
+The operation `#000000 minus 1` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compact/basic/16_hex_arithmetic/input.scss:
+The operation `#000000 minus #000001` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compact/basic/16_hex_arithmetic/input.scss:
+The operation `#ffff00 plus #010100` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compact/basic/16_hex_arithmetic/input.scss:
+The operation `#101010 div 7` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compact/basic/16_hex_arithmetic/input.scss:
+The operation `#000 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compact/basic/16_hex_arithmetic/input.scss:
+The operation `10 minus #a2B` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compact/basic/16_hex_arithmetic/input.scss:
+The operation `10 minus #aa22BB` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compact/basic/16_hex_arithmetic/input.scss:
+The operation `#000 minus #001` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compact/basic/16_hex_arithmetic/input.scss:
+The operation `#f0F plus #101` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compact/basic/16_hex_arithmetic/input.scss:
+The operation `#a2B plus 1` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compact/basic/16_hex_arithmetic/input.scss:
+The operation `10 div #a2B` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compact/basic/16_hex_arithmetic/input.scss:
+The operation `10 div #aa22BB` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compact/basic/16_hex_arithmetic/input.scss:
+The operation `#0a0a0a plus #010001` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compact/basic/16_hex_arithmetic/input.scss:
+The operation `#010000 plus white` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions

--- a/spec/output_styles/compact/basic/22_colors_with_alpha/error
+++ b/spec/output_styles/compact/basic/22_colors_with_alpha/error
@@ -1,0 +1,4 @@
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compact/basic/22_colors_with_alpha/input.scss:
+The operation `black plus #111` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions

--- a/spec/output_styles/compact/libsass-closed-issues/issue_1251/error
+++ b/spec/output_styles/compact/libsass-closed-issues/issue_1251/error
@@ -1,0 +1,4 @@
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compact/libsass-issues/issue_1251/input.scss:
+The operation `red plus green` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions

--- a/spec/output_styles/compact/libsass/color-names/error
+++ b/spec/output_styles/compact/libsass/color-names/error
@@ -1,0 +1,709 @@
+DEPRECATION WARNING on line 2 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#F0F8FF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FAEBD7 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#00FFFF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 5 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#7FFFD4 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#F0FFFF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#F5F5DC plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FFE4C4 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#000000 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FFEBCD plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#0000FF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#8A2BE2 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#A52A2A plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#DEB887 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#5F9EA0 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#7FFF00 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#D2691E plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FF7F50 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#6495ED plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FFF8DC plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#DC143C plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#00FFFF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#00008B plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#008B8B plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#B8860B plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#A9A9A9 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#006400 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#BDB76B plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#8B008B plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#556B2F plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FF8C00 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#9932CC plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#8B0000 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#E9967A plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#8FBC8F plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#483D8B plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#2F4F4F plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#00CED1 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#9400D3 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FF1493 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#00BFFF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 42 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#696969 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 43 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#1E90FF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 44 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#B22222 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 45 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FFFAF0 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 46 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#228B22 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 47 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FF00FF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 48 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#DCDCDC plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 49 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#F8F8FF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 50 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FFD700 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 51 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#DAA520 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 52 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#808080 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 53 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#008000 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 54 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#ADFF2F plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 55 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#F0FFF0 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 56 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FF69B4 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 57 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#CD5C5C plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 58 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#4B0082 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 59 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FFFFF0 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 60 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#F0E68C plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 61 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#E6E6FA plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 62 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FFF0F5 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 63 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#7CFC00 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 64 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FFFACD plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 65 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#ADD8E6 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 66 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#F08080 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 67 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#E0FFFF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 68 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FAFAD2 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 69 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#D3D3D3 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 70 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#90EE90 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 71 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FFB6C1 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 72 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FFA07A plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 73 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#20B2AA plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 74 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#87CEFA plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 75 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#778899 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 76 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#B0C4DE plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 77 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FFFFE0 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 78 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#00FF00 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 79 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#32CD32 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 80 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FAF0E6 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 81 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FF00FF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 82 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#800000 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 83 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#66CDAA plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 84 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#0000CD plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 85 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#BA55D3 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 86 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#9370DB plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 87 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#3CB371 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 88 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#7B68EE plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 89 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#00FA9A plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 90 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#48D1CC plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 91 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#C71585 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 92 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#191970 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 93 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#F5FFFA plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 94 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FFE4E1 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 95 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FFE4B5 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 96 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FFDEAD plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 97 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#000080 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 98 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FDF5E6 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 99 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#808000 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 100 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#6B8E23 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 101 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FFA500 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 102 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FF4500 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 103 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#DA70D6 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 104 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#EEE8AA plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 105 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#98FB98 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 106 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#AFEEEE plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 107 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#DB7093 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 108 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FFEFD5 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 109 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FFDAB9 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 110 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#CD853F plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 111 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FFC0CB plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 112 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#DDA0DD plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 113 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#B0E0E6 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 114 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#800080 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 115 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FF0000 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 116 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#BC8F8F plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 117 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#4169E1 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 118 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#8B4513 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 119 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FA8072 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 120 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#F4A460 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 121 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#2E8B57 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 122 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FFF5EE plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 123 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#A0522D plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 124 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#C0C0C0 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 125 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#87CEEB plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 126 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#6A5ACD plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 127 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#708090 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 128 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FFFAFA plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 129 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#00FF7F plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 130 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#4682B4 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 131 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#D2B48C plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 132 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#008080 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 133 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#D8BFD8 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 134 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FF6347 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 135 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#40E0D0 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 136 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#EE82EE plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 137 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#F5DEB3 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 138 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FFFFFF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 139 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#F5F5F5 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 140 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#FFFF00 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 141 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#9ACD32 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 142 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `#663399 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 143 of /sass/spec/output_styles/compact/libsass/color-names/input.scss:
+The operation `transparent plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions

--- a/spec/output_styles/compact/libsass/test/error
+++ b/spec/output_styles/compact/libsass/test/error
@@ -1,0 +1,9 @@
+DEPRECATION WARNING on line 51 of /sass/spec/output_styles/compact/libsass/test/input.scss:
+The operation `red plus green` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 52 of /sass/spec/output_styles/compact/libsass/test/input.scss:
+The operation `red plus green` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions

--- a/spec/output_styles/compact/scss/color_output/error
+++ b/spec/output_styles/compact/scss/color_output/error
@@ -1,0 +1,14 @@
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/compact/scss/color_output/input.scss:
+The operation `#00FF00 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compact/scss/color_output/input.scss:
+The operation `#00FF00 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/compact/scss/color_output/input.scss:
+The operation `#00FF00 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions

--- a/spec/output_styles/compressed/basic/16_hex_arithmetic/error
+++ b/spec/output_styles/compressed/basic/16_hex_arithmetic/error
@@ -1,0 +1,94 @@
+DEPRECATION WARNING on line 5 of /sass/spec/output_styles/compressed/basic/16_hex_arithmetic/input.scss:
+The operation `#AbC plus 1` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compressed/basic/16_hex_arithmetic/input.scss:
+The operation `#AbC plus #001` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compressed/basic/16_hex_arithmetic/input.scss:
+The operation `#0000ff plus 1` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compressed/basic/16_hex_arithmetic/input.scss:
+The operation `#0000ff plus #000001` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compressed/basic/16_hex_arithmetic/input.scss:
+The operation `#00ffff plus #000101` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compressed/basic/16_hex_arithmetic/input.scss:
+The operation `#000000 minus 1` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compressed/basic/16_hex_arithmetic/input.scss:
+The operation `#000000 minus #000001` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compressed/basic/16_hex_arithmetic/input.scss:
+The operation `#ffff00 plus #010100` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compressed/basic/16_hex_arithmetic/input.scss:
+The operation `#101010 div 7` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compressed/basic/16_hex_arithmetic/input.scss:
+The operation `#000 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compressed/basic/16_hex_arithmetic/input.scss:
+The operation `10 minus #a2B` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compressed/basic/16_hex_arithmetic/input.scss:
+The operation `10 minus #aa22BB` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compressed/basic/16_hex_arithmetic/input.scss:
+The operation `#000 minus #001` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compressed/basic/16_hex_arithmetic/input.scss:
+The operation `#f0F plus #101` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compressed/basic/16_hex_arithmetic/input.scss:
+The operation `#a2B plus 1` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compressed/basic/16_hex_arithmetic/input.scss:
+The operation `10 div #a2B` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compressed/basic/16_hex_arithmetic/input.scss:
+The operation `10 div #aa22BB` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compressed/basic/16_hex_arithmetic/input.scss:
+The operation `#0a0a0a plus #010001` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compressed/basic/16_hex_arithmetic/input.scss:
+The operation `#010000 plus white` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions

--- a/spec/output_styles/compressed/basic/22_colors_with_alpha/error
+++ b/spec/output_styles/compressed/basic/22_colors_with_alpha/error
@@ -1,0 +1,4 @@
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compressed/basic/22_colors_with_alpha/input.scss:
+The operation `black plus #111` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions

--- a/spec/output_styles/compressed/libsass-closed-issues/issue_1251/error
+++ b/spec/output_styles/compressed/libsass-closed-issues/issue_1251/error
@@ -1,0 +1,4 @@
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compressed/libsass-issues/issue_1251/input.scss:
+The operation `red plus green` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions

--- a/spec/output_styles/compressed/libsass/color-names/error
+++ b/spec/output_styles/compressed/libsass/color-names/error
@@ -1,0 +1,709 @@
+DEPRECATION WARNING on line 2 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#F0F8FF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FAEBD7 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#00FFFF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 5 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#7FFFD4 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#F0FFFF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#F5F5DC plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FFE4C4 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#000000 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FFEBCD plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#0000FF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#8A2BE2 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#A52A2A plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#DEB887 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#5F9EA0 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#7FFF00 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#D2691E plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FF7F50 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#6495ED plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FFF8DC plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#DC143C plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#00FFFF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#00008B plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#008B8B plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#B8860B plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#A9A9A9 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#006400 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#BDB76B plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#8B008B plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#556B2F plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FF8C00 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#9932CC plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#8B0000 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#E9967A plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#8FBC8F plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#483D8B plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#2F4F4F plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#00CED1 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#9400D3 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FF1493 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#00BFFF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 42 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#696969 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 43 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#1E90FF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 44 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#B22222 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 45 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FFFAF0 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 46 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#228B22 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 47 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FF00FF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 48 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#DCDCDC plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 49 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#F8F8FF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 50 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FFD700 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 51 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#DAA520 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 52 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#808080 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 53 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#008000 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 54 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#ADFF2F plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 55 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#F0FFF0 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 56 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FF69B4 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 57 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#CD5C5C plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 58 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#4B0082 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 59 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FFFFF0 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 60 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#F0E68C plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 61 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#E6E6FA plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 62 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FFF0F5 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 63 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#7CFC00 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 64 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FFFACD plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 65 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#ADD8E6 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 66 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#F08080 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 67 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#E0FFFF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 68 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FAFAD2 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 69 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#D3D3D3 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 70 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#90EE90 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 71 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FFB6C1 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 72 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FFA07A plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 73 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#20B2AA plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 74 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#87CEFA plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 75 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#778899 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 76 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#B0C4DE plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 77 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FFFFE0 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 78 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#00FF00 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 79 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#32CD32 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 80 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FAF0E6 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 81 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FF00FF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 82 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#800000 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 83 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#66CDAA plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 84 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#0000CD plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 85 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#BA55D3 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 86 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#9370DB plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 87 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#3CB371 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 88 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#7B68EE plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 89 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#00FA9A plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 90 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#48D1CC plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 91 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#C71585 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 92 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#191970 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 93 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#F5FFFA plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 94 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FFE4E1 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 95 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FFE4B5 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 96 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FFDEAD plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 97 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#000080 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 98 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FDF5E6 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 99 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#808000 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 100 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#6B8E23 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 101 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FFA500 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 102 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FF4500 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 103 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#DA70D6 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 104 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#EEE8AA plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 105 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#98FB98 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 106 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#AFEEEE plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 107 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#DB7093 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 108 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FFEFD5 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 109 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FFDAB9 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 110 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#CD853F plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 111 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FFC0CB plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 112 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#DDA0DD plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 113 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#B0E0E6 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 114 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#800080 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 115 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FF0000 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 116 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#BC8F8F plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 117 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#4169E1 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 118 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#8B4513 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 119 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FA8072 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 120 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#F4A460 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 121 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#2E8B57 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 122 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FFF5EE plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 123 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#A0522D plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 124 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#C0C0C0 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 125 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#87CEEB plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 126 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#6A5ACD plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 127 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#708090 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 128 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FFFAFA plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 129 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#00FF7F plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 130 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#4682B4 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 131 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#D2B48C plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 132 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#008080 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 133 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#D8BFD8 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 134 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FF6347 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 135 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#40E0D0 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 136 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#EE82EE plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 137 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#F5DEB3 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 138 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FFFFFF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 139 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#F5F5F5 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 140 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#FFFF00 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 141 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#9ACD32 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 142 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `#663399 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 143 of /sass/spec/output_styles/compressed/libsass/color-names/input.scss:
+The operation `transparent plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions

--- a/spec/output_styles/compressed/libsass/test/error
+++ b/spec/output_styles/compressed/libsass/test/error
@@ -1,0 +1,9 @@
+DEPRECATION WARNING on line 51 of /sass/spec/output_styles/compressed/libsass/test/input.scss:
+The operation `red plus green` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 52 of /sass/spec/output_styles/compressed/libsass/test/input.scss:
+The operation `red plus green` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions

--- a/spec/output_styles/nested/basic/16_hex_arithmetic/error
+++ b/spec/output_styles/nested/basic/16_hex_arithmetic/error
@@ -1,0 +1,94 @@
+DEPRECATION WARNING on line 5 of /sass/spec/output_styles/nested/basic/16_hex_arithmetic/input.scss:
+The operation `#AbC plus 1` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/nested/basic/16_hex_arithmetic/input.scss:
+The operation `#AbC plus #001` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/nested/basic/16_hex_arithmetic/input.scss:
+The operation `#0000ff plus 1` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/nested/basic/16_hex_arithmetic/input.scss:
+The operation `#0000ff plus #000001` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/nested/basic/16_hex_arithmetic/input.scss:
+The operation `#00ffff plus #000101` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/nested/basic/16_hex_arithmetic/input.scss:
+The operation `#000000 minus 1` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/nested/basic/16_hex_arithmetic/input.scss:
+The operation `#000000 minus #000001` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/nested/basic/16_hex_arithmetic/input.scss:
+The operation `#ffff00 plus #010100` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/nested/basic/16_hex_arithmetic/input.scss:
+The operation `#101010 div 7` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/nested/basic/16_hex_arithmetic/input.scss:
+The operation `#000 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/nested/basic/16_hex_arithmetic/input.scss:
+The operation `10 minus #a2B` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/nested/basic/16_hex_arithmetic/input.scss:
+The operation `10 minus #aa22BB` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/nested/basic/16_hex_arithmetic/input.scss:
+The operation `#000 minus #001` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/nested/basic/16_hex_arithmetic/input.scss:
+The operation `#f0F plus #101` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/nested/basic/16_hex_arithmetic/input.scss:
+The operation `#a2B plus 1` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/nested/basic/16_hex_arithmetic/input.scss:
+The operation `10 div #a2B` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/nested/basic/16_hex_arithmetic/input.scss:
+The operation `10 div #aa22BB` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/nested/basic/16_hex_arithmetic/input.scss:
+The operation `#0a0a0a plus #010001` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/nested/basic/16_hex_arithmetic/input.scss:
+The operation `#010000 plus white` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions

--- a/spec/output_styles/nested/basic/22_colors_with_alpha/error
+++ b/spec/output_styles/nested/basic/22_colors_with_alpha/error
@@ -1,0 +1,4 @@
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/nested/basic/22_colors_with_alpha/input.scss:
+The operation `black plus #111` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions

--- a/spec/output_styles/nested/libsass-closed-issues/issue_1251/error
+++ b/spec/output_styles/nested/libsass-closed-issues/issue_1251/error
@@ -1,0 +1,4 @@
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/nested/libsass-issues/issue_1251/input.scss:
+The operation `red plus green` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions

--- a/spec/output_styles/nested/libsass/color-names/error
+++ b/spec/output_styles/nested/libsass/color-names/error
@@ -1,0 +1,709 @@
+DEPRECATION WARNING on line 2 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#F0F8FF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FAEBD7 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 4 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#00FFFF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 5 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#7FFFD4 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 6 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#F0FFFF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 7 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#F5F5DC plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 8 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FFE4C4 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 9 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#000000 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 10 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FFEBCD plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 11 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#0000FF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 12 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#8A2BE2 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 13 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#A52A2A plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 14 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#DEB887 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 15 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#5F9EA0 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 16 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#7FFF00 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#D2691E plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 18 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FF7F50 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 19 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#6495ED plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 20 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FFF8DC plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 21 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#DC143C plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 22 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#00FFFF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 23 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#00008B plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 24 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#008B8B plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 25 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#B8860B plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 26 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#A9A9A9 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 27 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#006400 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 28 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#BDB76B plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#8B008B plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 30 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#556B2F plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 31 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FF8C00 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 32 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#9932CC plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 33 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#8B0000 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 34 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#E9967A plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 35 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#8FBC8F plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 36 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#483D8B plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 37 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#2F4F4F plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 38 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#00CED1 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 39 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#9400D3 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 40 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FF1493 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 41 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#00BFFF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 42 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#696969 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 43 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#1E90FF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 44 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#B22222 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 45 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FFFAF0 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 46 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#228B22 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 47 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FF00FF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 48 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#DCDCDC plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 49 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#F8F8FF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 50 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FFD700 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 51 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#DAA520 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 52 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#808080 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 53 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#008000 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 54 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#ADFF2F plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 55 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#F0FFF0 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 56 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FF69B4 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 57 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#CD5C5C plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 58 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#4B0082 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 59 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FFFFF0 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 60 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#F0E68C plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 61 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#E6E6FA plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 62 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FFF0F5 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 63 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#7CFC00 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 64 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FFFACD plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 65 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#ADD8E6 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 66 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#F08080 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 67 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#E0FFFF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 68 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FAFAD2 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 69 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#D3D3D3 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 70 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#90EE90 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 71 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FFB6C1 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 72 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FFA07A plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 73 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#20B2AA plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 74 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#87CEFA plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 75 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#778899 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 76 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#B0C4DE plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 77 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FFFFE0 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 78 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#00FF00 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 79 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#32CD32 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 80 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FAF0E6 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 81 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FF00FF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 82 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#800000 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 83 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#66CDAA plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 84 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#0000CD plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 85 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#BA55D3 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 86 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#9370DB plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 87 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#3CB371 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 88 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#7B68EE plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 89 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#00FA9A plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 90 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#48D1CC plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 91 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#C71585 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 92 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#191970 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 93 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#F5FFFA plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 94 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FFE4E1 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 95 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FFE4B5 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 96 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FFDEAD plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 97 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#000080 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 98 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FDF5E6 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 99 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#808000 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 100 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#6B8E23 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 101 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FFA500 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 102 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FF4500 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 103 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#DA70D6 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 104 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#EEE8AA plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 105 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#98FB98 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 106 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#AFEEEE plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 107 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#DB7093 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 108 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FFEFD5 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 109 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FFDAB9 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 110 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#CD853F plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 111 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FFC0CB plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 112 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#DDA0DD plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 113 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#B0E0E6 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 114 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#800080 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 115 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FF0000 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 116 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#BC8F8F plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 117 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#4169E1 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 118 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#8B4513 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 119 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FA8072 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 120 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#F4A460 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 121 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#2E8B57 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 122 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FFF5EE plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 123 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#A0522D plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 124 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#C0C0C0 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 125 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#87CEEB plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 126 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#6A5ACD plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 127 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#708090 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 128 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FFFAFA plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 129 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#00FF7F plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 130 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#4682B4 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 131 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#D2B48C plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 132 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#008080 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 133 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#D8BFD8 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 134 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FF6347 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 135 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#40E0D0 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 136 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#EE82EE plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 137 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#F5DEB3 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 138 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FFFFFF plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 139 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#F5F5F5 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 140 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#FFFF00 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 141 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#9ACD32 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 142 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `#663399 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 143 of /sass/spec/output_styles/nested/libsass/color-names/input.scss:
+The operation `transparent plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions

--- a/spec/output_styles/nested/libsass/test/error
+++ b/spec/output_styles/nested/libsass/test/error
@@ -1,0 +1,9 @@
+DEPRECATION WARNING on line 51 of /sass/spec/output_styles/nested/libsass/test/input.scss:
+The operation `red plus green` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 52 of /sass/spec/output_styles/nested/libsass/test/input.scss:
+The operation `red plus green` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions

--- a/spec/output_styles/nested/scss/color_output/error
+++ b/spec/output_styles/nested/scss/color_output/error
@@ -1,0 +1,14 @@
+DEPRECATION WARNING on line 3 of /sass/spec/output_styles/nested/scss/color_output/input.scss:
+The operation `#00FF00 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 17 of /sass/spec/output_styles/nested/scss/color_output/input.scss:
+The operation `#00FF00 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
+
+DEPRECATION WARNING on line 29 of /sass/spec/output_styles/nested/scss/color_output/input.scss:
+The operation `#00FF00 plus 0` is deprecated and will be an error in future versions.
+Consider using Sass's color functions instead.
+http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions


### PR DESCRIPTION
[skip libsass]

- update output style specs, that only libsass runs, with the deprecation warning