### PR TITLE
Add test for nested `&.:not`

### DIFF
--- a/spec/nesting/not.hrx
+++ b/spec/nesting/not.hrx
@@ -1,0 +1,10 @@
+<===> multiple_parent_selectors_with_trailing_ident/input.scss
+// Regression test for sass/libsass#2630
+.a, .b {
+  :not(&-c) {d: e}
+}
+
+<===> multiple_parent_selectors_with_trailing_ident/output.css
+:not(.a-c, .b-c) {
+  d: e;
+}


### PR DESCRIPTION
Refs https://github.com/sass/libsass/issues/2630