### PR TITLE
Add a spec covering the case of at-root wrapping a property declaration

### DIFF
--- a/spec/directives/at_root.hrx
+++ b/spec/directives/at_root.hrx
@@ -15,3 +15,19 @@ b {
 b {
   c: d;
 }
+
+<===>
+================================================================================
+<===> property_only/input.scss
+@media print {
+  a {
+    @at-root (without: media) {
+      b: c;
+    }
+  }
+}
+
+<===> property_only/output.css
+a {
+  b: c;
+}


### PR DESCRIPTION
This case is not covered by any of the existing `@at-root` specs. However, we have a test case for that in the scssphp testsuite. I think upstreaming it here makes sense.