### PR TITLE
Revert "De-HRX libsass/Sáss-UŢF8 and libsass/Sáss-UŢF8"

### DIFF
--- a/spec/libsass/Sáss-UŢF8.hrx
+++ b/spec/libsass/Sáss-UŢF8.hrx
@@ -1,0 +1,9 @@
+<===> input.scss
+span.utf8-in-path {
+  margin: auto;
+}
+
+<===> output.css
+span.utf8-in-path {
+  margin: auto;
+}

--- a/spec/libsass/Sáss-UŢF8/input.scss
+++ b/spec/libsass/Sáss-UŢF8/input.scss
@@ -1,4 +1,0 @@
-// TODO: Re-HRXify this test once https://github.com/sass/libsass/issues/2854 has been resolved.
-span.utf8-in-path {
-  margin: auto;
-}

--- a/spec/libsass/Sáss-UŢF8/output.css
+++ b/spec/libsass/Sáss-UŢF8/output.css
@@ -1,3 +1,0 @@
-span.utf8-in-path {
-  margin: auto;
-}

--- a/spec/libsass/Sáss-UŢF8.hrx
+++ b/spec/libsass/Sáss-UŢF8.hrx
@@ -1,0 +1,9 @@
+<===> input.scss
+span.utf8-in-path {
+  margin: auto;
+}
+
+<===> output.css
+span.utf8-in-path {
+  margin: auto;
+}

--- a/spec/libsass/Sáss-UŢF8/input.scss
+++ b/spec/libsass/Sáss-UŢF8/input.scss
@@ -1,4 +1,0 @@
-// TODO: Re-HRXify this test once https://github.com/sass/libsass/issues/2854 has been resolved.
-span.utf8-in-path {
-  margin: auto;
-}

--- a/spec/libsass/Sáss-UŢF8/output.css
+++ b/spec/libsass/Sáss-UŢF8/output.css
@@ -1,3 +1,0 @@
-span.utf8-in-path {
-  margin: auto;
-}


### PR DESCRIPTION
This reverts commit 368cfed2dfecc43245fccdb457b0f8c54dee94f1.

The non-HRX versions of these tests now live in the libsass repo (as of https://github.com/sass/libsass/pull/2855)