### PR TITLE
Add specs for map.deep-merge()

### DIFF
--- a/spec/core_functions/map/deep_merge.hrx
+++ b/spec/core_functions/map/deep_merge.hrx
@@ -1,0 +1,241 @@
+<===> options.yml
+---
+:todo:
+- sass/libsass#3127
+
+<===>
+================================================================================
+<===> shallow/empty/both/input.scss
+@use 'sass:map';
+a {b: inspect(map.deep-merge((), ()))}
+
+<===> shallow/empty/both/output.css
+a {
+  b: ();
+}
+
+<===>
+================================================================================
+<===> shallow/empty/first/input.scss
+@use 'sass:map';
+a {b: inspect(map.deep-merge((), (c: d, e: f)))}
+
+<===> shallow/empty/first/output.css
+a {
+  b: (c: d, e: f);
+}
+
+<===>
+================================================================================
+<===> shallow/empty/second/input.scss
+@use 'sass:map';
+a {b: inspect(map.deep-merge((c: d, e: f), ()))}
+
+<===> shallow/empty/second/output.css
+a {
+  b: (c: d, e: f);
+}
+
+<===>
+================================================================================
+<===> shallow/different_keys/input.scss
+@use 'sass:map';
+a {b: inspect(map.deep-merge((c: d, e: f), (1: 2, 3: 4)))}
+
+<===> shallow/different_keys/output.css
+a {
+  b: (1: 2, 3: 4, c: d, e: f);
+}
+
+<===>
+================================================================================
+<===> shallow/same_keys/input.scss
+@use 'sass:map';
+a {b: inspect(map.deep-merge((c: d, e: f), (c: 1, e: 2)))}
+
+<===> shallow/same_keys/output.css
+a {
+  b: (c: 1, e: 2);
+}
+
+<===>
+================================================================================
+<===> shallow/overlapping_keys/input.scss
+@use 'sass:map';
+a {b: inspect(map.deep-merge((c: d, e: f, g: h), (i: 1, e: 2, j: 3)))}
+
+<===> shallow/overlapping_keys/output.css
+a {
+  b: (i: 1, e: 2, j: 3, c: d, g: h);
+}
+
+<===>
+================================================================================
+<===> deep/empty/first/input.scss
+@use 'sass:map';
+a {b: inspect(map.deep-merge((c: ()), (c: (d: e))))}
+
+<===> deep/empty/first/output.css
+a {
+  b: (c: (d: e));
+}
+
+<===>
+================================================================================
+<===> deep/empty/second/input.scss
+@use 'sass:map';
+a {b: inspect(map.deep-merge((c: (d: e)), (c: ())))}
+
+<===> deep/empty/second/output.css
+a {
+  b: (c: (d: e));
+}
+
+<===>
+================================================================================
+<===> deep/different_keys/input.scss
+@use 'sass:map';
+a {b: inspect(map.deep-merge((c: (d: e, f: g)), (c: (1: 2, 3: 4))))}
+
+<===> deep/different_keys/output.css
+a {
+  b: (c: (1: 2, 3: 4, d: e, f: g));
+}
+
+<===>
+================================================================================
+<===> deep/same_keys/input.scss
+@use 'sass:map';
+a {b: inspect(map.deep-merge((c: (d: e, f: g)), (c: (d: 1, f: 2))))}
+
+<===> deep/same_keys/output.css
+a {
+  b: (c: (d: 1, f: 2));
+}
+
+<===>
+================================================================================
+<===> deep/overlapping_keys/input.scss
+@use 'sass:map';
+a {b: inspect(map.deep-merge((c: (d: e, f: g, h: i)), (c: (j: 1, f: 2, k: 3))))}
+
+<===> deep/overlapping_keys/output.css
+a {
+  b: (c: (j: 1, f: 2, k: 3, d: e, h: i));
+}
+
+<===>
+================================================================================
+<===> deep/multiple_layers/input.scss
+@use 'sass:map';
+a {b: inspect(map.deep-merge((c: (d: (e: (f: g)))), (c: (d: (e: (1: 2))))))}
+
+<===> deep/multiple_layers/output.css
+a {
+  b: (c: (d: (e: (1: 2, f: g))));
+}
+
+<===>
+================================================================================
+<===> named/input.scss
+@use 'sass:map';
+a {b: inspect(map.deep-merge($map1: (c: d), $map2: (1: 2)))}
+
+<===> named/output.css
+a {
+  b: (1: 2, c: d);
+}
+
+<===>
+================================================================================
+<===> error/type/map1/input.scss
+@use 'sass:map';
+a {b: map.deep-merge(1, (c: d))}
+
+<===> error/type/map1/error
+Error: $map1: 1 is not a map.
+  ,
+2 | a {b: map.deep-merge(1, (c: d))}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet
+
+<===> error/type/map1/error-libsass
+Error: argument `$map1` of `map.deep-merge($map1, $map2)` must be a map
+        on line 1:7 of input.scss, in function `map.deep-merge`
+        from line 1:7 of input.scss
+>> a {b: map.deep-merge(1, (c: d))}
+
+   ------^
+
+<===>
+================================================================================
+<===> error/type/map2/input.scss
+@use 'sass:map';
+a {b: map.deep-merge((c: d), 1)}
+
+<===> error/type/map2/error
+Error: $map2: 1 is not a map.
+  ,
+2 | a {b: map.deep-merge((c: d), 1)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet
+
+<===> error/type/map2/error-libsass
+Error: argument `$map2` of `map.deep-merge($map1, $map2)` must be a map
+        on line 1:7 of input.scss, in function `map.deep-merge`
+        from line 1:7 of input.scss
+>> a {b: map.deep-merge((c: d), 1)}
+
+   ------^
+
+<===>
+================================================================================
+<===> error/too_few_args/input.scss
+@use 'sass:map';
+a {b: map.deep-merge((c: d))}
+
+<===> error/too_few_args/error
+Error: Missing argument $map2.
+  ,--> input.scss
+2 | a {b: map.deep-merge((c: d))}
+  |       ^^^^^^^^^^^^^^^^^^^^^^ invocation
+  '
+  ,--> sass:map
+1 | @function deep-merge($map1, $map2) {
+  |           ======================== declaration
+  '
+  input.scss 2:7  root stylesheet
+
+<===> error/too_few_args/error-libsass
+Error: Function map.deep-merge is missing argument $map2.
+        on line 1 of input.scss
+>> a {b: map.deep-merge((c: d))}
+
+   ------^
+
+<===>
+================================================================================
+<===> error/too_many_args/input.scss
+@use 'sass:map';
+a {b: map.deep-merge((c: d), (e: f), (g: h))}
+
+<===> error/too_many_args/error
+Error: Only 2 arguments allowed, but 3 were passed.
+  ,--> input.scss
+2 | a {b: map.deep-merge((c: d), (e: f), (g: h))}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invocation
+  '
+  ,--> sass:map
+1 | @function deep-merge($map1, $map2) {
+  |           ======================== declaration
+  '
+  input.scss 2:7  root stylesheet
+
+<===> error/too_many_args/error-libsass
+Error: wrong number of arguments (3 for 2) for `map.deep-merge'
+        on line 1:7 of input.scss
+>> a {b: map.deep-merge((c: d), (e: f), (g: h))}
+
+   ------^


### PR DESCRIPTION
Note: this is the same as #1560, but correctly pointed at the
`feature.nested-maps` branch.

See sass/sass#2836

[skip dart-sass]