### PR TITLE
Fix a Ruby Sass breakage

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/sass/ruby-sass.git
-  revision: 2142138abddaf380ba8142d31bf66c361bbda5a3
+  revision: 8b77fc88f8bdbc21b44d0a5be7833d91a5edb04c
   branch: stable
   specs:
-    sass (3.5.6)
+    sass (3.5.7)
       sass-listen (~> 4.0.0)
 
 PATH
@@ -21,9 +21,9 @@ GEM
     colored (1.2)
     command_line_reporter (3.3.6)
       colored (>= 1.2)
-    diffy (3.1.0)
-    ffi (1.9.23)
-    minitest (5.10.1)
+    diffy (3.2.1)
+    ffi (1.9.25)
+    minitest (5.11.3)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)

--- a/spec/mixin/error/no_content/error-ruby-sass
+++ b/spec/mixin/error/no_content/error-ruby-sass
@@ -1,0 +1,4 @@
+Error: Mixin "no-content" does not accept a content block.
+        on line 3 of /sass/spec/mixin/error/no_content/input.scss, in `no-content'
+        from line 3 of /sass/spec/mixin/error/no_content/input.scss
+  Use --trace for backtrace.


### PR DESCRIPTION
Ruby Sass generates a slightly different error than Dart Sass, so it
needs its own expected error file.