### PR TITLE
Add a regression test case for :nth-child() with extra whitespace

### DIFF
--- a/spec/libsass-closed-issues/issue_2346/expected_output-dart-sass.css
+++ b/spec/libsass-closed-issues/issue_2346/expected_output-dart-sass.css
@@ -1,0 +1,3 @@
+li:nth-child(3n-3) {
+  color: red;
+}

--- a/spec/libsass/css_nth_selectors/expected_output-dart-sass.css
+++ b/spec/libsass/css_nth_selectors/expected_output-dart-sass.css
@@ -1,7 +1,7 @@
-:nth-child(2n + 3) {
+:nth-child(2n+3) {
   outer-whitespace: false;
 }
 
-:nth-child(2n + 3) {
+:nth-child(2n+3) {
   outer-whitespace: true;
 }

--- a/spec/libsass/css_nth_selectors/input.scss
+++ b/spec/libsass/css_nth_selectors/input.scss
@@ -1,2 +1,8 @@
 :nth-child(2n + 3) {
-  a: b; }
+  outer-whitespace: false;
+}
+
+// Regression test for sass/dart-sass#465.
+:nth-child( 2n + 3 ) {
+  outer-whitespace: true;
+}


### PR DESCRIPTION
Also update the expected :nth-child() output for Dart Sass to match
the new behavior.

See sass/dart-sass#465

[skip dart-sass]