### PR TITLE
Properly escape U+001F as unprintable

### DIFF
--- a/spec/values/identifiers/escape/normalize/expected_output.css
+++ b/spec/values/identifiers/escape/normalize/expected_output.css
@@ -7,7 +7,7 @@
   name-char-at-start: \-x \-x;
   digit-in-middle: a1x a1x;
   digit-at-start: \31 x \31 x;
-  non-printable: \0 x \1 x \2 x \3 x \4 x \5 x \6 x \7 x \8 x \b x \e x \f x \10 x \11 x \12 x \13 x \14 x \15 x \16 x \17 x \18 x \19 x \1a x \1b x \1c x \1d x \1e x \x \7f x;
+  non-printable: \0 x \1 x \2 x \3 x \4 x \5 x \6 x \7 x \8 x \b x \e x \f x \10 x \11 x \12 x \13 x \14 x \15 x \16 x \17 x \18 x \19 x \1a x \1b x \1c x \1d x \1e x \1f x \7f x;
   newline: \a x \c x \d x;
   name-char-interpolation-beginning: \-foo;
   name-char-interpolation-middle: foo-bar;


### PR DESCRIPTION
Closes #1287

[skip dart-sass]