### PR TITLE
Improve the way to exit from the spec runner

### DIFF
--- a/lib-js/cli-args.ts
+++ b/lib-js/cli-args.ts
@@ -1,7 +1,7 @@
 import path from "path"
 import yargs from "yargs/yargs"
 import { Argv } from "yargs"
-import { Compiler, DartCompiler, executableCompiler } from "./compiler"
+import { Compiler, DartCompiler, ExecutableCompiler } from "./compiler"
 
 export interface CliArgs {
   root: string
@@ -117,7 +117,7 @@ export async function parseArgs(
   }
 
   if (argv.command) {
-    args.compiler = executableCompiler(
+    args.compiler = new ExecutableCompiler(
       path.resolve(process.cwd(), argv.command),
       cmdArgs
     )

--- a/sass-spec.ts
+++ b/sass-spec.ts
@@ -40,6 +40,7 @@ async function runAllTests() {
   tabulator.printResults()
   console.log(`Finished in ${time}s`)
   process.exitCode = tabulator.exitCode()
+  args.compiler.shutdown()
 }
 
 runAllTests()

--- a/sass-spec.ts
+++ b/sass-spec.ts
@@ -39,7 +39,7 @@ async function runAllTests() {
 
   tabulator.printResults()
   console.log(`Finished in ${time}s`)
-  process.exit(tabulator.exitCode())
+  process.exitCode = tabulator.exitCode()
 }
 
 runAllTests()

--- a/test/fixtures/mock-compiler.ts
+++ b/test/fixtures/mock-compiler.ts
@@ -2,14 +2,18 @@ import yaml from "js-yaml"
 import { Compiler, Stdio } from "../../lib-js/compiler"
 import { SpecDirectory } from "../../lib-js/spec-directory"
 
-export function mockCompiler(specDir: SpecDirectory): Compiler {
-  return {
-    async compile(_, args): Promise<Stdio> {
-      // just read the input as yaml and then return its contents
-      const contents = await specDir.readFile(args[args.length - 1])
-      return yaml.safeLoad(contents) as Stdio
-    },
-    shutdown () {
-    },
+class MockCompiler extends Compiler {
+  constructor(private readonly specDir: SpecDirectory) {
+    super()
   }
+
+  async compile(_: string, args: string[]): Promise<Stdio> {
+    // just read the input as yaml and then return its contents
+    const contents = await this.specDir.readFile(args[args.length - 1])
+    return yaml.safeLoad(contents) as Stdio
+  }
+}
+
+export function mockCompiler(specDir: SpecDirectory): Compiler {
+  return new MockCompiler(specDir)
 }

--- a/test/fixtures/mock-compiler.ts
+++ b/test/fixtures/mock-compiler.ts
@@ -9,5 +9,7 @@ export function mockCompiler(specDir: SpecDirectory): Compiler {
       const contents = await specDir.readFile(args[args.length - 1])
       return yaml.safeLoad(contents) as Stdio
     },
+    shutdown () {
+    },
   }
 }

--- a/test/test-case/actual.test.ts
+++ b/test/test-case/actual.test.ts
@@ -85,7 +85,7 @@ OUTPUT
         stderr: "",
         status: 0,
       }))
-      const compiler = { compile }
+      const compiler = { compile, shutdown() {} }
       const dir = await fromContents(contents.trim())
       await TestCase.create(dir, "sass-mock", compiler)
       expect(compile).toHaveBeenCalledWith(


### PR DESCRIPTION
In node, write to stdout are asynchronous and can happen over multiple ticks of the event loop.
process.exit() forces the program to exit immediately, without waiting for any remaining pending asynchronous work, which can result in lost output if the output is not fully written yet.
Setting the process.exitCode property instead will configure the exit code to be used, while letting node terminate the process normally when nothing is pending in the event loop anymore.

See https://nodejs.org/api/process.html#process_process_exit_code for the doc about it.