### PR TITLE
Add specs for built-in modules

### DIFF
--- a/spec/core_functions/modules/README.md
+++ b/spec/core_functions/modules/README.md
@@ -1,0 +1,8 @@
+This directory tests that core functions are accessible from the `sass:` modules
+as defined in [the module system proposal][]. For the time being, it just tests
+that each individual function is accessible with the correct name, and that
+removed or renamed functions are not accessible. Once all implementations
+support the module system, we should migrate all the function tests to use
+module functions and just have simple tests for the global versions instead.
+
+[the module system proposal]: https://github.com/sass/sass/blob/master/accepted/module-system.md#built-in-modules-1

--- a/spec/core_functions/modules/color.hrx
+++ b/spec/core_functions/modules/color.hrx
@@ -1,0 +1,464 @@
+<===> red/input.scss
+@use "sass:color";
+a {b: color.red(#abcdef)}
+
+<===> red/output.css
+a {
+  b: 171;
+}
+
+<===>
+================================================================================
+<===> green/input.scss
+@use "sass:color";
+a {b: color.green(#abcdef)}
+
+<===> green/output.css
+a {
+  b: 205;
+}
+
+<===>
+================================================================================
+<===> blue/input.scss
+@use "sass:color";
+a {b: color.blue(#abcdef)}
+
+<===> blue/output.css
+a {
+  b: 239;
+}
+
+<===>
+================================================================================
+<===> hue/input.scss
+@use "sass:color";
+a {b: color.hue(#abcdef)}
+
+<===> hue/output.css
+a {
+  b: 210deg;
+}
+
+<===>
+================================================================================
+<===> saturation/input.scss
+@use "sass:color";
+a {b: color.saturation(#abcdef)}
+
+<===> saturation/output.css
+a {
+  b: 68%;
+}
+
+<===>
+================================================================================
+<===> lightness/input.scss
+@use "sass:color";
+a {b: color.lightness(#abcdef)}
+
+<===> lightness/output.css
+a {
+  b: 80.3921568627%;
+}
+
+<===>
+================================================================================
+<===> mix/input.scss
+@use "sass:color";
+a {b: color.mix(#abcdef, #daddee)}
+
+<===> mix/output.css
+a {
+  b: #c3d5ef;
+}
+
+<===>
+================================================================================
+<===> adjust_hue/input.scss
+@use "sass:color";
+a {b: color.adjust-hue(#abcdef, 15)}
+
+<===> adjust_hue/output.css
+a {
+  b: #abbcef;
+}
+
+<===>
+================================================================================
+<===> complement/input.scss
+@use "sass:color";
+a {b: color.complement(#abcdef)}
+
+<===> complement/output.css
+a {
+  b: #efcdab;
+}
+
+<===>
+================================================================================
+<===> invert/input.scss
+@use "sass:color";
+a {b: color.invert(#abcdef)}
+
+<===> invert/output.css
+a {
+  b: #543210;
+}
+
+<===>
+================================================================================
+<===> alpha/input.scss
+@use "sass:color";
+a {b: color.alpha(#abcdef)}
+
+<===> alpha/output.css
+a {
+  b: 1;
+}
+
+<===>
+================================================================================
+<===> adjust/input.scss
+@use "sass:color";
+a {b: color.adjust(#abcdef, $red: 10)}
+
+<===> adjust/output.css
+a {
+  b: #b5cdef;
+}
+
+<===>
+================================================================================
+<===> scale/input.scss
+@use "sass:color";
+a {b: color.scale(#abcdef, $red: 10%)}
+
+<===> scale/output.css
+a {
+  b: #b3cdef;
+}
+
+<===>
+================================================================================
+<===> change/input.scss
+@use "sass:color";
+a {b: color.change(#abcdef, $red: 10)}
+
+<===> change/output.css
+a {
+  b: #0acdef;
+}
+
+<===>
+================================================================================
+<===> ie_hex_str/input.scss
+@use "sass:color";
+a {b: color.ie-hex-str(#abcdef)}
+
+<===> ie_hex_str/output.css
+a {
+  b: #FFABCDEF;
+}
+
+<===>
+================================================================================
+<===> css_overloads/README.md
+CSS overloads are still supported for module functions to ease the transition,
+but they should produce deprecation warnings.
+
+<===>
+================================================================================
+<===> css_overloads/grayscale/input.scss
+@use "sass:color";
+a {b: color.grayscale(1)}
+
+<===> css_overloads/grayscale/output.css
+a {
+  b: grayscale(1);
+}
+
+<===> css_overloads/grayscale/warning
+WARNING: Passing a number to color.grayscale() is deprecated.
+
+Recommendation: grayscale(1)
+
+  ,
+2 | a {b: color.grayscale(1)}
+  |       ^^^^^^^^^^^^^^^^^^
+  '
+    input.scss 2:7  root stylesheet
+
+<===>
+================================================================================
+<===> css_overloads/invert/input.scss
+@use "sass:color";
+a {b: color.invert(1)}
+
+<===> css_overloads/invert/output.css
+a {
+  b: invert(1);
+}
+
+<===> css_overloads/invert/warning
+WARNING: Passing a number to color.invert() is deprecated.
+
+Recommendation: invert(1)
+
+  ,
+2 | a {b: color.invert(1)}
+  |       ^^^^^^^^^^^^^^^
+  '
+    input.scss 2:7  root stylesheet
+
+<===>
+================================================================================
+<===> css_overloads/alpha/one_arg/input.scss
+@use "sass:color";
+a {b: color.alpha(c=d)}
+
+<===> css_overloads/alpha/one_arg/output.css
+a {
+  b: alpha(c=d);
+}
+
+<===> css_overloads/alpha/one_arg/warning
+WARNING: Using color.alpha() for a Microsoft filter is deprecated.
+
+Recommendation: alpha(c=d)
+
+  ,
+2 | a {b: color.alpha(c=d)}
+  |       ^^^^^^^^^^^^^^^^
+  '
+    input.scss 2:7  root stylesheet
+
+<===>
+================================================================================
+<===> css_overloads/alpha/multi_arg/input.scss
+@use "sass:color";
+a {b: color.alpha(c=d, e=f, g=h)}
+
+<===> css_overloads/alpha/multi_arg/output.css
+a {
+  b: alpha(c=d, e=f, g=h);
+}
+
+<===> css_overloads/alpha/multi_arg/warning
+WARNING: Using color.alpha() for a Microsoft filter is deprecated.
+
+Recommendation: alpha(c=d, e=f, g=h)
+
+  ,
+2 | a {b: color.alpha(c=d, e=f, g=h)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+    input.scss 2:7  root stylesheet
+
+<===>
+================================================================================
+<===> css_overloads/opacity/input.scss
+@use "sass:color";
+a {b: color.opacity(1)}
+
+<===> css_overloads/opacity/output.css
+a {
+  b: opacity(1);
+}
+
+<===> css_overloads/opacity/warning
+WARNING: Passing a number to color.opacity() is deprecated.
+
+Recommendation: opacity(1)
+
+  ,
+2 | a {b: color.opacity(1)}
+  |       ^^^^^^^^^^^^^^^^
+  '
+    input.scss 2:7  root stylesheet
+
+<===>
+================================================================================
+<===> error/adjust_color/input.scss
+@use "sass:color";
+a {b: color.adjust-color(#abcdef, $red: 10)}
+
+<===> error/adjust_color/error
+Error: Undefined function.
+  ,
+2 | a {b: color.adjust-color(#abcdef, $red: 10)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet
+
+<===>
+================================================================================
+<===> error/scale_color/input.scss
+@use "sass:color";
+a {b: color.scale-color(#abcdef, $red: 10%)}
+
+<===> error/scale_color/error
+Error: Undefined function.
+  ,
+2 | a {b: color.scale-color(#abcdef, $red: 10%)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet
+
+<===>
+================================================================================
+<===> error/change_color/input.scss
+@use "sass:color";
+a {b: color.change-color(#abcdef, $red: 10)}
+
+<===> error/change_color/error
+Error: Undefined function.
+  ,
+2 | a {b: color.change-color(#abcdef, $red: 10)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet
+
+<===>
+================================================================================
+<===> error/lighten/input.scss
+@use "sass:color";
+a {b: color.lighten(#abcdef, 10%)}
+
+<===> error/lighten/error
+Error: The function lighten() isn't in the new module system.
+
+Recommendation: color.adjust(#abcdef, $lightness: 10%)
+
+More info: https://sass-lang.com/documentation/functions/color#lighten
+  ,
+2 | a {b: color.lighten(#abcdef, 10%)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet
+
+<===>
+================================================================================
+<===> error/darken/input.scss
+@use "sass:color";
+a {b: color.darken(#abcdef, 10%)}
+
+<===> error/darken/error
+Error: The function darken() isn't in the new module system.
+
+Recommendation: color.adjust(#abcdef, $lightness: -10%)
+
+More info: https://sass-lang.com/documentation/functions/color#darken
+  ,
+2 | a {b: color.darken(#abcdef, 10%)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet
+
+<===>
+================================================================================
+<===> error/saturate/input.scss
+@use "sass:color";
+a {b: color.saturate(#abcdef, 10%)}
+
+<===> error/saturate/error
+Error: The function saturate() isn't in the new module system.
+
+Recommendation: color.adjust(#abcdef, $saturation: 10%)
+
+More info: https://sass-lang.com/documentation/functions/color#saturate
+  ,
+2 | a {b: color.saturate(#abcdef, 10%)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet
+
+<===>
+================================================================================
+<===> error/desaturate/input.scss
+@use "sass:color";
+a {b: color.desaturate(#abcdef, 10%)}
+
+<===> error/desaturate/error
+Error: The function desaturate() isn't in the new module system.
+
+Recommendation: color.adjust(#abcdef, $saturation: -10%)
+
+More info: https://sass-lang.com/documentation/functions/color#desaturate
+  ,
+2 | a {b: color.desaturate(#abcdef, 10%)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet
+
+<===>
+================================================================================
+<===> error/opacify/input.scss
+@use "sass:color";
+a {b: color.opacify(#abcdef, 0.5)}
+
+<===> error/opacify/error
+Error: The function opacify() isn't in the new module system.
+
+Recommendation: color.adjust(#abcdef, $alpha: 0.5)
+
+More info: https://sass-lang.com/documentation/functions/color#opacify
+  ,
+2 | a {b: color.opacify(#abcdef, 0.5)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet
+
+<===>
+================================================================================
+<===> error/fade_in/input.scss
+@use "sass:color";
+a {b: color.fade-in(#abcdef, 0.5)}
+
+<===> error/fade_in/error
+Error: The function fade-in() isn't in the new module system.
+
+Recommendation: color.adjust(#abcdef, $alpha: 0.5)
+
+More info: https://sass-lang.com/documentation/functions/color#fade-in
+  ,
+2 | a {b: color.fade-in(#abcdef, 0.5)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet
+
+<===>
+================================================================================
+<===> error/transparentize/input.scss
+@use "sass:color";
+a {b: color.transparentize(#abcdef, 0.5)}
+
+<===> error/transparentize/error
+Error: The function transparentize() isn't in the new module system.
+
+Recommendation: color.adjust(#abcdef, $alpha: -0.5)
+
+More info: https://sass-lang.com/documentation/functions/color#transparentize
+  ,
+2 | a {b: color.transparentize(#abcdef, 0.5)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet
+
+<===>
+================================================================================
+<===> error/fade_out/input.scss
+@use "sass:color";
+a {b: color.fade-out(#abcdef, 0.5)}
+
+<===> error/fade_out/error
+Error: The function fade-out() isn't in the new module system.
+
+Recommendation: color.adjust(#abcdef, $alpha: -0.5)
+
+More info: https://sass-lang.com/documentation/functions/color#fade-out
+  ,
+2 | a {b: color.fade-out(#abcdef, 0.5)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet

--- a/spec/core_functions/modules/general.hrx
+++ b/spec/core_functions/modules/general.hrx
@@ -1,0 +1,123 @@
+<===> global/input.scss
+@use "sass:math" as *;
+a {b: compatible(1px, 1in)}
+
+<===> global/output.css
+a {
+  b: true;
+}
+
+<===>
+================================================================================
+<===> as/input.scss
+@use "sass:math" as m;
+a {b: m.round(0.7)}
+
+<===> as/output.css
+a {
+  b: 1;
+}
+
+<===>
+================================================================================
+<===> error/set_variable/input.scss
+@use "sass:math";
+$math.a: b;
+
+<===> error/set_variable/error
+Error: Undefined variable.
+  ,
+2 | $math.a: b;
+  | ^^^^^^^^^^
+  '
+  input.scss 2:1  root stylesheet
+
+<===>
+================================================================================
+<===> forward/bare/input.scss
+@use "other";
+a {b: other.round(0.7)}
+
+<===> forward/bare/_other.scss
+@forward "sass:math";
+
+<===> forward/bare/output.css
+a {
+  b: 1;
+}
+
+<===>
+================================================================================
+<===> forward/show/input.scss
+@use "other";
+a {b: other.round(0.7)}
+
+<===> forward/show/_other.scss
+@forward "sass:math" show round;
+
+<===> forward/show/output.css
+a {
+  b: 1;
+}
+
+<===>
+================================================================================
+<===> forward/hide/input.scss
+@use "other";
+a {b: other.round(0.7)}
+
+<===> forward/hide/_other.scss
+@forward "sass:math" hide ceil;
+
+<===> forward/hide/output.css
+a {
+  b: 1;
+}
+
+<===>
+================================================================================
+<===> forward/as/input.scss
+@use "other";
+a {b: other.s-round(0.7)}
+
+<===> forward/as/_other.scss
+@forward "sass:math" as s-*;
+
+<===> forward/as/output.css
+a {
+  b: 1;
+}
+
+<===>
+================================================================================
+<===> forward/error/show/input.scss
+@use "other";
+a {b: other.round(0.7)}
+
+<===> forward/error/show/_other.scss
+@forward "sass:math" show ceil;
+
+<===> forward/error/show/error
+Error: Undefined function.
+  ,
+2 | a {b: other.round(0.7)}
+  |       ^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet
+
+<===>
+================================================================================
+<===> forward/error/hide/input.scss
+@use "other";
+a {b: other.round(0.7)}
+
+<===> forward/error/hide/_other.scss
+@forward "sass:math" hide round;
+
+<===> forward/error/hide/error
+Error: Undefined function.
+  ,
+2 | a {b: other.round(0.7)}
+  |       ^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet

--- a/spec/core_functions/modules/map.hrx
+++ b/spec/core_functions/modules/map.hrx
@@ -1,0 +1,151 @@
+<===> get/input.scss
+@use "sass:map";
+a {b: map.get((c: d), c)}
+
+<===> get/output.css
+a {
+  b: d;
+}
+
+<===>
+================================================================================
+<===> merge/input.scss
+@use "sass:map";
+@use "sass:meta";
+a {b: meta.inspect(map.merge((c: d), (e: f)))}
+
+<===> merge/output.css
+a {
+  b: (c: d, e: f);
+}
+
+<===>
+================================================================================
+<===> remove/input.scss
+@use "sass:map";
+@use "sass:meta";
+a {b: meta.inspect(map.remove((c: d), c))}
+
+<===> remove/output.css
+a {
+  b: ();
+}
+
+<===>
+================================================================================
+<===> keys/input.scss
+@use "sass:map";
+a {b: map.keys((c: d))}
+
+<===> keys/output.css
+a {
+  b: c;
+}
+
+<===>
+================================================================================
+<===> values/input.scss
+@use "sass:map";
+a {b: map.values((c: d))}
+
+<===> values/output.css
+a {
+  b: d;
+}
+
+<===>
+================================================================================
+<===> has_key/input.scss
+@use "sass:map";
+a {b: map.has-key((c: d), c)}
+
+<===> has_key/output.css
+a {
+  b: true;
+}
+
+<===>
+================================================================================
+<===> error/map_get/input.scss
+@use "sass:map";
+a {b: map.map-get((c: d), c)}
+
+<===> error/map_get/error
+Error: Undefined function.
+  ,
+2 | a {b: map.map-get((c: d), c)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet
+
+<===>
+================================================================================
+<===> error/map_merge/input.scss
+@use "sass:map";
+@use "sass:meta";
+a {b: meta.map-inspect(map.merge((c: d), (e: f)))}
+
+<===> error/map_merge/error
+Error: Undefined function.
+  ,
+3 | a {b: meta.map-inspect(map.merge((c: d), (e: f)))}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 3:7  root stylesheet
+
+<===>
+================================================================================
+<===> error/map_remove/input.scss
+@use "sass:map";
+@use "sass:meta";
+a {b: meta.map-inspect(map.remove((c: d), c))}
+
+<===> error/map_remove/error
+Error: Undefined function.
+  ,
+3 | a {b: meta.map-inspect(map.remove((c: d), c))}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 3:7  root stylesheet
+
+<===>
+================================================================================
+<===> error/map_keys/input.scss
+@use "sass:map";
+a {b: map.map-keys((c: d))}
+
+<===> error/map_keys/error
+Error: Undefined function.
+  ,
+2 | a {b: map.map-keys((c: d))}
+  |       ^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet
+
+<===>
+================================================================================
+<===> error/map_values/input.scss
+@use "sass:map";
+a {b: map.map-values((c: d), c)}
+
+<===> error/map_values/error
+Error: Undefined function.
+  ,
+2 | a {b: map.map-values((c: d), c)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet
+
+<===>
+================================================================================
+<===> error/map_has_key/input.scss
+@use "sass:map";
+a {b: map.map-has-key((c: d), c)}
+
+<===> error/map_has_key/error
+Error: Undefined function.
+  ,
+2 | a {b: map.map-has-key((c: d), c)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet

--- a/spec/core_functions/modules/math.hrx
+++ b/spec/core_functions/modules/math.hrx
@@ -1,0 +1,147 @@
+<===> percentage/input.scss
+@use "sass:math";
+a {b: math.percentage(0.5)}
+
+<===> percentage/output.css
+a {
+  b: 50%;
+}
+
+
+<===>
+================================================================================
+<===> round/input.scss
+@use "sass:math";
+a {b: math.round(0.5)}
+
+<===> round/output.css
+a {
+  b: 1;
+}
+
+<===>
+================================================================================
+<===> ceil/input.scss
+@use "sass:math";
+a {b: math.ceil(0.5)}
+
+<===> ceil/output.css
+a {
+  b: 1;
+}
+
+<===>
+================================================================================
+<===> floor/input.scss
+@use "sass:math";
+a {b: math.floor(0.5)}
+
+<===> floor/output.css
+a {
+  b: 0;
+}
+
+<===>
+================================================================================
+<===> abs/input.scss
+@use "sass:math";
+a {b: math.abs(-1)}
+
+<===> abs/output.css
+a {
+  b: 1;
+}
+
+<===>
+================================================================================
+<===> min/input.scss
+@use "sass:math";
+a {b: math.min(1, 2, 3)}
+
+<===> min/output.css
+a {
+  b: 1;
+}
+
+<===>
+================================================================================
+<===> max/input.scss
+@use "sass:math";
+a {b: math.max(1, 2, 3)}
+
+<===> max/output.css
+a {
+  b: 3;
+}
+
+<===>
+================================================================================
+<===> random/input.scss
+@use "sass:math";
+a {b: math.random(5) <= 5}
+
+<===> random/output.css
+a {
+  b: true;
+}
+
+<===>
+================================================================================
+<===> unit/input.scss
+@use "sass:math";
+a {b: math.unit(5px)}
+
+<===> unit/output.css
+a {
+  b: "px";
+}
+
+<===>
+================================================================================
+<===> is_unitless/input.scss
+@use "sass:math";
+a {b: math.is-unitless(1)}
+
+<===> is_unitless/output.css
+a {
+  b: true;
+}
+
+<===>
+================================================================================
+<===> compatible/input.scss
+@use "sass:math";
+a {b: math.compatible(1px, 1in)}
+
+<===> compatible/output.css
+a {
+  b: true;
+}
+
+<===>
+================================================================================
+<===> error/unitless/input.scss
+@use "sass:math";
+a {b: math.unitless(1)}
+
+<===> error/unitless/error
+Error: Undefined function.
+  ,
+2 | a {b: math.unitless(1)}
+  |       ^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet
+
+<===>
+================================================================================
+<===> error/comparable/input.scss
+@use "sass:math";
+a {b: math.comparable(1px, 1in)}
+
+<===> error/comparable/error
+Error: Undefined function.
+  ,
+2 | a {b: math.comparable(1px, 1in)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet

--- a/spec/core_functions/modules/meta.hrx
+++ b/spec/core_functions/modules/meta.hrx
@@ -1,0 +1,128 @@
+<===> inspect/input.scss
+@use "sass:meta";
+a {b: meta.inspect(())}
+
+<===> inspect/output.css
+a {
+  b: ();
+}
+
+<===>
+================================================================================
+<===> feature_exists/input.scss
+@use "sass:meta";
+a {b: meta.feature-exists(at-error)}
+
+<===> feature_exists/output.css
+a {
+  b: true;
+}
+
+<===>
+================================================================================
+<===> variable_exists/input.scss
+@use "sass:meta";
+a {b: meta.variable-exists(c)}
+
+<===> variable_exists/output.css
+a {
+  b: false;
+}
+
+<===>
+================================================================================
+<===> global_variable_exists/input.scss
+@use "sass:meta";
+a {b: meta.global-variable-exists(c)}
+
+<===> global_variable_exists/output.css
+a {
+  b: false;
+}
+
+<===>
+================================================================================
+<===> function_exists/input.scss
+@use "sass:meta";
+a {b: meta.function-exists(c)}
+
+<===> function_exists/output.css
+a {
+  b: false;
+}
+
+<===>
+================================================================================
+<===> mixin_exists/input.scss
+@use "sass:meta";
+a {b: meta.mixin-exists(c)}
+
+<===> mixin_exists/output.css
+a {
+  b: false;
+}
+
+<===>
+================================================================================
+<===> get_function/input.scss
+@use "sass:meta";
+a {b: meta.inspect(meta.get-function(rgb))}
+
+<===> get_function/output.css
+a {
+  b: get-function("rgb");
+}
+
+<===>
+================================================================================
+<===> type_of/input.scss
+@use "sass:meta";
+a {b: meta.type-of(())}
+
+<===> type_of/output.css
+a {
+  b: list;
+}
+
+<===>
+================================================================================
+<===> call/input.scss
+@use "sass:meta";
+a {b: meta.call(meta.get-function("rgb"), 1, 2, 3)}
+
+<===> call/output.css
+a {
+  b: #010203;
+}
+
+<===>
+================================================================================
+<===> content_exists/input.scss
+@use "sass:meta";
+
+@mixin print-content-exists {
+  a {b: meta.content-exists()}
+}
+
+@include print-content-exists;
+
+<===> content_exists/output.css
+a {
+  b: false;
+}
+
+<===>
+================================================================================
+<===> keywords/input.scss
+@use "sass:meta";
+
+@function keywords($args...) {
+  @return meta.keywords($args);
+}
+
+a {b: meta.inspect(keywords($c: d))}
+
+<===> keywords/output.css
+a {
+  b: (c: d);
+}

--- a/spec/core_functions/modules/options.yml
+++ b/spec/core_functions/modules/options.yml
@@ -1,0 +1,3 @@
+---
+:todo:
+- libsass # sass/libsass#2807

--- a/spec/core_functions/modules/selector.hrx
+++ b/spec/core_functions/modules/selector.hrx
@@ -1,0 +1,169 @@
+<===> nest/input.scss
+@use "sass:selector";
+a {b: selector.nest(c, d)}
+
+<===> nest/output.css
+a {
+  b: c d;
+}
+
+<===>
+================================================================================
+<===> append/input.scss
+@use "sass:selector";
+a {b: selector.append(c, d)}
+
+<===> append/output.css
+a {
+  b: cd;
+}
+
+<===>
+================================================================================
+<===> replace/input.scss
+@use "sass:selector";
+a {b: selector.replace(c, c, d)}
+
+<===> replace/output.css
+a {
+  b: d;
+}
+
+<===>
+================================================================================
+<===> extend/input.scss
+@use "sass:selector";
+a {b: selector.extend(c, c, d)}
+
+<===> extend/output.css
+a {
+  b: c, d;
+}
+
+<===>
+================================================================================
+<===> unify/input.scss
+@use "sass:selector";
+a {b: selector.unify(".c", ".d")}
+
+<===> unify/output.css
+a {
+  b: .c.d;
+}
+
+<===>
+================================================================================
+<===> is_superselector/input.scss
+@use "sass:selector";
+a {b: selector.is-superselector(c, d)}
+
+<===> is_superselector/output.css
+a {
+  b: false;
+}
+
+<===>
+================================================================================
+<===> simple_selectors/input.scss
+@use "sass:selector";
+a {b: selector.simple-selectors(".c.d")}
+
+<===> simple_selectors/output.css
+a {
+  b: .c, .d;
+}
+
+<===>
+================================================================================
+<===> parse/input.scss
+@use "sass:selector";
+a {b: selector.parse(".c, .d")}
+
+<===> parse/output.css
+a {
+  b: .c, .d;
+}
+
+<===>
+================================================================================
+<===> error/selector_nest/input.scss
+@use "sass:selector";
+a {b: selector.selector-nest(c, d)}
+
+<===> error/selector_nest/error
+Error: Undefined function.
+  ,
+2 | a {b: selector.selector-nest(c, d)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet
+
+<===>
+================================================================================
+<===> error/selector_append/input.scss
+@use "sass:selector";
+a {b: selector.selector-append(c, d)}
+
+<===> error/selector_append/error
+Error: Undefined function.
+  ,
+2 | a {b: selector.selector-append(c, d)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet
+
+<===>
+================================================================================
+<===> error/selector_replace/input.scss
+@use "sass:selector";
+a {b: selector.selector-replace(c, c, d)}
+
+<===> error/selector_replace/error
+Error: Undefined function.
+  ,
+2 | a {b: selector.selector-replace(c, c, d)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet
+
+<===>
+================================================================================
+<===> error/selector_extend/input.scss
+@use "sass:selector";
+a {b: selector.selector-extend(c, c, d)}
+
+<===> error/selector_extend/error
+Error: Undefined function.
+  ,
+2 | a {b: selector.selector-extend(c, c, d)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet
+
+<===>
+================================================================================
+<===> error/selector_unify/input.scss
+@use "sass:selector";
+a {b: selector.selector-unify(".c", ".d")}
+
+<===> error/selector_unify/error
+Error: Undefined function.
+  ,
+2 | a {b: selector.selector-unify(".c", ".d")}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet
+
+<===>
+================================================================================
+<===> error/selector_parse/input.scss
+@use "sass:selector";
+a {b: selector.selector-parse(".c.d")}
+
+<===> error/selector_parse/error
+Error: Undefined function.
+  ,
+2 | a {b: selector.selector-parse(".c.d")}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet

--- a/spec/core_functions/modules/string.hrx
+++ b/spec/core_functions/modules/string.hrx
@@ -1,0 +1,142 @@
+<===> unquote/input.scss
+@use "sass:string";
+a {b: string.unquote("c")}
+
+<===> unquote/output.css
+a {
+  b: c;
+}
+
+<===>
+================================================================================
+<===> quote/input.scss
+@use "sass:string";
+a {b: string.quote(c)}
+
+<===> quote/output.css
+a {
+  b: "c";
+}
+
+<===>
+================================================================================
+<===> length/input.scss
+@use "sass:string";
+a {b: string.length("c")}
+
+<===> length/output.css
+a {
+  b: 1;
+}
+
+<===>
+================================================================================
+<===> insert/input.scss
+@use "sass:string";
+a {b: string.insert("c", "d", 1)}
+
+<===> insert/output.css
+a {
+  b: "dc";
+}
+
+<===>
+================================================================================
+<===> index/input.scss
+@use "sass:string";
+a {b: string.index("c", "c")}
+
+<===> index/output.css
+a {
+  b: 1;
+}
+
+<===>
+================================================================================
+<===> slice/input.scss
+@use "sass:string";
+a {b: string.slice("c", 1, 1)}
+
+<===> slice/output.css
+a {
+  b: "c";
+}
+
+<===>
+================================================================================
+<===> to_upper_case/input.scss
+@use "sass:string";
+a {b: string.to-upper-case("c")}
+
+<===> to_upper_case/output.css
+a {
+  b: "C";
+}
+
+<===>
+================================================================================
+<===> unique_id/input.scss
+@use "sass:meta";
+@use "sass:string";
+a {b: meta.type-of(string.unique-id())}
+
+<===> unique_id/output.css
+a {
+  b: string;
+}
+
+<===>
+================================================================================
+<===> error/str_length/input.scss
+@use "sass:string";
+a {b: string.str-length("c")}
+
+<===> error/str_length/error
+Error: Undefined function.
+  ,
+2 | a {b: string.str-length("c")}
+  |       ^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet
+
+<===>
+================================================================================
+<===> error/str_insert/input.scss
+@use "sass:string";
+a {b: string.str-insert("c", 1, "d")}
+
+<===> error/str_insert/error
+Error: Undefined function.
+  ,
+2 | a {b: string.str-insert("c", 1, "d")}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet
+
+<===>
+================================================================================
+<===> error/str_index/input.scss
+@use "sass:string";
+a {b: string.str-index("c", "c")}
+
+<===> error/str_index/error
+Error: Undefined function.
+  ,
+2 | a {b: string.str-index("c", "c")}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet
+
+<===>
+================================================================================
+<===> error/str_slice/input.scss
+@use "sass:string";
+a {b: string.str-slice("c", 1, 1)}
+
+<===> error/str_slice/error
+Error: Undefined function.
+  ,
+2 | a {b: string.str-slice("c", 1, 1)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet


### PR DESCRIPTION
This does not include specs for functions that are newly defined as
part of the module system spec.

[skip dart-sass]