### PR TITLE
Make the spec runner compatible with the sass executable

### DIFF
--- a/lib/sass_spec/engine_adapter.rb
+++ b/lib/sass_spec/engine_adapter.rb
@@ -28,7 +28,7 @@ class ExecutableEngineAdapter < EngineAdapter
     @command = command
     @timeout = 90
     @description = description || command
-    @version = `#{@command} -v`
+    @version = `#{@command} --version`
   end
 
   def set_description(description)
@@ -43,7 +43,7 @@ class ExecutableEngineAdapter < EngineAdapter
     command = File.absolute_path(@command)
     dirname, basename = File.split(sass_filename)
     result = capture3_with_timeout(
-      command, "--precision", precision.to_s, "-t", "expanded",
+      command, "--precision", precision.to_s, "--style", "expanded",
       "-I", File.expand_path("../../../spec", __FILE__), *@args&.split(/\s+/), basename,
       binmode: true, timeout: @timeout, chdir: dirname)
 

--- a/tests/fixtures/basic/basic.hrx
+++ b/tests/fixtures/basic/basic.hrx
@@ -3,7 +3,7 @@ p {
   color: #ff8000;
 }
 <===> output.css
-input: ["--precision", "10", "-t", "expanded", "input.scss"]
+input: ["--precision", "10", "--style", "expanded", "input.scss"]
 file: p {
   color: #ff8000;
 }

--- a/tests/fixtures/limit/basic.hrx
+++ b/tests/fixtures/limit/basic.hrx
@@ -4,7 +4,7 @@ p {
 }
 
 <===> limit/1/output.css
-input: ["--precision", "10", "-t", "expanded", "input.scss"]
+input: ["--precision", "10", "--style", "expanded", "input.scss"]
 file: p {
   color: #ff8000;
 }
@@ -17,7 +17,7 @@ p {
 }
 
 <===> limit/2/output.css
-input: ["--precision", "10", "-t", "expanded", "input.scss"]
+input: ["--precision", "10", "--style", "expanded", "input.scss"]
 file: p {
   color: #ff8000;
 }
@@ -30,7 +30,7 @@ p {
 }
 
 <===> limit/3/output.css
-input: ["--precision", "10", "-t", "expanded", "input.scss"]
+input: ["--precision", "10", "--style", "expanded", "input.scss"]
 file: p {
   color: #ff8000;
 }
@@ -43,7 +43,7 @@ p {
 }
 
 <===> limit/4/output.css
-input: ["--precision", "10", "-t", "expanded", "input.scss"]
+input: ["--precision", "10", "--style", "expanded", "input.scss"]
 file: p {
   color: #ff8000;
 }

--- a/tests/fixtures/todo/basic.hrx
+++ b/tests/fixtures/todo/basic.hrx
@@ -4,7 +4,7 @@ p {
 }
 
 <===> no_todo/output.css
-input: ["--precision", "10", "-t", "expanded", "input.scss"]
+input: ["--precision", "10", "--style", "expanded", "input.scss"]
 file: p {
   color: #ff8000;
 }
@@ -22,7 +22,7 @@ p {
 }
 
 <===> todo/output.css
-input: ["--precision", "10", "-t", "expanded", "input.scss"]
+input: ["--precision", "10", "--style", "expanded", "input.scss"]
 file: p {
   color: #ff8000;
 }

--- a/tests/sass_stub
+++ b/tests/sass_stub
@@ -3,7 +3,7 @@
 # transformations and simply outputs the input file to stdout.
 
 # Version flag needs to return a value.
-if ARGV.last == '-v'
+if ARGV.last == '--version'
   puts '0.1'
 else
   # sass-spec passes in full paths to the -I command. We should


### PR DESCRIPTION
Closes #1540 

To run specs against a sass binary, use this command:

```
bundle exec ./sass-spec.rb --impl dart-sass -c /path/to/sass --cmd-args='--no-unicode --no-color'
```

`--cmd-args` is needed to match the arguments used by `--dart` so that the output matches the expectation.

Regarding performance, this indeed helps when running only a few specs. Here are the result on my machine. The `-c` run uses the Linux x64 binary for dart-sass 1.28.0 downloaded from the github releases.

Full run:
- `--dart`: Finished in 23.162925s, 251.1773 runs/s
- `-c`: Finished in 131.673413s, 44.1851 runs/s

Run filtered on `spec/directives/import/error/not_found`:
- `--dart`: Finished in 0.264161s, 11.3567 runs/s
- `-c`: Finished in 0.069728s, 43.0243 runs/s