### PR TITLE
Tests + bug fixes on --limit flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ branches:
 matrix:
   fast_finish: true
   include:
+    - name: "Unit Tests"
+      script: bundle exec rspec tests/
     - name: "LibSass"
       env:
         - IMPL=libsass

--- a/lib/sass_spec/cli.rb
+++ b/lib/sass_spec/cli.rb
@@ -12,7 +12,6 @@ module SassSpec::CLI
       skip: false,
       verbose: false,
       filter: "",
-      limit: -1,
       implementation: 'sass'
     }
 

--- a/lib/sass_spec/cli.rb
+++ b/lib/sass_spec/cli.rb
@@ -88,6 +88,7 @@ Make sure the command you provide prints to stdout.
       end
 
       opts.on("--limit NUMBER", "Limit the number of tests run to this positive integer.") do |limit|
+        raise "--limit must receive a positive integer" if limit.to_i < 0
         options[:limit] = limit.to_i
       end
 

--- a/lib/sass_spec/test.rb
+++ b/lib/sass_spec/test.rb
@@ -8,7 +8,7 @@ require_relative "util"
 # Holder to put and run test cases
 class SassSpec::Test < Minitest::Test
   def self.create_tests(test_cases, options = {})
-    test_cases[0..options[:limit]].each do |test_case|
+    test_cases[0...options[:limit]].each do |test_case|
       define_method("test__#{test_case.name}") do
         runner = SassSpecRunner.new(test_case, options)
         test_case.finalize(runner.run)

--- a/lib/sass_spec/test.rb
+++ b/lib/sass_spec/test.rb
@@ -8,6 +8,7 @@ require_relative "util"
 # Holder to put and run test cases
 class SassSpec::Test < Minitest::Test
   def self.create_tests(test_cases, options = {})
+    options[:limit] = test_cases.length + 1 unless options[:limit]
     test_cases[0...options[:limit]].each do |test_case|
       define_method("test__#{test_case.name}") do
         runner = SassSpecRunner.new(test_case, options)

--- a/lib/sass_spec/test.rb
+++ b/lib/sass_spec/test.rb
@@ -8,7 +8,7 @@ require_relative "util"
 # Holder to put and run test cases
 class SassSpec::Test < Minitest::Test
   def self.create_tests(test_cases, options = {})
-    options[:limit] = test_cases.length + 1 unless options[:limit]
+    options[:limit] ||= test_cases.length + 1
     test_cases[0...options[:limit]].each do |test_case|
       define_method("test__#{test_case.name}") do
         runner = SassSpecRunner.new(test_case, options)

--- a/tests/cli_spec.rb
+++ b/tests/cli_spec.rb
@@ -4,39 +4,34 @@ require_relative 'spec_helper'
 
 RSpec.describe 'run tests', type: :aruba do
   it 'runs a single spec' do
-    run_command "#{Dir.pwd}/sass-spec.rb --command "\
-                "'#{Dir.pwd}/tests/sass_stub' "\
-                "#{Dir.pwd}/tests/fixtures/basic"
+    run_command command('basic')
+
     expect(last_command_started).to be_successfully_executed
   end
 
   it 'should not run todo specs by default' do
-    run_command "#{Dir.pwd}/sass-spec.rb --command "\
-                "'#{Dir.pwd}/tests/sass_stub' "\
-                "#{Dir.pwd}/tests/fixtures/todo"
+    run_command command('todo')
+
     expect(last_command_started).to be_successfully_executed
     expect(test_results(last_command_started.output)[:skips]).to eq 1
   end
 
   it 'should run todo specs with --run-todo flag' do
-    run_command "#{Dir.pwd}/sass-spec.rb --run-todo --command "\
-                "'#{Dir.pwd}/tests/sass_stub' "\
-                "#{Dir.pwd}/tests/fixtures/todo"
+    run_command command('todo', ["--run-todo"])
+
     expect(last_command_started).to be_successfully_executed
     expect(test_results(last_command_started.output)[:skips]).to eq 0
   end
 
   it 'should not allow limit to take a negative number' do
