### PR TITLE
Enable scale-color saturation tests for libsass

### DIFF
--- a/spec/core_functions/color/scale_color/hsl.hrx
+++ b/spec/core_functions/color/scale_color/hsl.hrx
@@ -1,8 +1,3 @@
-<===> saturation/max/options.yml
----
-:todo:
-- sass/libsass#2903
-
 <===> saturation/max/input.scss
 a {b: scale-color(plum, $saturation: 100%)}
 
@@ -33,11 +28,6 @@ a {
 
 <===>
 ================================================================================
-<===> saturation/high/options.yml
----
-:todo:
-- sass/libsass#2903
-
 <===> saturation/high/input.scss
 a {b: scale-color(plum, $saturation: 67%)}
 
@@ -108,11 +98,6 @@ a {
 
 <===>
 ================================================================================
-<===> all/options.yml
----
-:todo:
-- sass/libsass#2903
-
 <===> all/input.scss
 a {b: scale-color(turquoise, $saturation: 24%, $lightness: -48%)}
 
@@ -123,11 +108,6 @@ a {
 
 <===>
 ================================================================================
-<===> alpha_input/options.yml
----
-:todo:
-- sass/libsass#2903
-
 <===> alpha_input/input.scss
 a {b: scale-color(rgba(turquoise, 0.7), $saturation: 24%, $lightness: -48%)}
 
@@ -138,11 +118,6 @@ a {
 
 <===>
 ================================================================================
-<===> alpha_arg/options.yml
----
-:todo:
-- sass/libsass#2903
-
 <===> alpha_arg/input.scss
 a {b: scale-color(turquoise, $saturation: 24%, $lightness: -48%, $alpha: -70%)}
 
@@ -153,11 +128,6 @@ a {
 
 <===>
 ================================================================================
-<===> named/options.yml
----
-:todo:
-- sass/libsass#2903
-
 <===> named/input.scss
 a {b: scale-color($color: turquoise, $saturation: 24%, $lightness: -48%)}
 


### PR DESCRIPTION
These tests are fixed by https://github.com/sass/libsass/pull/2954

[skip libsass]