### PR TITLE
Fetch the pull request body using @sassbot's credentials

### DIFF
--- a/tools/skipped-for-impl.sh
+++ b/tools/skipped-for-impl.sh
@@ -14,7 +14,15 @@ fi
 
 >&2 echo "Fetching pull request $TRAVIS_PULL_REQUEST..."
 
-JSON=$(curl -L -sS https://api.github.com/repos/sass/sass-spec/pulls/$TRAVIS_PULL_REQUEST)
+url=https://api.github.com/repos/sass/sass-spec/pulls/$TRAVIS_PULL_REQUEST
+if [ -z "$GITHUB_AUTH" ]; then
+    >&2 echo "Fetching pull request info without authentication"
+    JSON=$(curl -L -sS $url)
+else
+    >&2 echo "Fetching pull request info as sassbot"
+    JSON=$(curl -u "sassbot:$GITHUB_AUTH" -L -sS $url)
+fi
+>&2 echo "$JSON"
 
 RE_SKIP="[Ss]kip\>[a-z, -]*\<$IMPL"
 if [[ $JSON =~ $RE_SKIP ]]; then


### PR DESCRIPTION
This avoids running into GitHub's low rate limits for unauthenticated
requests.