### PR TITLE
Fix "compound selectors may *no* longer be extended" error message

### DIFF
--- a/spec/extend-tests/094_test_long_extendee_runs_unification/error-dart-sass
+++ b/spec/extend-tests/094_test_long_extendee_runs_unification/error-dart-sass
@@ -1,4 +1,4 @@
-Error: compound selectors may longer be extended.
+Error: compound selectors may no longer be extended.
 Consider `@extend .foo, .bar` instead.
 See http://bit.ly/ExtendCompound for details.
 


### PR DESCRIPTION
See https://github.com/sass/dart-sass/pull/576

[skip dart-sass]