### PR TITLE
Remove duplicate specs for feature-exists

### DIFF
--- a/spec/libsass/features/at-error.hrx
+++ b/spec/libsass/features/at-error.hrx
@@ -1,9 +1,0 @@
-<===> input.scss
-foo {
-  foo: feature-exists('at-error');
-}
-
-<===> output.css
-foo {
-  foo: true;
-}

--- a/spec/libsass/features/extend-selector-pseudoclass.hrx
+++ b/spec/libsass/features/extend-selector-pseudoclass.hrx
@@ -1,9 +1,0 @@
-<===> input.scss
-foo {
-  foo: feature-exists('extend-selector-pseudoclass');
-}
-
-<===> output.css
-foo {
-  foo: true;
-}

--- a/spec/libsass/features/global-variable-shadowing.hrx
+++ b/spec/libsass/features/global-variable-shadowing.hrx
@@ -1,9 +1,0 @@
-<===> input.scss
-foo {
-  foo: feature-exists('global-variable-shadowing');
-}
-
-<===> output.css
-foo {
-  foo: true;
-}

--- a/spec/libsass/features/units-level-3.hrx
+++ b/spec/libsass/features/units-level-3.hrx
@@ -1,9 +1,0 @@
-<===> input.scss
-foo {
-  foo: feature-exists('units-level-3');
-}
-
-<===> output.css
-foo {
-  foo: true;
-}


### PR DESCRIPTION
These specs are exactly the same than the ones available in `core_functions/meta/feature_exists.hrx` (which has more of them).