### PR TITLE
Add specs covering unitless weights in mix()

### DIFF
--- a/spec/core_functions/color/mix.hrx
+++ b/spec/core_functions/color/mix.hrx
@@ -81,6 +81,26 @@ a {
 
 <===>
 ================================================================================
+<===> unitless_weight/firstwards/input.scss
+a {b: mix(#91e16f, #0144bf, 92)}
+
+<===> unitless_weight/firstwards/output.css
+a {
+  b: #85d475;
+}
+
+<===>
+================================================================================
+<===> unitless_weight/lastwards/input.scss
+a {b: mix(#91e16f, #0144bf, 43)}
+
+<===> unitless_weight/lastwards/output.css
+a {
+  b: #3f889d;
+}
+
+<===>
+================================================================================
 <===> alpha/even/input.scss
 a {b: mix(rgba(#91e16f, 0.3), rgba(#0144bf, 0.3))}
 


### PR DESCRIPTION
Bootstrap 5 relies on using unitless weights in `mix()`. Our implementation in scssphp was buggy (which is the root cause of https://github.com/scssphp/scssphp/issues/459), treating `1` as being `100%` rather than `1%` (i.e. treating it the same than alpha channels for the `rgba()` function).
this adds spec covering the usage with unitless numbers rather than percentages.