### PR TITLE
Preserve parentheses around var() functions in calculations

### DIFF
--- a/spec/values/calculation/calc/no_operator.hrx
+++ b/spec/values/calculation/calc/no_operator.hrx
@@ -18,6 +18,16 @@ a {
 
 <===>
 ================================================================================
+<===> syntax/extra_whitespace/parenthesized_var/input.scss
+a {b: calc( ( var(--c) ) )}
+
+<===> syntax/extra_whitespace/parenthesized_var/output.css
+a {
+  b: calc((var(--c)));
+}
+
+<===>
+================================================================================
 <===> number/integer/input.scss
 a {b: calc(1px)}
 
@@ -193,6 +203,36 @@ a {b: calc((1px))}
 <===> parentheses/output.css
 a {
   b: 1px;
+}
+
+<===>
+================================================================================
+<===> var/parenthesized/input.scss
+a {b: calc((var(--c)))}
+
+<===> var/parenthesized/output.css
+a {
+  b: calc((var(--c)));
+}
+
+<===>
+================================================================================
+<===> var/double_parenthesized/input.scss
+a {b: calc(((var(--c))))}
+
+<===> var/double_parenthesized/output.css
+a {
+  b: calc((var(--c)));
+}
+
+<===>
+================================================================================
+<===> var/bare/input.scss
+a {b: calc(var(--c))}
+
+<===> var/bare/output.css
+a {
+  b: calc(var(--c));
 }
 
 <===>

--- a/spec/values/calculation/calc/operator.hrx
+++ b/spec/values/calculation/calc/operator.hrx
@@ -439,6 +439,26 @@ a {
 
 <===>
 ================================================================================
+<===> var/directly_parenthesized/input.scss
+a {b: calc(1 + (var(--c)))}
+
+<===> var/directly_parenthesized/output.css
+a {
+  b: calc(1 + (var(--c)));
+}
+
+<===>
+================================================================================
+<===> var/indirectly_parenthesized/input.scss
+a {b: calc((1 + var(--c)))}
+
+<===> var/indirectly_parenthesized/output.css
+a {
+  b: calc(1 + var(--c));
+}
+
+<===>
+================================================================================
 <===> sass_script/plus_string/lhs/input.scss
 a {b: calc(1px + 1%) + ""}
 


### PR DESCRIPTION
See sass/sass#3153
See sass/sass#3154
[skip dart-sass]