### PR TITLE
Add deprecation warning for libsass global variable creation

### DIFF
--- a/spec/libsass-closed-issues/issue_1081.hrx
+++ b/spec/libsass-closed-issues/issue_1081.hrx
@@ -1,8 +1,3 @@
-<===> options.yml
----
-:warning_todo:
-- sass/libsass#2834
-
 <===> input.scss
 $foo: foo !global !default;
 
@@ -52,3 +47,8 @@ declare new variables. Consider adding `$foo: null` at the top level.
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
   '
     input.scss 1:1  root stylesheet
+
+<===> warning-libsass
+DEPRECATION WARNING on line 1, column 5 of /sass/spec/libsass-issues/issue_1081/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$foo: null` at the top level.

--- a/spec/libsass-closed-issues/issue_1632.hrx
+++ b/spec/libsass-closed-issues/issue_1632.hrx
@@ -1,8 +1,3 @@
-<===> options.yml
----
-:warning_todo:
-- sass/libsass#2834
-
 <===> input.scss
 $foo: \/ !global;
 .foo#{$foo}bar { a: b; }
@@ -21,3 +16,8 @@ declare new variables. Consider adding `$foo: null` at the top level.
   | ^^^^^^^^^^^^^^^^
   '
     input.scss 1:1  root stylesheet
+
+<===> warning-libsass
+DEPRECATION WARNING on line 1, column 5 of /sass/spec/libsass-issues/issue_1632/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$foo: null` at the top level.

--- a/spec/libsass-closed-issues/issue_2520.hrx
+++ b/spec/libsass-closed-issues/issue_2520.hrx
@@ -278,3 +278,12 @@
 [class*="modal--"][class*="--animate"][class*="--zoom"] {
   content: "fizzbuzz";
 }
+
+<===> warning-libsass
+DEPRECATION WARNING on line 120, column 14 of /sass/spec/libsass-issues/issue_2520/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$config: null` at the top level.
+
+DEPRECATION WARNING on line 130, column 14 of /sass/spec/libsass-issues/issue_2520/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$module: null` at the top level.

--- a/spec/libsass-closed-issues/issue_759.hrx
+++ b/spec/libsass-closed-issues/issue_759.hrx
@@ -1,8 +1,3 @@
-<===> options.yml
----
-:warning_todo:
-- sass/libsass#2834
-
 <===> input.scss
 $a: 10px !global !default;
 $b: 20px !default !global;
@@ -72,3 +67,24 @@ declare new variables. Consider adding `$e: null` at the top level.
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   '
     input.scss 5:1  root stylesheet
