### PR TITLE
Fix a filename typo

### DIFF
--- a/spec/core_functions/meta/mixin_exists.hrx
+++ b/spec/core_functions/meta/mixin_exists.hrx
@@ -75,7 +75,7 @@ a {b: mixin-exists("c", "other")}
 <===> different_module/defined/_other.scss
 @mixin c() {}
 
-<===> different_module/defined/output.scss
+<===> different_module/defined/output.css
 a {
   b: true;
 }


### PR DESCRIPTION
Fix what I assue must be a typo in a filename in `different_module/defined` in `spec/core_functions/meta/mixin_exists.hrx`