-    run_command "#{Dir.pwd}/sass-spec.rb --limit -10 --command "\
-                "'#{Dir.pwd}/tests/sass_stub' "\
-                "#{Dir.pwd}/tests/fixtures/basic"
+    run_command command('basic', ["--limit -10"])
+
     expect(last_command_started).to_not be_successfully_executed
   end
 
   it 'should not allow limit to take a negative number' do
-    run_command "#{Dir.pwd}/sass-spec.rb --run-todo --limit 1 --command "\
-                "'#{Dir.pwd}/tests/sass_stub' "\
-                "#{Dir.pwd}/tests/fixtures/todo"
+    run_command command('todo', ["--run-todo", "--limit 1"])
+
     expect(last_command_started).to be_successfully_executed
     expect(test_results(last_command_started.output)[:runs]).to eq 1
   end

--- a/tests/cli_spec.rb
+++ b/tests/cli_spec.rb
@@ -25,4 +25,11 @@ RSpec.describe 'run tests', type: :aruba do
     expect(last_command_started).to be_successfully_executed
     expect(test_results(last_command_started.output)[:skips]).to eq 0
   end
+
+  it 'should not allow limit to take a negative number' do
+    run_command "#{Dir.pwd}/sass-spec.rb --limit -10 --command "\
+                "'#{Dir.pwd}/tests/sass_stub' "\
+                "#{Dir.pwd}/tests/fixtures/basic"
+    expect(last_command_started).to_not be_successfully_executed
+  end
 end

--- a/tests/cli_spec.rb
+++ b/tests/cli_spec.rb
@@ -24,15 +24,15 @@ RSpec.describe 'run tests', type: :aruba do
   end
 
   it 'should not allow limit to take a negative number' do
-    run_command command('basic', ["--limit -10"])
+    run_command command('limit', ["--limit -10"])
 
     expect(last_command_started).to_not be_successfully_executed
   end
 
   it 'should not allow limit to take a negative number' do
-    run_command command('todo', ["--run-todo", "--limit 1"])
+    run_command command('limit', ["--run-todo", "--limit 3"])
 
     expect(last_command_started).to be_successfully_executed
-    expect(test_results(last_command_started.output)[:runs]).to eq 1
+    expect(test_results(last_command_started.output)[:runs]).to eq 3
   end
 end

--- a/tests/cli_spec.rb
+++ b/tests/cli_spec.rb
@@ -32,4 +32,12 @@ RSpec.describe 'run tests', type: :aruba do
                 "#{Dir.pwd}/tests/fixtures/basic"
     expect(last_command_started).to_not be_successfully_executed
   end
+
+  it 'should not allow limit to take a negative number' do
+    run_command "#{Dir.pwd}/sass-spec.rb --run-todo --limit 1 --command "\
+                "'#{Dir.pwd}/tests/sass_stub' "\
+                "#{Dir.pwd}/tests/fixtures/todo"
+    expect(last_command_started).to be_successfully_executed
+    expect(test_results(last_command_started.output)[:runs]).to eq 1
+  end
 end

--- a/tests/cli_spec.rb
+++ b/tests/cli_spec.rb
@@ -4,33 +4,33 @@ require_relative 'spec_helper'
 
 RSpec.describe 'run tests', type: :aruba do
   it 'runs a single spec' do
-    run_command command('basic')
+    run_sass('basic')
 
     expect(last_command_started).to be_successfully_executed
   end
 
   it 'should not run todo specs by default' do
-    run_command command('todo')
+    run_sass('todo')
 
     expect(last_command_started).to be_successfully_executed
     expect(test_results(last_command_started.output)[:skips]).to eq 1
   end
 
   it 'should run todo specs with --run-todo flag' do
