### PR TITLE
Add specs covering functions in import support conditions

### DIFF
--- a/spec/css/plain/import/conditions.hrx
+++ b/spec/css/plain/import/conditions.hrx
@@ -34,6 +34,18 @@
 
 <===>
 ================================================================================
+<===> supports/condition_function/options.yml
+:ignore_for:
+  - libsass
+
+<===> supports/condition_function/input.scss
+@import "a.css" supports(a(b));
+
+<===> supports/condition_function/output.css
+@import "a.css" supports(a(b));
+
+<===>
+================================================================================
 <===> supports/condition_negation/options.yml
 :ignore_for:
   - libsass


### PR DESCRIPTION
This adds a spec covering https://github.com/sass/dart-sass/issues/1462

skip dart-sass