### PR TITLE
Add libsass warnings for invalid selectors

### DIFF
--- a/spec/core_functions/selector/extend/no_op.hrx
+++ b/spec/core_functions/selector/extend/no_op.hrx
@@ -46,6 +46,11 @@ a {
   b: ::c.d;
 }
 
+<===> conflict/pseudo_element/unknown/warning-libsass
+WARNING on line 1, column 30 of /sass/spec/core_functions/selector/extend/no_op/conflict/pseudo_element/unknown/input.scss:
+LibSass detected an invalid selector order: "::c.d"
+This will make any group of selectors containing it invalid!
+
 <===>
 ================================================================================
 <===> conflict/pseudo_element/class_syntax/input.scss
@@ -55,6 +60,11 @@ a {b: selector-extend(":before.c", ".c", ":after")}
 a {
   b: :before.c;
 }
+
+<===> conflict/pseudo_element/class_syntax/warning-libsass
+WARNING on line 1, column 34 of /sass/spec/core_functions/selector/extend/no_op/conflict/pseudo_element/class_syntax/input.scss:
+LibSass detected an invalid selector order: ":before.c"
+This will make any group of selectors containing it invalid!
 
 <===>
 ================================================================================

--- a/spec/core_functions/selector/is_superselector/compound.hrx
+++ b/spec/core_functions/selector/is_superselector/compound.hrx
@@ -28,6 +28,11 @@ a {
   b: true;
 }
 
+<===> different_order/warning-libsass
+WARNING on line 1, column 38 of /sass/spec/core_functions/selector/is_superselector/compound/different_order/input.scss:
+LibSass detected an invalid selector order: "c:d.e"
+This will make any group of selectors containing it invalid!
+
 <===>
 ================================================================================
 <===> superset/input.scss

--- a/spec/core_functions/selector/unify/complex/overlap.hrx
+++ b/spec/core_functions/selector/unify/complex/overlap.hrx
@@ -46,6 +46,15 @@ a {
   b: ::s1-1.c ::s2-1.c .s1-2.s2-2, ::s2-1.c ::s1-1.c .s1-2.s2-2;
 }
 
+<===> pseudo_element/no_unification/warning-libsass
+WARNING on line 1, column 38 of /sass/spec/core_functions/selector/unify/complex/overlap/pseudo_element/no_unification/input.scss:
+LibSass detected an invalid selector order: "::s1-1.c"
+This will make any group of selectors containing it invalid!
+
+WARNING on line 1, column 56 of /sass/spec/core_functions/selector/unify/complex/overlap/pseudo_element/no_unification/input.scss:
+LibSass detected an invalid selector order: "::s2-1.c"
+This will make any group of selectors containing it invalid!
+
 <===>
 ================================================================================
 <===> pseudo_element/forced_unification/input.scss

--- a/spec/non_conformant/extend-tests/070_test_pseudo_unification.hrx
+++ b/spec/non_conformant/extend-tests/070_test_pseudo_unification.hrx
@@ -6,3 +6,13 @@
 -a :foo.baz, -a :foo:foo(2n+1) {
   a: b;
 }
+
+<===> warning-libsass
+WARNING on line 1, column 5 of /sass/spec/non_conformant/extend-tests/070_test_pseudo_unification/input.scss:
+LibSass detected an invalid selector order: ":foo.baz"
+This will make any group of selectors containing it invalid!
+
+WARNING on line 1, column 5 of /sass/spec/non_conformant/extend-tests/070_test_pseudo_unification/input.scss:
+LibSass detected an invalid selector order: ":foo.baz"
+This may happen due to invalid use of the `&` parent selector.
+It will make any group of selectors containing it invalid!

--- a/spec/non_conformant/extend-tests/071_test_pseudo_unification.hrx
+++ b/spec/non_conformant/extend-tests/071_test_pseudo_unification.hrx
@@ -6,3 +6,13 @@
 -a :foo.baz, -a :foo::foo {
   a: b;
 }
+
+<===> warning-libsass
+WARNING on line 1, column 5 of /sass/spec/non_conformant/extend-tests/071_test_pseudo_unification/input.scss:
+LibSass detected an invalid selector order: ":foo.baz"
+This will make any group of selectors containing it invalid!
+
+WARNING on line 1, column 5 of /sass/spec/non_conformant/extend-tests/071_test_pseudo_unification/input.scss:
+LibSass detected an invalid selector order: ":foo.baz"
+This may happen due to invalid use of the `&` parent selector.
+It will make any group of selectors containing it invalid!

--- a/spec/non_conformant/extend-tests/072_test_pseudo_unification.hrx
+++ b/spec/non_conformant/extend-tests/072_test_pseudo_unification.hrx
@@ -6,3 +6,13 @@
 -a ::foo {
   a: b;
 }
+
+<===> warning-libsass
+WARNING on line 1, column 5 of /sass/spec/non_conformant/extend-tests/072_test_pseudo_unification/input.scss:
+LibSass detected an invalid selector order: "::foo.baz"
+This will make any group of selectors containing it invalid!
+
+WARNING on line 1, column 5 of /sass/spec/non_conformant/extend-tests/072_test_pseudo_unification/input.scss:
+LibSass detected an invalid selector order: "::foo.baz"
+This may happen due to invalid use of the `&` parent selector.
+It will make any group of selectors containing it invalid!

