### PR TITLE
Update specs for Dart Sass errors

### DIFF
--- a/spec/errors/unicode/report/before/error-dart-sass
+++ b/spec/errors/unicode/report/before/error-dart-sass
@@ -1,4 +1,4 @@
-Error: expected "{".
+Error: expected "}".
   ,
 1 | öüäöüäöü{a:c
   |             ^

--- a/spec/libsass-closed-issues/issue_1484/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_1484/error-dart-sass
@@ -1,4 +1,4 @@
-Error: expected "{".
+Error: expected "}".
   ,
 1 | div {
   |      ^

--- a/spec/libsass-closed-issues/issue_2307/error-dart-sass
+++ b/spec/libsass-closed-issues/issue_2307/error-dart-sass
@@ -1,4 +1,4 @@
-Error: expected "{".
+Error: expected "}".
   ,
 2 | {
   |  ^

--- a/spec/libsass-todo-issues/issue_1720/error-dart-sass
+++ b/spec/libsass-todo-issues/issue_1720/error-dart-sass
@@ -1,4 +1,4 @@
-Error: expected "{".
+Error: expected "}".
   ,
 3 | }
   |  ^


### PR DESCRIPTION
This updates specs that used to say they expected a "{" to (more
sensibly) say they expect a "}".

[skip dart-sass]