### PR TITLE
Don't include leading underscores in implicit namespaces

### DIFF
--- a/spec/directives/use/member/namespaced.hrx
+++ b/spec/directives/use/member/namespaced.hrx
@@ -170,6 +170,22 @@ a {
 
 <===>
 ================================================================================
+<===> default/without_underscore/input.scss
+// A single leading underscore is removed before determining the namespace.
+@use "_other";
+
+a {b: other.$variable}
+
+<===> default/without_underscore/_other.scss
+$variable: value;
+
+<===> default/without_underscore/output.css
+a {
+  b: value;
+}
+
+<===>
+================================================================================
 <===> explicit/variable_use/input.scss
 @use "other" as o;
 


### PR DESCRIPTION
See sass/sass#2800

[skip dart-sass]