### PR TITLE
Add missing newline for expected output

### DIFF
--- a/spec/core_functions/selector/extend/simple/pseudo/selector/match.hrx
+++ b/spec/core_functions/selector/extend/simple/pseudo/selector/match.hrx
@@ -43,6 +43,7 @@ a {b: selector-extend(":is(c d.e, f g)", ":is", "h")}
 a {
   b: :is(c d.e, f g);
 }
+
 <===>
 ================================================================================
 <===> unprefixed/matches/class/equal/input.scss


### PR DESCRIPTION
Otherwise ruby spec runner is sad :(
https://github.com/sass/libsass/pull/3156/checks?check_run_id=2634854094

```diff
  1) Failure:
SassSpec::Test#test__sass-spec/spec/core_functions/selector/extend/simple/pseudo/selector/match/unprefixed/is/class/unequal/has_argument [/home/runner/work/libsass/libsass/sass-spec/lib/sass_spec/test.rb:267]:
expected did not match output.
--- expected
+++ actual
@@ -1,3 +1,4 @@
 "a {
   b: :is(c d.e, f g);
-}"
+}
+"
```