+
+<===> warning-libsass
+DEPRECATION WARNING on line 1, column 3 of /sass/spec/libsass-issues/issue_759/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$a: null` at the top level.
+
+DEPRECATION WARNING on line 2, column 3 of /sass/spec/libsass-issues/issue_759/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$b: null` at the top level.
+
+DEPRECATION WARNING on line 3, column 3 of /sass/spec/libsass-issues/issue_759/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$c: null` at the top level.
+
+DEPRECATION WARNING on line 4, column 3 of /sass/spec/libsass-issues/issue_759/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$d: null` at the top level.
+
+DEPRECATION WARNING on line 5, column 3 of /sass/spec/libsass-issues/issue_759/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$e: null` at the top level.

--- a/spec/libsass/variable-scoping/blead-global/expanding/at-root.hrx
+++ b/spec/libsass/variable-scoping/blead-global/expanding/at-root.hrx
@@ -1,8 +1,3 @@
-<===> options.yml
----
-:warning_todo:
-- sass/libsass#2834
-
 <===> input.scss
 $root_default: initial;
 $root_implicit: initial;
@@ -66,3 +61,12 @@ declare new variables. Consider adding `$local_explicit: null` at the top level.
   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   '
     input.scss 10:3  root stylesheet
+
+<===> warning-libsass
+DEPRECATION WARNING on line 3, column 15 of /sass/spec/libsass/variable-scoping/blead-global/expanding/at-root/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$root-explicit: null` at the top level.
+
+DEPRECATION WARNING on line 10, column 18 of /sass/spec/libsass/variable-scoping/blead-global/expanding/at-root/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$local-explicit: null` at the top level.

--- a/spec/libsass/variable-scoping/blead-global/expanding/each.hrx
+++ b/spec/libsass/variable-scoping/blead-global/expanding/each.hrx
@@ -1,8 +1,3 @@
-<===> options.yml
----
-:warning_todo:
-- sass/libsass#2834
-
 <===> input.scss
 $root_default: initial;
 $root_implicit: initial;
@@ -72,3 +67,12 @@ declare new variables. Consider adding `$local_explicit: null` at the top level.
   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   '
     input.scss 10:3  root stylesheet
+
+<===> warning-libsass
+DEPRECATION WARNING on line 3, column 15 of /sass/spec/libsass/variable-scoping/blead-global/expanding/each/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$root-explicit: null` at the top level.
+
+DEPRECATION WARNING on line 10, column 18 of /sass/spec/libsass/variable-scoping/blead-global/expanding/each/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$local-explicit: null` at the top level.

--- a/spec/libsass/variable-scoping/blead-global/expanding/else.hrx
+++ b/spec/libsass/variable-scoping/blead-global/expanding/else.hrx
@@ -1,8 +1,3 @@
-<===> options.yml
----
-:warning_todo:
-- sass/libsass#2834
-
 <===> input.scss
 $root_default: initial;
 $root_implicit: initial;
@@ -72,3 +67,12 @@ declare new variables. Consider adding `$local_explicit: null` at the top level.
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    '
     input.scss 13:3  root stylesheet
+
+<===> warning-libsass
+DEPRECATION WARNING on line 3, column 15 of /sass/spec/libsass/variable-scoping/blead-global/expanding/else/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$root-explicit: null` at the top level.
+
+DEPRECATION WARNING on line 13, column 18 of /sass/spec/libsass/variable-scoping/blead-global/expanding/else/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$local-explicit: null` at the top level.

--- a/spec/libsass/variable-scoping/blead-global/expanding/elseif.hrx
+++ b/spec/libsass/variable-scoping/blead-global/expanding/elseif.hrx
@@ -1,8 +1,3 @@
-<===> options.yml
----
-:warning_todo:
-- sass/libsass#2834
-
 <===> input.scss
 $root_default: initial;
 $root_implicit: initial;
@@ -72,3 +67,12 @@ declare new variables. Consider adding `$local_explicit: null` at the top level.
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    '
     input.scss 13:3  root stylesheet
+
+<===> warning-libsass
+DEPRECATION WARNING on line 3, column 15 of /sass/spec/libsass/variable-scoping/blead-global/expanding/elseif/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$root-explicit: null` at the top level.
+
+DEPRECATION WARNING on line 13, column 18 of /sass/spec/libsass/variable-scoping/blead-global/expanding/elseif/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$local-explicit: null` at the top level.

--- a/spec/libsass/variable-scoping/blead-global/expanding/for.hrx
+++ b/spec/libsass/variable-scoping/blead-global/expanding/for.hrx
@@ -1,8 +1,3 @@
-<===> options.yml
----
-:warning_todo:
-- sass/libsass#2834
-
 <===> input.scss
 $continue: true;
 $root_default: initial;
@@ -73,3 +68,12 @@ declare new variables. Consider adding `$local_explicit: null` at the top level.
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    '
     input.scss 11:3  root stylesheet
+
+<===> warning-libsass
+DEPRECATION WARNING on line 4, column 15 of /sass/spec/libsass/variable-scoping/blead-global/expanding/for/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$root-explicit: null` at the top level.
+
+DEPRECATION WARNING on line 11, column 18 of /sass/spec/libsass/variable-scoping/blead-global/expanding/for/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$local-explicit: null` at the top level.

--- a/spec/libsass/variable-scoping/blead-global/expanding/function.hrx
+++ b/spec/libsass/variable-scoping/blead-global/expanding/function.hrx
@@ -1,8 +1,3 @@
-<===> options.yml
----
-:warning_todo:
-- sass/libsass#2834
-
 <===> input.scss
 $continue_inner: true;
 $continue_outer: true;
@@ -81,3 +76,12 @@ declare new variables. Consider adding `$local_explicit: null` at the top level.
    '
     input.scss 12:3  fn()
     input.scss 28:7  root stylesheet
+
+<===> warning-libsass
+DEPRECATION WARNING on line 5, column 15 of /sass/spec/libsass/variable-scoping/blead-global/expanding/function/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$root-explicit: null` at the top level.
+
+DEPRECATION WARNING on line 12, column 18 of /sass/spec/libsass/variable-scoping/blead-global/expanding/function/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$local-explicit: null` at the top level.

--- a/spec/libsass/variable-scoping/blead-global/expanding/if.hrx
+++ b/spec/libsass/variable-scoping/blead-global/expanding/if.hrx
@@ -1,8 +1,3 @@
-<===> options.yml
----
-:warning_todo:
-- sass/libsass#2834
-
 <===> input.scss
 $root_default: initial;
 $root_implicit: initial;
@@ -66,3 +61,12 @@ declare new variables. Consider adding `$local_explicit: null` at the top level.
   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   '
     input.scss 10:3  root stylesheet
+
+<===> warning-libsass
+DEPRECATION WARNING on line 3, column 15 of /sass/spec/libsass/variable-scoping/blead-global/expanding/if/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$root-explicit: null` at the top level.
+
+DEPRECATION WARNING on line 10, column 18 of /sass/spec/libsass/variable-scoping/blead-global/expanding/if/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$local-explicit: null` at the top level.

--- a/spec/libsass/variable-scoping/blead-global/expanding/mixin.hrx
+++ b/spec/libsass/variable-scoping/blead-global/expanding/mixin.hrx
@@ -1,8 +1,3 @@
-<===> options.yml
----
-:warning_todo:
-- sass/libsass#2834
-
 <===> input.scss
 $root_default: initial;
 $root_implicit: initial;
@@ -71,3 +66,12 @@ declare new variables. Consider adding `$local_explicit: null` at the top level.
    '
     input.scss 19:3  set_variable_outer()
     input.scss 24:1  root stylesheet
+
+<===> warning-libsass
+DEPRECATION WARNING on line 3, column 15 of /sass/spec/libsass/variable-scoping/blead-global/expanding/mixin/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$root-explicit: null` at the top level.
+
+DEPRECATION WARNING on line 19, column 18 of /sass/spec/libsass/variable-scoping/blead-global/expanding/mixin/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$local-explicit: null` at the top level.

--- a/spec/libsass/variable-scoping/blead-global/expanding/ruleset.hrx
+++ b/spec/libsass/variable-scoping/blead-global/expanding/ruleset.hrx
@@ -1,8 +1,3 @@
-<===> options.yml
----
-:warning_todo:
-- sass/libsass#2834
-
 <===> input.scss
 $root_default: initial;
 $root_implicit: initial;
@@ -66,3 +61,12 @@ declare new variables. Consider adding `$local_explicit: null` at the top level.
   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   '
     input.scss 10:3  root stylesheet
+
+<===> warning-libsass
+DEPRECATION WARNING on line 3, column 15 of /sass/spec/libsass/variable-scoping/blead-global/expanding/ruleset/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$root-explicit: null` at the top level.
+
+DEPRECATION WARNING on line 19, column 18 of /sass/spec/libsass/variable-scoping/blead-global/expanding/ruleset/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$local-explicit: null` at the top level.

--- a/spec/libsass/variable-scoping/blead-global/expanding/while.hrx
+++ b/spec/libsass/variable-scoping/blead-global/expanding/while.hrx
@@ -1,8 +1,3 @@
-<===> options.yml
----
-:warning_todo:
-- sass/libsass#2834
-
 <===> input.scss
 $continue_inner: true;
 $continue_outer: true;
@@ -78,3 +73,12 @@ declare new variables. Consider adding `$local_explicit: null` at the top level.
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    '
     input.scss 12:3  root stylesheet
+
+<===> warning-libsass
+DEPRECATION WARNING on line 5, column 15 of /sass/spec/libsass/variable-scoping/blead-global/expanding/while/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$root-explicit: null` at the top level.
+
+DEPRECATION WARNING on line 12, column 18 of /sass/spec/libsass/variable-scoping/blead-global/expanding/while/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$local-explicit: null` at the top level.

--- a/spec/libsass/variable-scoping/blead-global/functional/each.hrx
+++ b/spec/libsass/variable-scoping/blead-global/functional/each.hrx
@@ -1,8 +1,3 @@
-<===> options.yml
----
-:warning_todo:
-- sass/libsass#2834
-
 <===> input.scss
 $root_default: initial;
 $root_implicit: initial;
@@ -122,3 +117,24 @@ declare new variables. Consider adding `$check_default: null` at the top level.
    '
     input.scss 24:3  fn()
     input.scss 29:7  root stylesheet
+
+<===> warning-libsass
+DEPRECATION WARNING on line 3, column 15 of /sass/spec/libsass/variable-scoping/blead-global/functional/each/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$root-explicit: null` at the top level.
+
+DEPRECATION WARNING on line 11, column 20 of /sass/spec/libsass/variable-scoping/blead-global/functional/each/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$local-explicit: null` at the top level.
+
+DEPRECATION WARNING on line 22, column 18 of /sass/spec/libsass/variable-scoping/blead-global/functional/each/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$check-implicit: null` at the top level.
+
+DEPRECATION WARNING on line 23, column 18 of /sass/spec/libsass/variable-scoping/blead-global/functional/each/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$check-explicit: null` at the top level.
+
+DEPRECATION WARNING on line 24, column 17 of /sass/spec/libsass/variable-scoping/blead-global/functional/each/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$check-default: null` at the top level.