--- a/spec/non_conformant/extend-tests/073_test_pseudo_unification.hrx
+++ b/spec/non_conformant/extend-tests/073_test_pseudo_unification.hrx
@@ -6,3 +6,13 @@
 -a ::foo(2n+1) {
   a: b;
 }
+
+<===> warning-libsass
+WARNING on line 1, column 5 of /sass/spec/non_conformant/extend-tests/073_test_pseudo_unification/input.scss:
+LibSass detected an invalid selector order: "::foo(2n+1).baz"
+This will make any group of selectors containing it invalid!
+
+WARNING on line 1, column 5 of /sass/spec/non_conformant/extend-tests/073_test_pseudo_unification/input.scss:
+LibSass detected an invalid selector order: "::foo(2n+1).baz"
+This may happen due to invalid use of the `&` parent selector.
+It will make any group of selectors containing it invalid!

--- a/spec/non_conformant/extend-tests/074_test_pseudo_unification.hrx
+++ b/spec/non_conformant/extend-tests/074_test_pseudo_unification.hrx
@@ -6,3 +6,13 @@
 -a :foo.baz, -a :foo:bar {
   a: b;
 }
+
+<===> warning-libsass
+WARNING on line 1, column 5 of /sass/spec/non_conformant/extend-tests/074_test_pseudo_unification/input.scss:
+LibSass detected an invalid selector order: ":foo.baz"
+This will make any group of selectors containing it invalid!
+
+WARNING on line 1, column 5 of /sass/spec/non_conformant/extend-tests/074_test_pseudo_unification/input.scss:
+LibSass detected an invalid selector order: ":foo.baz"
+This may happen due to invalid use of the `&` parent selector.
+It will make any group of selectors containing it invalid!

--- a/spec/non_conformant/extend-tests/077_test_pseudo_unification.hrx
+++ b/spec/non_conformant/extend-tests/077_test_pseudo_unification.hrx
@@ -6,3 +6,13 @@
 -a :foo {
   a: b;
 }
+
+<===> warning-libsass
+WARNING on line 1, column 5 of /sass/spec/non_conformant/extend-tests/077_test_pseudo_unification/input.scss:
+LibSass detected an invalid selector order: ":foo.baz"
+This will make any group of selectors containing it invalid!
+
+WARNING on line 1, column 5 of /sass/spec/non_conformant/extend-tests/077_test_pseudo_unification/input.scss:
+LibSass detected an invalid selector order: ":foo.baz"
+This may happen due to invalid use of the `&` parent selector.
+It will make any group of selectors containing it invalid!

--- a/spec/non_conformant/extend-tests/087_test_negation_unification.hrx
+++ b/spec/non_conformant/extend-tests/087_test_negation_unification.hrx
@@ -6,3 +6,13 @@
 -a :not(.foo).baz, -a :not(.foo):not(.bar) {
   a: b;
 }
+
+<===> warning-libsass
+WARNING on line 1, column 5 of /sass/spec/non_conformant/extend-tests/087_test_negation_unification/input.scss:
+LibSass detected an invalid selector order: ":not(.foo).baz"
+This will make any group of selectors containing it invalid!
+
+WARNING on line 1, column 5 of /sass/spec/non_conformant/extend-tests/087_test_negation_unification/input.scss:
+LibSass detected an invalid selector order: ":not(.foo).baz"
+This may happen due to invalid use of the `&` parent selector.
+It will make any group of selectors containing it invalid!

--- a/spec/non_conformant/extend-tests/088_test_negation_unification.hrx
+++ b/spec/non_conformant/extend-tests/088_test_negation_unification.hrx
@@ -6,3 +6,13 @@
 -a :not(.foo) {
   a: b;
 }
+
+<===> warning-libsass
+WARNING on line 1, column 5 of /sass/spec/non_conformant/extend-tests/088_test_negation_unification/input.scss:
+LibSass detected an invalid selector order: ":not(.foo).baz"
+This will make any group of selectors containing it invalid!
+
+WARNING on line 1, column 5 of /sass/spec/non_conformant/extend-tests/088_test_negation_unification/input.scss:
+LibSass detected an invalid selector order: ":not(.foo).baz"
+This may happen due to invalid use of the `&` parent selector.
+It will make any group of selectors containing it invalid!

--- a/spec/non_conformant/extend-tests/089_test_negation_unification.hrx
+++ b/spec/non_conformant/extend-tests/089_test_negation_unification.hrx
@@ -6,3 +6,13 @@
 -a :not([a=b]) {
   a: b;
 }
+
+<===> warning-libsass
+WARNING on line 1, column 5 of /sass/spec/non_conformant/extend-tests/089_test_negation_unification/input.scss:
+LibSass detected an invalid selector order: ":not([a=b]).baz"
+This will make any group of selectors containing it invalid!
+
+WARNING on line 1, column 5 of /sass/spec/non_conformant/extend-tests/089_test_negation_unification/input.scss:
+LibSass detected an invalid selector order: ":not([a=b]).baz"
+This may happen due to invalid use of the `&` parent selector.
+It will make any group of selectors containing it invalid!


### PR DESCRIPTION
I would like to warn users if we encounter invalid selectors.
I believe this is always unwanted and can lead to hard to debug issues.