### PR TITLE
Add a missing warning to a LibSass spec

### DIFF
--- a/spec/libsass-closed-issues/issue_2520.hrx
+++ b/spec/libsass-closed-issues/issue_2520.hrx
@@ -278,3 +278,12 @@
 [class*="modal--"][class*="--animate"][class*="--zoom"] {
   content: "fizzbuzz";
 }
+
+<===> warning-libsass
+DEPRECATION WARNING on line 120 of /sass/spec/libsass-issues/issue_2520/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$config: null` at the top level.
+
+DEPRECATION WARNING on line 130 of /sass/spec/libsass-issues/issue_2520/input.scss:
+!global assignments won't be able to declare new variables in future versions.
+Consider adding `$module: null` at the top level.


### PR DESCRIPTION
This warning was added by sass/libsass#2913