### PR TITLE
Add a regression test for operator precedence

### DIFF
--- a/spec/parser/operator_precedence.hrx
+++ b/spec/parser/operator_precedence.hrx
@@ -1,0 +1,10 @@
+<===> mixed/input.scss
+// Regression test for scssphp/scssphp#435
+a {
+  b: true or 1 < 0 and false;
+}
+
+<===> mixed/output.css
+a {
+  b: true;
+}


### PR DESCRIPTION
This is a regression test for https://github.com/scssphp/scssphp/issues/435 (and https://github.com/scssphp/scssphp/issues/434 which is caused by it)

Due to a bug, scssphp was parsing that as `(true or 1 < 0) and false` instead of `true or (1 < 0 and false)` (it happened due to the 3 operators with precedence of 1, 3 and 2. Removing the `<` operator was not reproducing the issue anymore).