### PR TITLE
Add the ability to run shared JS API tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 env:
+  PROTOC_VERSION: 3.x
   NODE_VERSION: 14
 
 
@@ -10,7 +11,7 @@ on:
 
 jobs:
   unit_tests_rb:
-    name: "Unit tests: Ruby"
+    name: "Unit tests | Ruby"
     runs-on: ubuntu-latest
 
     steps:
@@ -21,7 +22,7 @@ jobs:
         run: bundle exec rspec tests/
 
   unit_tests_ts:
-    name: "Unit tests: Typescript"
+    name: "Unit tests | Typescript"
     runs-on: ubuntu-latest
 
     steps:
@@ -44,8 +45,8 @@ jobs:
       - run: npm install
       - run: npm run lint
 
-  dart_sass:
-    name: Dart Sass
+  dart_sass_language:
+    name: "Language | Dart Sass"
     runs-on: ubuntu-latest
     if: "github.event_name != 'pull_request' || !contains(github.event.pull_request.body, 'skip dart-sass')"
 
@@ -71,7 +72,7 @@ jobs:
         run: npm run sass-spec -- --dart ../dart-sass
 
   libsass:
-    name: LibSass
+    name: "Language | LibSass"
     runs-on: ubuntu-latest
     if: "github.event_name != 'pull_request' || !contains(github.event.pull_request.body, 'skip libsass')"
 
@@ -95,3 +96,82 @@ jobs:
 
       - name: Run specs
         run: npm run sass-spec -- --impl libsass -c ../sassc/bin/sassc
+
+  dart_sass_js:
+    name: "JS API | Dart Sass | ${{ matrix.os }}"
+    runs-on: ubuntu-latest
+    if: "github.event_name != 'pull_request' || !contains(github.event.pull_request.body, 'skip dart-sass')"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with: {node-version: "${{ env.NODE_VERSION }}"}
+      - run: npm install
+      - uses: dart-lang/setup-dart@v1
+        with: {sdk: stable}
+
+      - name: Install dart-sass
+        run: |
+          git clone https://github.com/sass/dart-sass.git ../dart-sass --depth 1
+          (
+            cd ../dart-sass
+            dart pub get
+            dart pub run grinder pkg-npm-dev
+          )
+          npm install ../dart-sass/build/npm
+
+      - name: Check out Sass specification
+        run: git clone https://github.com/sass/sass.git ../sass --depth 1
+
+      - name: Run specs
+        run: npm run js-api-spec -- --sassSassRepo ../sass
+
+  embedded_host_js:
+    name: "JS API | Embedded Host | ${{ matrix.os }}"
+    runs-on: ubuntu-latest
+    if: "github.event_name != 'pull_request' || !contains(github.event.pull_request.body, 'skip embedded-host')"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with: {node-version: "${{ env.NODE_VERSION }}"}
+      - run: npm install
+      - uses: dart-lang/setup-dart@v1
+        with: {sdk: stable}
+      - uses: arduino/setup-protoc@v1
+        with:
+          version: ${{ env.PROTOC_VERSION }}
+          repo-token: '${{ github.token }}'
+
+      - name: Install embedded-host-node
+        run: |
+          git clone https://github.com/sass/embedded-host-node.git ../embedded-host-node --depth 1
+          (
+            cd ../embedded-host-node
+            npm install
+            npm run init
+            npm run compile
+            ln -s {`pwd`/,dist/}lib/src/vendor/dart-sass-embedded
+            # Prefer the Sass specification to the natively-generated .d.ts
+            # files. This ensures that when we add tests for new features, they
+            # won't cause compile-time failures if the embedded host doesn't
+            # support them.
+            find dist -name '*.d.ts' -exec rm {} \;
+          )
+          npm install sass@file:../embedded-host-node
+
+      - name: Check out Sass specification
+        run: git clone https://github.com/sass/sass.git ../sass --depth 1
+
+      - name: Run specs
+        run: npm run js-api-spec -- --sassSassRepo ../sass --sassPackage

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-};

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,9 @@
+import type {Config} from '@jest/types';
+
+const config: Config.InitialOptions = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['test'],
+};
+
+export default config;