--- a/spec/libsass/variable-scoping/blead-global/functional/else.hrx
+++ b/spec/libsass/variable-scoping/blead-global/functional/else.hrx
@@ -1,8 +1,3 @@
-<===> options.yml
----
-:warning_todo:
-- sass/libsass#2834
-
 <===> input.scss
 $root_default: initial;
 $root_implicit: initial;
@@ -128,3 +123,24 @@ declare new variables. Consider adding `$check_default: null` at the top level.
    '
     input.scss 30:3  fn()
     input.scss 35:7  root stylesheet
+
+<===> warning-libsass
+DEPRECATION WARNING on line 3, column 15 of /sass/spec/libsass/variable-scoping/blead-global/functional/else/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$root-explicit: null` at the top level.
+
+DEPRECATION WARNING on line 11, column 20 of /sass/spec/libsass/variable-scoping/blead-global/functional/else/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$local-explicit: null` at the top level.
+
+DEPRECATION WARNING on line 22, column 18 of /sass/spec/libsass/variable-scoping/blead-global/functional/else/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$check-implicit: null` at the top level.
+
+DEPRECATION WARNING on line 23, column 18 of /sass/spec/libsass/variable-scoping/blead-global/functional/else/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$check-explicit: null` at the top level.
+
+DEPRECATION WARNING on line 24, column 17 of /sass/spec/libsass/variable-scoping/blead-global/functional/else/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$check-default: null` at the top level.

--- a/spec/libsass/variable-scoping/blead-global/functional/elseif.hrx
+++ b/spec/libsass/variable-scoping/blead-global/functional/elseif.hrx
@@ -1,8 +1,3 @@
-<===> options.yml
----
-:warning_todo:
-- sass/libsass#2834
-
 <===> input.scss
 $root_default: initial;
 $root_implicit: initial;
@@ -128,3 +123,24 @@ declare new variables. Consider adding `$check_default: null` at the top level.
    '
     input.scss 30:3  fn()
     input.scss 35:7  root stylesheet
+
+<===> warning-libsass
+DEPRECATION WARNING on line 3, column 15 of /sass/spec/libsass/variable-scoping/blead-global/functional/elseif/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$root-explicit: null` at the top level.
+
+DEPRECATION WARNING on line 11, column 20 of /sass/spec/libsass/variable-scoping/blead-global/functional/elseif/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$local-explicit: null` at the top level.
+
+DEPRECATION WARNING on line 22, column 18 of /sass/spec/libsass/variable-scoping/blead-global/functional/elseif/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$check-implicit: null` at the top level.
+
+DEPRECATION WARNING on line 23, column 18 of /sass/spec/libsass/variable-scoping/blead-global/functional/elseif/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$check-explicit: null` at the top level.
+
+DEPRECATION WARNING on line 24, column 17 of /sass/spec/libsass/variable-scoping/blead-global/functional/elseif/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$check-default: null` at the top level.

