### PR TITLE
Add a spec for bubbling an empty @keyframes rule

### DIFF
--- a/spec/css/keyframes.hrx
+++ b/spec/css/keyframes.hrx
@@ -1,0 +1,10 @@
+<===> bubble/empty/input.scss
+// Regression test for sass/dart-sass#611.
+a {
+  @keyframes {/**/}
+}
+
+<===> bubble/empty/output.css
+@keyframes {
+  /**/
+}


### PR DESCRIPTION
See sass/dart-sass#611

[skip dart-sass]