--- a/js-api-spec.ts
+++ b/js-api-spec.ts
@@ -1,0 +1,106 @@
+/* eslint-disable no-process-exit */
+
+import * as fs from 'fs';
+import * as jest from 'jest';
+import * as p from 'path';
+import * as tmp from 'tmp';
+import yargs from 'yargs/yargs';
+
+import config from './jest.config';
+
+declare module 'jest' {
+  function run(args: string[]): never;
+}
+
+const args = yargs(process.argv.slice(2))
+  .parserConfiguration({'unknown-options-as-args': true})
+  .help(false)
+  .version(false)
+  .option('sassSassRepo', {
+    type: 'string',
+    description:
+      'The path to the sass/sass repo. Used to load type declarations. If ' +
+      'the sass package being tested declares its own types, those are used ' +
+      'instead, but this can provide type declarations for packages without ' +
+      'them.',
+  })
+  .option('sassPackage', {
+    type: 'string',
+    description:
+      'The path to the npm package that exports the Sass API. ' +
+      'Used to test locally against different APIs without having to install ' +
+      'and uninstall them.',
+  })
+  .option('help', {
+    type: 'boolean',
+    alias: 'h',
+    hidden: true,
+  });
+
+const argv = args.argv;
+
+if (argv.help) {
+  args.showHelp();
+  console.error('');
+  jest.run(['--help']);
+}
+
+// Set up a temp directory that overrides the default Jest configuration and
+// adds node_modules that depend on the given sassSassRepo and sassPackage.
+const tmpObject = tmp.dirSync({
+  template: 'js-api-spec.XXXXXX',
+  unsafeCleanup: true,
+});
+const dir = tmpObject.name;
+fs.rmSync(dir, {recursive: true, force: true});
+fs.mkdirSync(p.join(dir, 'node_modules', '@types', 'sass'), {recursive: true});
+
+const configPath = p.join(dir, 'jest.config.json');
+fs.writeFileSync(
+  configPath,
+  JSON.stringify({
+    ...config,
+    rootDir: p.resolve('.'),
+    roots: ['<rootDir>/js-api-spec'],
+  })
+);
+
+if (argv.sassPackage) {
+  fs.symlinkSync(
+    p.resolve(argv.sassPackage),
+    p.join(dir, 'node_modules', 'sass')
+  );
+}
+
+if (argv.sassSassRepo) {
+  fs.symlinkSync(
+    p.resolve(p.join(argv.sassSassRepo, 'spec/js-api')),
+    p.join(dir, 'node_modules', '@types', 'sass', 'js-api')
+  );
+  fs.writeFileSync(
+    p.join(dir, 'node_modules', '@types', 'sass', 'package.json'),
+    JSON.stringify({
+      name: '@types/sass',
+      types: 'js-api/index.d.ts',
+    })
+  );
+}
+
+fs.rmSync(p.join('js-api-spec', 'node_modules'), {
+  recursive: true,
+  force: true,
+});
+fs.symlinkSync(
+  p.resolve(p.join(dir, 'node_modules')),
+  p.join('js-api-spec', 'node_modules')
+);
+
+process.on('exit', () => {
+  fs.rmSync(p.join('js-api-spec', 'node_modules'), {
+    recursive: true,
+    force: true,
+  });
+  tmpObject.removeCallback();
+});
+
+jest.run([`--config=${configPath}`, ...(argv._ as string[])]);