--- a/spec/libsass/variable-scoping/blead-global/functional/for.hrx
+++ b/spec/libsass/variable-scoping/blead-global/functional/for.hrx
@@ -1,8 +1,3 @@
-<===> options.yml
----
-:warning_todo:
-- sass/libsass#2834
-
 <===> input.scss
 $root_default: initial;
 $root_implicit: initial;
@@ -122,3 +117,24 @@ declare new variables. Consider adding `$check_default: null` at the top level.
    '
     input.scss 24:3  fn()
     input.scss 29:7  root stylesheet
+
+<===> warning-libsass
+DEPRECATION WARNING on line 3, column 15 of /sass/spec/libsass/variable-scoping/blead-global/functional/for/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$root-explicit: null` at the top level.
+
+DEPRECATION WARNING on line 11, column 20 of /sass/spec/libsass/variable-scoping/blead-global/functional/for/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$local-explicit: null` at the top level.
+
+DEPRECATION WARNING on line 22, column 18 of /sass/spec/libsass/variable-scoping/blead-global/functional/for/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$check-implicit: null` at the top level.
+
+DEPRECATION WARNING on line 23, column 18 of /sass/spec/libsass/variable-scoping/blead-global/functional/for/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$check-explicit: null` at the top level.
+
+DEPRECATION WARNING on line 24, column 17 of /sass/spec/libsass/variable-scoping/blead-global/functional/for/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$check-default: null` at the top level.

--- a/spec/libsass/variable-scoping/blead-global/functional/if.hrx
+++ b/spec/libsass/variable-scoping/blead-global/functional/if.hrx
@@ -1,8 +1,3 @@
-<===> options.yml
----
-:warning_todo:
-- sass/libsass#2834
-
 <===> input.scss
 $root_default: initial;
 $root_implicit: initial;
@@ -122,3 +117,24 @@ declare new variables. Consider adding `$check_default: null` at the top level.
    '
     input.scss 24:3  fn()
     input.scss 29:7  root stylesheet
+
+<===> warning-libsass
+DEPRECATION WARNING on line 3, column 15 of /sass/spec/libsass/variable-scoping/blead-global/functional/if/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$root-explicit: null` at the top level.
+
+DEPRECATION WARNING on line 11, column 20 of /sass/spec/libsass/variable-scoping/blead-global/functional/if/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$local-explicit: null` at the top level.
+
+DEPRECATION WARNING on line 22, column 18 of /sass/spec/libsass/variable-scoping/blead-global/functional/if/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$check-implicit: null` at the top level.
+
+DEPRECATION WARNING on line 23, column 18 of /sass/spec/libsass/variable-scoping/blead-global/functional/if/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$check-explicit: null` at the top level.
+
+DEPRECATION WARNING on line 24, column 17 of /sass/spec/libsass/variable-scoping/blead-global/functional/if/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$check-default: null` at the top level.

