### PR TITLE
Produce better stack traces for syntax errors loaded via import/use

### DIFF
--- a/spec/css/plain/error/expression.hrx
+++ b/spec/css/plain/error/expression.hrx
@@ -11,7 +11,7 @@ Error: This function isn't allowed in plain CSS.
 2 |   x: index(1 2 3, 1);
   |      ^^^^^^^^^^^^^^^
   '
-  plain.css 2:6   root stylesheet
+  plain.css 2:6   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -29,7 +29,7 @@ Error: expected ")".
 2 |   x: hsl(0, 100%, 50%...);
   |                      ^
   '
-  plain.css 2:22  root stylesheet
+  plain.css 2:22  @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -47,7 +47,7 @@ Error: Sass variables aren't allowed in plain CSS.
 2 |   x: hsl(0, 100%, $lightness: 50%);
   |                   ^^^^^^^^^^
   '
-  plain.css 2:19  root stylesheet
+  plain.css 2:19  @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -65,7 +65,7 @@ Error: Parentheses aren't allowed in plain CSS.
 2 |   x: ();
   |      ^
   '
-  plain.css 2:6   root stylesheet
+  plain.css 2:6   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -83,7 +83,7 @@ Error: Parentheses aren't allowed in plain CSS.
 2 |   x: (,);
   |      ^
   '
-  plain.css 2:6   root stylesheet
+  plain.css 2:6   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -101,7 +101,7 @@ Error: Parentheses aren't allowed in plain CSS.
 2 |   x: (y: z);
   |      ^
   '
-  plain.css 2:6   root stylesheet
+  plain.css 2:6   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -119,7 +119,7 @@ Error: Parentheses aren't allowed in plain CSS.
 2 |   x: (y);
   |      ^
   '
-  plain.css 2:6   root stylesheet
+  plain.css 2:6   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -137,7 +137,7 @@ Error: The parent selector isn't allowed in plain CSS.
 2 |   x: &;
   |      ^
   '
-  plain.css 2:6   root stylesheet
+  plain.css 2:6   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -155,7 +155,7 @@ Error: Sass variables aren't allowed in plain CSS.
 2 |   x: $var;
   |      ^^^^
   '
-  plain.css 2:6   root stylesheet
+  plain.css 2:6   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -171,7 +171,7 @@ Error: Sass variables aren't allowed in plain CSS.
 1 | $var: value;
   | ^^^^
   '
