### PR TITLE
Fix broken selector specs

### DIFF
--- a/spec/css/selector.hrx
+++ b/spec/css/selector.hrx
@@ -101,7 +101,7 @@ b {
 }
 
 <===> inline_comments/silent/with_comma_in_comment/warning
-WARNING on line 4, column 1 of input.sass:
+WARNING on line 4, column 1 of input.sass: 
 This selector doesn't have any properties and won't be rendered.
   ,
 4 | a // comment,
@@ -363,7 +363,7 @@ Error: unterminated attribute selector for a
 <===>
 ================================================================================
 <===> escaping/number_as_first_char_without_space/input.scss
-.\31u {a: n;}
+.\31u {a: b;}
 
 <===> escaping/number_as_first_char_without_space/output.css
 .\31 u {


### PR DESCRIPTION
This should fix the broken specs and unblock Dart Sass PRs.

Check the CI log manually to confirm there are now failures before submitting, since it's currently not reporting them.

As a sidenote, we should probably do something about specs containing lines ending with whitespace. A lot of editors (including mine) automatically remove trailing whitespace, which makes it easy for errors like this to slip in.