--- a/spec/libsass/variable-scoping/blead-global/functional/while.hrx
+++ b/spec/libsass/variable-scoping/blead-global/functional/while.hrx
@@ -1,8 +1,3 @@
-<===> options.yml
----
-:warning_todo:
-- sass/libsass#2834
-
 <===> input.scss
 $continue_inner: true;
 $continue_outer: true;
@@ -128,3 +123,24 @@ declare new variables. Consider adding `$check_default: null` at the top level.
    '
     input.scss 28:3  fn()
     input.scss 33:7  root stylesheet
+
+<===> warning-libsass
+DEPRECATION WARNING on line 5, column 15 of /sass/spec/libsass/variable-scoping/blead-global/functional/while/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$root-explicit: null` at the top level.
+
+DEPRECATION WARNING on line 13, column 20 of /sass/spec/libsass/variable-scoping/blead-global/functional/while/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$local-explicit: null` at the top level.
+
+DEPRECATION WARNING on line 26, column 18 of /sass/spec/libsass/variable-scoping/blead-global/functional/while/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$check-implicit: null` at the top level.
+
+DEPRECATION WARNING on line 27, column 18 of /sass/spec/libsass/variable-scoping/blead-global/functional/while/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$check-explicit: null` at the top level.
+
+DEPRECATION WARNING on line 28, column 17 of /sass/spec/libsass/variable-scoping/blead-global/functional/while/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$check-default: null` at the top level.

--- a/spec/libsass/variable-scoping/defaults-global-null.hrx
+++ b/spec/libsass/variable-scoping/defaults-global-null.hrx
@@ -1,8 +1,3 @@
-<===> options.yml
----
-:warning_todo:
-- sass/libsass#2834
-
 <===> input.scss
 div {
   $foo: null !default !global;
@@ -47,3 +42,8 @@ declare new variables. Consider adding `$foo: null` at the top level.
   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   '
     input.scss 2:3  root stylesheet
+
+<===> warning-libsass
+DEPRECATION WARNING on line 2, column 7 of /sass/spec/libsass/variable-scoping/defaults-global-null/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$foo: null` at the top level.