-  plain.css 1:1   root stylesheet
+  plain.css 1:1   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -189,7 +189,7 @@ Error: Interpolation isn't allowed in plain CSS.
 2 |   w: calc(#{1px} + 10%);
   |           ^^^^^^
   '
-  plain.css 2:11  root stylesheet
+  plain.css 2:11  @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -207,7 +207,7 @@ Error: Interpolation isn't allowed in plain CSS.
 2 |   w: x#{y}z;
   |       ^^^^
   '
-  plain.css 2:7   root stylesheet
+  plain.css 2:7   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -225,7 +225,7 @@ Error: Interpolation isn't allowed in plain CSS.
 2 |   w: "x#{y}z";
   |        ^^^^
   '
-  plain.css 2:8   root stylesheet
+  plain.css 2:8   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -243,7 +243,7 @@ Error: Interpolation isn't allowed in plain CSS.
 2 |   w: #{x};
   |      ^^^^
   '
-  plain.css 2:6   root stylesheet
+  plain.css 2:6   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -261,7 +261,7 @@ Error: Operators aren't allowed in plain CSS.
 2 |   x: y + z;
   |        ^
   '
-  plain.css 2:8   root stylesheet
+  plain.css 2:8   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -279,7 +279,7 @@ Error: Operators aren't allowed in plain CSS.
 2 |   x: y - z;
   |        ^
   '
-  plain.css 2:8   root stylesheet
+  plain.css 2:8   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -297,7 +297,7 @@ Error: Operators aren't allowed in plain CSS.
 2 |   x: y * z;
   |        ^
   '
-  plain.css 2:8   root stylesheet
+  plain.css 2:8   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -315,7 +315,7 @@ Error: Operators aren't allowed in plain CSS.
 2 |   x: y % z;
   |        ^
   '
-  plain.css 2:8   root stylesheet
+  plain.css 2:8   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -333,7 +333,7 @@ Error: Operators aren't allowed in plain CSS.
 2 |   x: y < z;
   |        ^
   '
-  plain.css 2:8   root stylesheet
+  plain.css 2:8   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -351,7 +351,7 @@ Error: Operators aren't allowed in plain CSS.
 2 |   x: y <= z;
   |        ^^
   '
-  plain.css 2:8   root stylesheet
+  plain.css 2:8   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -369,7 +369,7 @@ Error: Operators aren't allowed in plain CSS.
 2 |   x: y > z;
   |        ^
   '
-  plain.css 2:8   root stylesheet
+  plain.css 2:8   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -387,7 +387,7 @@ Error: Operators aren't allowed in plain CSS.
 2 |   x: y >= z;
   |        ^^
   '
-  plain.css 2:8   root stylesheet
+  plain.css 2:8   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -405,7 +405,7 @@ Error: Operators aren't allowed in plain CSS.
 2 |   x: y == z;
   |        ^^
   '
-  plain.css 2:8   root stylesheet
+  plain.css 2:8   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -423,7 +423,7 @@ Error: Operators aren't allowed in plain CSS.
 2 |   x: y != z;
   |        ^^
   '
-  plain.css 2:8   root stylesheet
+  plain.css 2:8   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -443,5 +443,5 @@ Error: Silent comments aren't allowed in plain CSS.
 2 |   b: c // d
   |        ^^^^
   '
-  plain.css 2:8   root stylesheet
+  plain.css 2:8   @import
   input.scss 1:9  root stylesheet

--- a/spec/css/plain/error/statement.hrx
+++ b/spec/css/plain/error/statement.hrx
@@ -13,7 +13,7 @@ Error: This at-rule isn't allowed in plain CSS.
 2 |   @at-root b {
   |   ^^^^^^^^^^^
   '
-  plain.css 2:3   root stylesheet
+  plain.css 2:3   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -29,7 +29,7 @@ Error: This at-rule isn't allowed in plain CSS.
 1 | @content;
   | ^^^^^^^^
   '
-  plain.css 1:1   root stylesheet
+  plain.css 1:1   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -45,7 +45,7 @@ Error: This at-rule isn't allowed in plain CSS.
 1 | @debug foo;
   | ^^^^^^^^^^
   '
-  plain.css 1:1   root stylesheet
+  plain.css 1:1   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -65,7 +65,7 @@ Error: This at-rule isn't allowed in plain CSS.
 1 | @each $i in 1 2 3 {
   | ^^^^^^^^^^^^^^^^^^
   '
-  plain.css 1:1   root stylesheet
+  plain.css 1:1   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -81,7 +81,7 @@ Error: This at-rule isn't allowed in plain CSS.
 1 | @error foo;
   | ^^^^^^^^^^
   '
-  plain.css 1:1   root stylesheet
+  plain.css 1:1   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -99,7 +99,7 @@ Error: This at-rule isn't allowed in plain CSS.
 2 |   @extend b;
   |   ^^^^^^^^^
   '
-  plain.css 2:3   root stylesheet
+  plain.css 2:3   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -119,7 +119,7 @@ Error: This at-rule isn't allowed in plain CSS.
 1 | @for $i from 1 to 5 {
   | ^^^^^^^^^^^^^^^^^^^^
   '
-  plain.css 1:1   root stylesheet
+  plain.css 1:1   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -137,7 +137,7 @@ Error: This at-rule isn't allowed in plain CSS.
 1 | @function foo() {
   | ^^^^^^^^^^^^^^^^
   '
-  plain.css 1:1   root stylesheet
+  plain.css 1:1   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -157,7 +157,7 @@ Error: This at-rule isn't allowed in plain CSS.
 1 | @if true {
   | ^^^^^^^^^
   '
-  plain.css 1:1   root stylesheet
+  plain.css 1:1   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -173,7 +173,7 @@ Error: Interpolation isn't allowed in plain CSS.
 1 | @import url("foo#{bar}baz");
   |                 ^^^^^^
   '
-  plain.css 1:17  root stylesheet
+  plain.css 1:17  @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -203,7 +203,7 @@ Error: expected ";".
 1 | @import "foo", "bar";
   |              ^
   '
-  plain.css 1:14  root stylesheet
+  plain.css 1:14  @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -219,7 +219,7 @@ Error: This at-rule isn't allowed in plain CSS.
 1 | @include foo;
   | ^^^^^^^^^^^^
   '
-  plain.css 1:1   root stylesheet
+  plain.css 1:1   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -239,7 +239,7 @@ Error: This at-rule isn't allowed in plain CSS.
 1 | @mixin foo {
   | ^^^^^^^^^^^
   '
-  plain.css 1:1   root stylesheet
+  plain.css 1:1   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -255,7 +255,7 @@ Error: This at-rule isn't allowed in plain CSS.
 1 | @return foo;
   | ^^^^^^^^^^^
   '
-  plain.css 1:1   root stylesheet
+  plain.css 1:1   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -271,7 +271,7 @@ Error: This at-rule isn't allowed in plain CSS.
 1 | @warn foo;
   | ^^^^^^^^^
   '
-  plain.css 1:1   root stylesheet
+  plain.css 1:1   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -291,7 +291,7 @@ Error: This at-rule isn't allowed in plain CSS.
 1 | @while false {
   | ^^^^^^^^^^^^^
   '
-  plain.css 1:1   root stylesheet
+  plain.css 1:1   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -307,7 +307,7 @@ Error: Interpolation isn't allowed in plain CSS.
 1 | @foo a#{b}c;
   |       ^^^^
   '
-  plain.css 1:7   root stylesheet
+  plain.css 1:7   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -327,7 +327,7 @@ Error: expected ":".
 2 |   b {
   |     ^
   '
-  plain.css 2:5   root stylesheet
+  plain.css 2:5   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -347,7 +347,7 @@ Error: Nested declarations aren't allowed in plain CSS.
 2 |   x: {
   |      ^
   '
-  plain.css 2:6   root stylesheet
+  plain.css 2:6   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -401,7 +401,7 @@ Error: Interpolation isn't allowed in plain CSS.
 1 | a#{b}c {
   |  ^^^^
   '
-  plain.css 1:2   root stylesheet
+  plain.css 1:2   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -419,7 +419,7 @@ Error: Interpolation isn't allowed in plain CSS.
 2 |   w#{x}y: z;
   |    ^^^^
   '
-  plain.css 2:4   root stylesheet
+  plain.css 2:4   @import
   input.scss 1:9  root stylesheet
 
 <===>
@@ -436,5 +436,5 @@ Error: Silent comments arne't allowed in plain CSS.
 1 | // silent
   | ^^^^^^^^^
   '
-  plain.css 1:1   root stylesheet
+  plain.css 1:1   @import
   input.scss 1:9  root stylesheet

--- a/spec/libsass-todo-issues/issue_2295/error/basic.hrx
+++ b/spec/libsass-todo-issues/issue_2295/error/basic.hrx
@@ -17,5 +17,5 @@ Error: expected "{".
 1 | display: none;
   |              ^
   '
-  include.scss 1:14  root stylesheet
+  include.scss 1:14  @import
   input.scss 2:11    root stylesheet

--- a/spec/libsass-todo-issues/issue_2295/error/wrapped.hrx
+++ b/spec/libsass-todo-issues/issue_2295/error/wrapped.hrx
@@ -18,5 +18,5 @@ Error: expected "{".
 2 |   display: none;
   |                ^
   '
-  include.scss 2:16  root stylesheet
+  include.scss 2:16  @import
   input.scss 2:11    root stylesheet


### PR DESCRIPTION
Instead of using "root stylesheet" as the member name for the loaded
files, this now uses "@import" or "@use".

[skip dart-sass]