### PR TITLE
Update a couple specs for eager dash-normalization in Dart Sass

### DIFF
--- a/spec/core_functions/meta/keywords.hrx
+++ b/spec/core_functions/meta/keywords.hrx
@@ -116,18 +116,13 @@ a {
 
 <===>
 ================================================================================
-<===> dash_sensitive/options.yml
----
-:todo:
-- sass/libsass#2936
-
-<===> dash_sensitive/input.scss
+<===> dash_insensitive/input.scss
 @import "../utils";
 a {b: inspect(args-to-keywords($c-d: e, $f_g: h))}
 
-<===> dash_sensitive/output.css
+<===> dash_insensitive/output.css
 a {
-  b: (c-d: e, f_g: h);
+  b: (c-d: e, f-g: h);
 }
 
 <===>

--- a/spec/libsass/variable-scoping/blead-global/expanding/mixin.hrx
+++ b/spec/libsass/variable-scoping/blead-global/expanding/mixin.hrx
@@ -71,5 +71,5 @@ stylesheet.
 19 |   $local_explicit: outer !global;
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    '
-    input.scss 19:3  set_variable_outer()
+    input.scss 19:3  set-variable-outer()
     input.scss 24:1  root stylesheet


### PR DESCRIPTION
We're going against Ruby Sass in normalizing the keys in the
keywords() function, but this is the more user-friendly solution
because it doesn't require users to manually dash-normalize in order
to match caller expectations.

[skip dart-sass]