### PR TITLE
add spec for trimming super selectors in `@extend`

### DIFF
--- a/spec/non_conformant/extend-tests/239_trims_super_selector_without_combinator.hrx
+++ b/spec/non_conformant/extend-tests/239_trims_super_selector_without_combinator.hrx
@@ -1,0 +1,17 @@
+<===> input.scss
+a b {
+  @extend %c;
+}
+
+a > b {
+  @extend %c;
+}
+
+%c {
+  color: red;
+}
+
+<===> output.css
+a b {
+  color: red;
+}


### PR DESCRIPTION
This was a really interesting bug -- the only one I've had to actually clone the `dart-sass` repo for in order to track down. The bug ended up being related to this line
![Captura de pantalla de 2021-07-30 23-37-40](https://user-images.githubusercontent.com/39542938/127727592-f4391bdd-5c40-42da-8036-f976c709eac7.png)

https://github.com/sass/dart-sass/blob/6f17b4aa9ca879d79d07f83474bae164617570bd/lib/src/extend/extension_store.dart#L135

`Set.identity` constructs a set that uses _pointer_ equality, rather than true equality. In rust this is hard to model, so this behavior was overlooked. The fix was implemented by giving a unique id to every original. See https://github.com/connorskees/grass/commit/fccf93cd96740c6642fa4eddb623472a90b85b76

Resolves https://github.com/sass/sass-spec/issues/1678