### PR TITLE
Fix single character typo

### DIFF
--- a/spec/non_conformant/extend-tests/extend-result-of-extend.hrx
+++ b/spec/non_conformant/extend-tests/extend-result-of-extend.hrx
@@ -1,5 +1,5 @@
 <===> input.scss
-// The result of :not(.c) being extended should itself be extenable.
+// The result of :not(.c) being extended should itself be extendable.
 .a {@extend :not(.b)}
 .b {@extend .c}
 :not(.c) {x: y}


### PR DESCRIPTION
"extenable" => "extendable"