--- a/js-api-spec/legacy/render.test.ts
+++ b/js-api-spec/legacy/render.test.ts
@@ -1,0 +1,11 @@
+import * as sass from 'sass';
+
+describe('renderSync()', () => {
+  it('renders a string', done => {
+    sass.render({data: 'a {b: c}'}, (err, result) => {
+      expect(err).toBeFalsy();
+      expect(result!.css.toString()).toBe('a {\n  b: c;\n}');
+      done();
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,18 +5,24 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "sass-spec",
       "version": "3.5.4",
       "license": "MIT",
       "dependencies": {
+        "@jest/types": "^26.6.2",
         "@types/diff": "^4.0.2",
         "@types/js-yaml": "^3.12.5",
         "@types/lodash": "^4.14.168",
         "@types/node": "^14.14.7",
+        "@types/tmp": "^0.2.1",
         "@types/yargs": "^15.0.9",
         "diff": "^5.0.0",
         "js-yaml": "^3.14.0",
         "lodash": "^4.17.21",
         "node-hrx": "^0.1.0",
+        "rxjs": "^6.5.5",
+        "source-map": "^0.6.1",
+        "tmp": "^0.0.33",
         "yargs": "^16.1.0"
       },
       "devDependencies": {
@@ -888,7 +894,6 @@
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
       "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
-      "dev": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
@@ -1041,14 +1046,12 @@
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
-      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==",
-      "dev": true
+      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw=="
     },
     "node_modules/@types/istanbul-lib-report": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
       "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
-      "dev": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
       }
@@ -1057,7 +1060,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
       "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
-      "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
@@ -1116,6 +1118,11 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
       "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
       "dev": true
+    },
+    "node_modules/@types/tmp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-7cTXwKP/HLOPVgjg+YhBdQ7bMiobGMuoBmrGmqwIWJv8elC6t1DfVc/mn4fD9UE1IjhwmhaQ5pGVXkmXbH0rhg=="
     },
     "node_modules/@types/yargs": {
       "version": "15.0.13",
@@ -1958,7 +1965,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
       "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -3777,7 +3783,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -5936,7 +5941,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6681,7 +6685,6 @@
       "version": "6.6.7",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
       "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-      "dev": true,
       "dependencies": {
         "tslib": "^1.9.0"
       },
@@ -7360,7 +7363,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7652,7 +7654,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -7770,7 +7771,6 @@
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
       "dependencies": {
         "os-tmpdir": "~1.0.2"
       },
@@ -7954,8 +7954,7 @@
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -9200,7 +9199,6 @@
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
       "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
-      "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
@@ -9332,14 +9330,12 @@
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
-      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==",
-      "dev": true
+      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw=="
     },
     "@types/istanbul-lib-report": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
       "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
-      "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "*"
       }
@@ -9348,7 +9344,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
       "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
-      "dev": true,
       "requires": {
         "@types/istanbul-lib-report": "*"
       }
@@ -9407,6 +9402,11 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
       "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
       "dev": true
+    },
+    "@types/tmp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-7cTXwKP/HLOPVgjg+YhBdQ7bMiobGMuoBmrGmqwIWJv8elC6t1DfVc/mn4fD9UE1IjhwmhaQ5pGVXkmXbH0rhg=="
     },
     "@types/yargs": {
       "version": "15.0.13",
@@ -10009,7 +10009,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
       "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -11400,8 +11399,7 @@
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
     "has-value": {
       "version": "1.0.0",
@@ -13087,8 +13085,7 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-cancelable": {
       "version": "1.1.0",
@@ -13621,7 +13618,6 @@
       "version": "6.6.7",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
       "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -14168,8 +14164,7 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-resolve": {
       "version": "0.5.3",
@@ -14406,7 +14401,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
       }
@@ -14504,7 +14498,6 @@
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
       "requires": {
         "os-tmpdir": "~1.0.2"
       }
@@ -14637,8 +14630,7 @@
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -21,15 +21,20 @@
   },
   "homepage": "https://github.com/sass/sass-spec#readme",
   "dependencies": {
+    "@jest/types": "^26.6.2",
     "@types/diff": "^4.0.2",
     "@types/js-yaml": "^3.12.5",
     "@types/lodash": "^4.14.168",
     "@types/node": "^14.14.7",
+    "@types/tmp": "^0.2.1",
     "@types/yargs": "^15.0.9",
     "diff": "^5.0.0",
     "js-yaml": "^3.14.0",
     "lodash": "^4.17.21",
     "node-hrx": "^0.1.0",
+    "rxjs": "^6.5.5",
+    "source-map": "^0.6.1",
+    "tmp": "^0.0.33",
     "yargs": "^16.1.0"
   },
   "devDependencies": {
@@ -44,6 +49,7 @@
   },
   "scripts": {
     "sass-spec": "ts-node sass-spec.ts",
+    "js-api-spec": "ts-node js-api-spec.ts",
     "test": "jest",
     "lint": "gts lint",
     "fix": "gts fix"


### PR DESCRIPTION
So far this only has one ultra-simple test, but we can build it out
once the core infrastructure is in place.