### PR TITLE
Update specs for Dart Sass errors

### DIFF
--- a/spec/css/custom_properties/error/unmatched_brackets/curly/error-dart-sass
+++ b/spec/css/custom_properties/error/unmatched_brackets/curly/error-dart-sass
@@ -1,6 +1,6 @@
 Error: expected "{".
   ,
-3 | }
-  | ^
+2 |   --prop: };
+  |             ^
   '
-  /sass/spec/css/custom_properties/error/unmatched_brackets/curly/input.scss 3:1  root stylesheet
+  /sass/spec/css/custom_properties/error/unmatched_brackets/curly/input.scss 2:13  root stylesheet

--- a/spec/libsass-closed-issues/issue_1484/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_1484/error-dart-sass
@@ -1,6 +1,6 @@
 Error: expected "{".
   ,
-2 | 
-  | ^
+1 | div {
+  |      ^
   '
-  /sass/spec/libsass-issues/issue_1484/input.scss 2:1  root stylesheet
+  /sass/spec/libsass-issues/issue_1484/input.scss 1:6  root stylesheet

--- a/spec/libsass-closed-issues/issue_2307/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_2307/error-dart-sass
@@ -1,6 +1,6 @@
 Error: expected "{".
   ,
-3 | 
-  | ^
+2 | {
+  |  ^
   '
-  /sass/spec/libsass-issues/issue_2307/input.scss 3:1  root stylesheet
+  /sass/spec/libsass-issues/issue_2307/input.scss 2:2  root stylesheet

--- a/spec/libsass-closed-issues/issue_2371/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_2371/error-dart-sass
@@ -1,6 +1,6 @@
 Error: expected "{".
   ,
-2 | 
-  | ^
+1 | #{a==b}
+  |        ^
   '
-  /sass/spec/libsass-issues/issue_2371/input.scss 2:1  root stylesheet
+  /sass/spec/libsass-issues/issue_2371/input.scss 1:8  root stylesheet

--- a/spec/libsass-closed-issues/issue_2569/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_2569/error-dart-sass
@@ -1,6 +1,6 @@
 Error: expected "@".
   ,
-5 |     opacity: 1;
-  |     ^
+4 |   } @else {
+  |            ^
   '
-  /sass/spec/libsass-issues/issue_2569/input.scss 5:5  root stylesheet
+  /sass/spec/libsass-issues/issue_2569/input.scss 4:12  root stylesheet

--- a/spec/libsass-todo-issues/issue_1720/error-dart-sass
+++ b/spec/libsass-todo-issues/issue_1720/error-dart-sass
@@ -1,6 +1,6 @@
 Error: expected "{".
   ,
-4 | 
-  | ^
+3 | }
+  |  ^
   '
-  /sass/spec/libsass-issues/issue_1720/input.scss 4:1  root stylesheet
+  /sass/spec/libsass-issues/issue_1720/input.scss 3:2  root stylesheet


### PR DESCRIPTION
This adjusts specs for errors that of the form "expected ____" that
are detected at the end of the file, but should be printed as pointing
after the previous non-whitespace character.

[skip dart-sass]