### PR TITLE
Update a Dart Sass error spec for the @use parser

### DIFF
--- a/spec/libsass-todo-issues/issue_2016/error-dart-sass
+++ b/spec/libsass-todo-issues/issue_2016/error-dart-sass
@@ -1,4 +1,4 @@
-Error: Expected digit.
+Error: Expected identifier.
   ,
 1 | $_: ___((Classes and IDs must follow a specific grammar. And this thing here doesn’t.));
   |                                                         ^


### PR DESCRIPTION
[skip dart-sass]