### PR TITLE
Add specs covering interpolation failures in loud comments

### DIFF
--- a/spec/css/comment.hrx
+++ b/spec/css/comment.hrx
@@ -225,3 +225,43 @@ Error: Invalid CSS after "...    e */ f {} }": expected selector or at-rule, was
 >>           e */ f {} } }
 
    ---------------------^
+
+<===>
+================================================================================
+<===> error/loud/interpolation/unterminated/input.scss
+/* #{broken */
+
+<===> error/loud/interpolation/unterminated/error
+Error: Expected expression.
+  ,
+1 | /* #{broken */
+  |               ^
+  '
+  input.scss 1:15  root stylesheet
+
+<===> error/loud/interpolation/unterminated/error-libsass
+Error: unterminated interpolant inside string constant /* #{broken */
+        on line 1:1 of input.scss
+>> /* #{broken */
+
+   ^
+
+<===>
+================================================================================
+<===> error/loud/interpolation/failure/input.scss
+/* #{$undefined} */
+
+<===> error/loud/interpolation/failure/error
+Error: Undefined variable.
+  ,
+1 | /* #{$undefined} */
+  |      ^^^^^^^^^^
+  '
+  input.scss 1:6  root stylesheet
+
+<===> error/loud/interpolation/failure/error-libsass
+Error: Undefined variable: "$undefined".
+        on line 1:20 of input.scss
+>> /* #{$undefined} */
+
+   -------------------^


### PR DESCRIPTION
This ensures that such failures are not ignored silently.

scssphp used to ignore interpolation in comments. Then, interpolation support was implemented but in a lenient way, showing the original source of the comment in case of failure (either due to the parsing of the interpolation or due to its evaluation).
This enforces the proper behavior for comments.