### PR TITLE
Allow arguments to be passed to any command

### DIFF
--- a/lib/sass_spec/cli.rb
+++ b/lib/sass_spec/cli.rb
@@ -48,18 +48,21 @@ Make sure the command you provide prints to stdout.
 
       opts.on("-c", "--command COMMAND", "Sets a specific binary to run") do |v|
         options[:engine_adapter] = ExecutableEngineAdapter.new(v)
+        options[:engine_adapter].args = options[:cmd_args]
       end
 
       opts.on("--dart PATH", "Run Dart Sass, whose repo should be at the given path.") do |path|
         options[:engine_adapter] = DartEngineAdapter.new(path)
-        options[:engine_adapter].args = options[:dart_args]
+        options[:engine_adapter].args = options[:cmd_args]
       end
 
-      opts.on("--dart-args ARGS", "Pass ARGS to Dart Sass.") do |args|
+      opts.on("--cmd-args ARGS", "Pass ARGS to command or Dart Sass.") do |args|
         if (adapter = options[:engine_adapter]) && adapter.is_a?(DartEngineAdapter)
           adapter.args = args
+        elsif (adapter = options[:engine_adapter]) && adapter.is_a?(ExecutableEngineAdapter)
+          adapter.args = args
         else
-          options[:dart_args] = args
+          options[:cmd_args] = args
         end
       end
 

--- a/lib/sass_spec/engine_adapter.rb
+++ b/lib/sass_spec/engine_adapter.rb
@@ -22,6 +22,7 @@ end
 
 class ExecutableEngineAdapter < EngineAdapter
   include CaptureWithTimeout
+  attr_accessor :args
 
   def initialize(command, description = nil)
     @command = command
@@ -43,7 +44,7 @@ class ExecutableEngineAdapter < EngineAdapter
     dirname, basename = File.split(sass_filename)
     result = capture3_with_timeout(
       command, "--precision", precision.to_s, "-t", "expanded",
-      "-I", File.absolute_path("spec"), basename,
+      "-I", File.absolute_path("spec"), *@args&.split(/\s+/), basename,
       binmode: true, timeout: @timeout, chdir: dirname)
 
     if result[:timeout]


### PR DESCRIPTION
Renames `--dart-args` to `--cmd-args`

Allows libsass to work around #1427.

@nex3 I probably will merge this very soon since #1427 is quite a blocker ATM for me.
I think this change makes sense even on its own, but feel free to change it as you see fit.