### PR TITLE
Add an editorconfig file with basic rules for editors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+
+[*.hrx]
+trim_trailing_whitespace = false


### PR DESCRIPTION
The configured rules help contributors respect the project styles when their editor support this (which most editors do either natively or with a plugin nowadays), even if their own editor configuration has different defaults.
The configured rules for now are:

- use 2 spaces for indentation
- don't trim trailing whitespaces in HRX files, as some specs rely on them (see #1622)