-    run_command command('todo', ["--run-todo"])
+    run_sass('todo', ["--run-todo"])
 
     expect(last_command_started).to be_successfully_executed
     expect(test_results(last_command_started.output)[:skips]).to eq 0
   end
 
   it 'should not allow limit to take a negative number' do
-    run_command command('limit', ["--limit -10"])
+    run_sass('limit', ["--limit -10"])
 
     expect(last_command_started).to_not be_successfully_executed
   end
 
   it 'should not allow limit to take a negative number' do
-    run_command command('limit', ["--run-todo", "--limit 3"])
+    run_sass('limit', ["--run-todo", "--limit 3"])
 
     expect(last_command_started).to be_successfully_executed
     expect(test_results(last_command_started.output)[:runs]).to eq 3

--- a/tests/fixtures/limit/basic.hrx
+++ b/tests/fixtures/limit/basic.hrx
@@ -1,0 +1,51 @@
+<===> limit/1/input.scss
+p {
+  color: #ff8000;
+}
+
+<===> limit/1/output.css
+input: ["--precision", "10", "-t", "expanded", "input.scss"]
+file: p {
+  color: #ff8000;
+}
+
+<===>
+============================================================
+<===> limit/2/input.scss
+p {
+  color: #ff8000;
+}
+
+<===> limit/2/output.css
+input: ["--precision", "10", "-t", "expanded", "input.scss"]
+file: p {
+  color: #ff8000;
+}
+
+<===>
+============================================================
+<===> limit/3/input.scss
+p {
+  color: #ff8000;
+}
+
+<===> limit/3/output.css
+input: ["--precision", "10", "-t", "expanded", "input.scss"]
+file: p {
+  color: #ff8000;
+}
+
+<===>
+============================================================
+<===> limit/4/input.scss
+p {
+  color: #ff8000;
+}
+
+<===> limit/4/output.css
+input: ["--precision", "10", "-t", "expanded", "input.scss"]
+file: p {
+  color: #ff8000;
+}
+
+<===>

--- a/tests/spec_helper.rb
+++ b/tests/spec_helper.rb
@@ -14,3 +14,12 @@ def test_results(output)
   matches.names.each { |k, v| results[k.to_sym] = matches[k].to_i }
   results
 end
+
+# Gives a command string that Aruba should run for a unit test.
+# This command calls sass-spec using the sass stub.
+# It takes in the name of a fixture folder and an array of additional flags.
+def command(fixture_folder, additional_flags = [])
+  ["#{Dir.pwd}/sass-spec.rb #{additional_flags.join(' ')}",
+  "--command '#{Dir.pwd}/tests/sass_stub'",
+  "#{Dir.pwd}/tests/fixtures/#{fixture_folder}"].join(' ')
+end

--- a/tests/spec_helper.rb
+++ b/tests/spec_helper.rb
@@ -18,8 +18,8 @@ end
 # Gives a command string that Aruba should run for a unit test.
 # This command calls sass-spec using the sass stub.
 # It takes in the name of a fixture folder and an array of additional flags.
-def command(fixture_folder, additional_flags = [])
-  ["#{Dir.pwd}/sass-spec.rb #{additional_flags.join(' ')}",
+def run_sass(fixture_folder, additional_flags = [])
+  run_command(["#{Dir.pwd}/sass-spec.rb #{additional_flags.join(' ')}",
   "--command '#{Dir.pwd}/tests/sass_stub'",
-  "#{Dir.pwd}/tests/fixtures/#{fixture_folder}"].join(' ')
+  "#{Dir.pwd}/tests/fixtures/#{fixture_folder}"].join(' '))
 end


### PR DESCRIPTION
This is a set of unit tests on the --limit flag.

It contains two bug fixes:

* Limit flag accepts negative numbers, despite what docs say (which leads to unintuitive behavior)
* When using limits, the runner would always run limit + 1 tests.

This also adds the Unit tests into Travis runs.