### PR TITLE
Fix typo: unecessary → unnecessary

### DIFF
--- a/lib/sass_spec/cli.rb
+++ b/lib/sass_spec/cli.rb
@@ -99,7 +99,7 @@ Make sure the command you provide prints to stdout.
         options[:silent] = true
       end
 
-      opts.on("--check-annotations", "Check if any test annotations are unecessary.") do
+      opts.on("--check-annotations", "Check if any test annotations are unnecessary.") do
         options[:check_annotations] = true
       end
 


### PR DESCRIPTION
Caught by the Debian Lintian tool:

`I: sass-spec: spelling-error-in-manpage usr/share/man/man1/sass-spec.1.gz unecessary unnecessary`

Thanks!
