### PR TITLE
Fix --test-probe

### DIFF
--- a/lib/sass_spec/runner.rb
+++ b/lib/sass_spec/runner.rb
@@ -60,10 +60,10 @@ class SassSpec::Runner
       passing = []
       test_cases.each do |test_case|
         if test_case.todo? && test_case.result?
-          passing << test_case.folder
+          passing << test_case.dir.to_s
         end
       end
-      if passing.any?
+      if !passing.empty?
         puts "The following tests pass but were marked as TODO for #{@options[:engine_adapter].describe}:"
         puts passing.join("\n")
       else

--- a/spec/libsass/Sáss-UŢF8.hrx
+++ b/spec/libsass/Sáss-UŢF8.hrx
@@ -1,9 +1,0 @@
-<===> input.scss
-span.utf8-in-path {
-  margin: auto;
-}
-
-<===> output.css
-span.utf8-in-path {
-  margin: auto;
-}

--- a/spec/libsass/Sáss-UŢF8/input.scss
+++ b/spec/libsass/Sáss-UŢF8/input.scss
@@ -1,0 +1,4 @@
+// TODO: Re-HRXify this test once https://github.com/sass/libsass/issues/2854 has been resolved.
+span.utf8-in-path {
+  margin: auto;
+}

--- a/spec/libsass/Sáss-UŢF8/output.css
+++ b/spec/libsass/Sáss-UŢF8/output.css
@@ -1,0 +1,3 @@
+span.utf8-in-path {
+  margin: auto;
+}

--- a/spec/libsass/Sáss-UŢF8.hrx
+++ b/spec/libsass/Sáss-UŢF8.hrx
@@ -1,9 +1,0 @@
-<===> input.scss
-span.utf8-in-path {
-  margin: auto;
-}
-
-<===> output.css
-span.utf8-in-path {
-  margin: auto;
-}

--- a/spec/libsass/Sáss-UŢF8/input.scss
+++ b/spec/libsass/Sáss-UŢF8/input.scss
@@ -1,0 +1,4 @@
+// TODO: Re-HRXify this test once https://github.com/sass/libsass/issues/2854 has been resolved.
+span.utf8-in-path {
+  margin: auto;
+}

--- a/spec/libsass/Sáss-UŢF8/output.css
+++ b/spec/libsass/Sáss-UŢF8/output.css
@@ -1,0 +1,3 @@
+span.utf8-in-path {
+  margin: auto;
+}


### PR DESCRIPTION
1. Changes `folder` to `dir.to_s` (`folder` no longer exists).
2. Changes `passing.any?` to `!passing.empty?`, as `any?` has pitfalls:
   Took me a few minutes to debug when I tried with `input_path` instead of `dir.to_s`, and that was returning `nil` (`[nil].any? #=> false`).