### PR TITLE
Fix the arguments for running specs against the dart-sass command

### DIFF
--- a/lib-js/cli-args.ts
+++ b/lib-js/cli-args.ts
@@ -14,7 +14,7 @@ export interface CliArgs {
 }
 
 const implArgs: Record<string, string[]> = {
-  "dart-sass": ["--no-unicode", "--no-color"],
+  "dart-sass": ["--verbose", "--no-unicode", "--no-color"],
   libsass: ["--style", "expanded"],
 }
 

--- a/lib-js/compiler.ts
+++ b/lib-js/compiler.ts
@@ -92,7 +92,7 @@ export class DartCompiler implements Compiler {
 
   async compile(path: string, opts: string[]): Promise<Stdio> {
     this.stdin.write(`!cd ${path}\n`)
-    this.stdin.write(["--verbose", ...this.initArgs, ...opts].join(" ") + "\n")
+    this.stdin.write([...this.initArgs, ...opts].join(" ") + "\n")
 
     return {
       stdout: (await this.stdout.next()).value,


### PR DESCRIPTION
Thet `--verbose` argument is needed by the `dart-sass` implementation for both implementations of the sass-spec Compiler, not only for the DartCompiler. Otherwise, specs are failing when running `npm run sass-spec -- --impl dart-sass -c $(which sass) spec/non_conformant/scss/precision`