### PR TITLE
Feature: Test support for multiline expressions in indented syntax

### DIFF
--- a/spec/multiline_sass/input.sass
+++ b/spec/multiline_sass/input.sass
@@ -1,0 +1,64 @@
+@mixin reset-list
+  margin: 0
+  padding: 0
+  list-style: none
+@mixin horizontal-list
+  @include reset-list
+
+  li
+    display: inline-block
+    margin:
+      left: -2px
+      right: 2em
+
+nav ul
+  @include horizontal-list
+
+/* Mixins */
+@mixin col($cols, $mleft: 0, $mright: 0, $include-margin: false, $border: 0, \
+           $pleft: 0, $pright: 0, $include-padding: true, $extra: 0, $clear: false, \
+           $lead: true, $container: false)
+    width: $cols
+    color: red
+    display: block
+
+div
+    @include col(5)
+
+/* Font faces */
+@font-face
+    font-family: 'SPEdessa'
+    src: url('fonts/spedessa-webfont.eot')
+    src: url('fonts/spedessa-webfont.eot?#iefix') format('embedded-opentype'), \
+        url('fonts/spedessa-webfont.woff') format('woff'), \
+        url('fonts/spedessa-webfont.ttf') format('truetype')
+    font-weight: normal
+    font-style: normal
+
+/* List */
+$list:  (1,  "value"), \
+    (5,  "value"), \
+    (23, "value"), \
+    (85, "value"), \
+    (32, "value"), \
+    (11, "value"), \
+    (35, "value"), \
+    (89, "value")
+
+@each $item in $list
+    .icon-#{$item} 
+        font-size: $item
+
+/* Maps */
+$susy: ( columns: 12, \
+  gutters: 1/3, \
+  gutter-position: after, \
+  math: fluid, \
+  output: float, \
+  flow: ltr, \
+  global-box-sizing: border-box )
+
+@each $key, $value in $susy
+    div-#{$key}
+        color: red
+        test : $value

--- a/spec/multiline_sass/options.yml
+++ b/spec/multiline_sass/options.yml
@@ -1,0 +1,4 @@
+---
+:todo:
+- ruby-sass
+- libsass

--- a/spec/multiline_sass/output.css
+++ b/spec/multiline_sass/output.css
@@ -1,0 +1,94 @@
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav ul li {
+  display: inline-block;
+  margin-left: -2px;
+  margin-right: 2em;
+}
+
+/* Mixins */
+div {
+  width: 5;
+  color: red;
+  display: block;
+}
+
+/* Font faces */
+@font-face {
+  font-family: "SPEdessa";
+  src: url("fonts/spedessa-webfont.eot");
+  src: url("fonts/spedessa-webfont.eot?#iefix") format("embedded-opentype"), url("fonts/spedessa-webfont.woff") format("woff"), url("fonts/spedessa-webfont.ttf") format("truetype");
+  font-weight: normal;
+  font-style: normal;
+}
+/* List */
+.icon-1, value {
+  font-size: 1, "value";
+}
+
+.icon-5, value {
+  font-size: 5, "value";
+}
+
+.icon-23, value {
+  font-size: 23, "value";
+}
+
+.icon-85, value {
+  font-size: 85, "value";
+}
+
+.icon-32, value {
+  font-size: 32, "value";
+}
+
+.icon-11, value {
+  font-size: 11, "value";
+}
+
+.icon-35, value {
+  font-size: 35, "value";
+}
+
+.icon-89, value {
+  font-size: 89, "value";
+}
+
+/* Maps */
+div-columns {
+  color: red;
+  test: 12;
+}
+
+div-gutters {
+  color: red;
+  test: 0.3333333333;
+}
+
+div-gutter-position {
+  color: red;
+  test: after;
+}
+
+div-math {
+  color: red;
+  test: fluid;
+}
+
+div-output {
+  color: red;
+  test: float;
+}
+
+div-flow {
+  color: red;
+  test: ltr;
+}
+
+div-global-box-sizing {
+  color: red;
+  test: border-box;
+}


### PR DESCRIPTION
Test for https://github.com/sass/dart-sass/pull/1098

backslash `\` is used to wrap long lines, it most be followed by newline and spaces after will be ignored.

fixes sass/dart-sass#280
fixes sass/sass#216

All test passed
![Captura de pantalla de 2020-09-27 10-43-37](https://user-images.githubusercontent.com/7505980/94359326-1a923b80-00af-11eb-9260-5ca2397a06ca.png)