--- a/spec/libsass/variable-scoping/defaults-global.hrx
+++ b/spec/libsass/variable-scoping/defaults-global.hrx
@@ -1,8 +1,3 @@
-<===> options.yml
----
-:warning_todo:
-- sass/libsass#2834
-
 <===> input.scss
 div {
   $foo: inner !default !global;
@@ -41,3 +36,8 @@ declare new variables. Consider adding `$foo: null` at the top level.
   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   '
     input.scss 2:3  root stylesheet
+
+<===> warning-libsass
+DEPRECATION WARNING on line 2, column 7 of /sass/spec/libsass/variable-scoping/defaults-global/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$foo: null` at the top level.

--- a/spec/libsass/variable-scoping/defaults.hrx
+++ b/spec/libsass/variable-scoping/defaults.hrx
@@ -1,8 +1,3 @@
-<===> options.yml
----
-:warning_todo:
-- sass/libsass#2834
-
 <===> input.scss
 $i: 9;
 $z: 3 !default;
@@ -70,3 +65,8 @@ declare new variables. Consider adding `$n: null` at the top level.
   |   ^^^^^^^^^^^^^^
   '
     input.scss 6:3  root stylesheet
+
+<===> warning-libsass
+DEPRECATION WARNING on line 6, column 5 of /sass/spec/libsass/variable-scoping/defaults/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$n: null` at the top level.

--- a/spec/variables.hrx
+++ b/spec/variables.hrx
@@ -1,10 +1,3 @@
-<===> global/first_declaration/options.yml
----
-:warning_todo:
-- sass/libsass#2834
-
-<===>
-================================================================================
 <===> global/first_declaration/top_level/input.scss
 $var: value !global;
 a {b: $var}
@@ -23,6 +16,11 @@ declare new variables. Consider adding `$var: null` at the top level.
   | ^^^^^^^^^^^^^^^^^^^
   '
     input.scss 1:1  root stylesheet
+
+<===> global/first_declaration/top_level/warning-libsass
+DEPRECATION WARNING on line 1, column 5 of /sass/spec/variables/global/first_declaration/top_level/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$var: null` at the top level.
 
 <===>
 ================================================================================
@@ -44,3 +42,8 @@ declare new variables. Consider adding `$var: null` at the top level.
   |    ^^^^^^^^^^^^^^^^^^^
   '
     input.scss 1:4  root stylesheet
+
+<===> global/first_declaration/nested/warning-libsass
+DEPRECATION WARNING on line 1, column 8 of /sass/spec/variables/global/first_declaration/nested/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$var: null` at the top level.


### PR DESCRIPTION
It seems there were some strange newlines in some of these hrx files.