### PR TITLE
Update specs for unquoting non-strings

### DIFF
--- a/spec/libsass-closed-issues/issue_1106.hrx
+++ b/spec/libsass-closed-issues/issue_1106.hrx
@@ -22,15 +22,6 @@ Error: $string: null is not a string.
   '
   input.scss 7:14  root stylesheet
 
-<===> output.css
-a {
-  foo: bar;
-}
-
-<===> warning
-DEPRECATION WARNING: Passing null, a non-string value, to unquote()
-will be an error in future versions of Sass.
-        on line 7 of input.scss
-DEPRECATION WARNING: Passing null, a non-string value, to unquote()
-will be an error in future versions of Sass.
-        on line 13 of input.scss
+<===> error-libsass
+Internal Error: Invalid Data Type for unquote
+>> unquote: unquote($foo);

--- a/spec/libsass-closed-issues/issue_1258.hrx
+++ b/spec/libsass-closed-issues/issue_1258.hrx
@@ -12,13 +12,7 @@ $string: '(-webkit-min-device-pixel-ratio: 2),   (min-resolution: 192dpi)';
   content: unquote($list);
   content: unquote($string);
 }
-<===> output.css
-.foo {
-  content: "(-webkit-min-device-pixel-ratio: 2)", "(min-resolution: 192dpi)";
-  content: (-webkit-min-device-pixel-ratio: 2),   (min-resolution: 192dpi);
-}
 
-<===> warning
-DEPRECATION WARNING: Passing "(-webkit-min-device-pixel-ratio: 2)", "(min-resolution: 192dpi)", a non-string value, to unquote()
-will be an error in future versions of Sass.
-        on line 6 of input.scss
+<===> error-libsass
+Internal Error: Invalid Data Type for unquote
+>> content: unquote($list);

--- a/spec/libsass-closed-issues/issue_1291.hrx
+++ b/spec/libsass-closed-issues/issue_1291.hrx
@@ -26,22 +26,7 @@
   @include spec3(7);
   @include spec3(-7);
 }
-<===> output.css
-.my-element {
-  value: -3;
-  value: 3;
-  value: -5;
-  value: 5;
-  value: -7;
-  value: 7;
-}
 
-<===> warning
-DEPRECATION WARNING: Passing 3, a non-string value, to unquote()
-will be an error in future versions of Sass.
-        on line 2 of input.scss, in `spec1'
-        from line 16 of input.scss
-DEPRECATION WARNING: Passing 5, a non-string value, to unquote()
-will be an error in future versions of Sass.
-        on line 7 of input.scss, in `spec2'
-        from line 18 of input.scss
+<===> error-libsass
+Internal Error: Invalid Data Type for unquote
+>> $decimal: unquote($decimal) * -1;


### PR DESCRIPTION
This behavior is now fully deprecated. Make sure specs are expecting
errors now, instead of deprecation warnings.

See sass/libsass#3017

[skip libsass]