### PR TITLE
Remove the deprecated del types package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^26.6.2",
-        "@types/del": "^4.0.0",
         "@types/diff": "^4.0.2",
         "@types/js-yaml": "^3.12.5",
         "@types/lodash": "^4.14.168",
@@ -1026,15 +1025,6 @@
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.3.0"
-      }
-    },
-    "node_modules/@types/del": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/del/-/del-4.0.0.tgz",
-      "integrity": "sha512-LDE5atstX5kKnTobWknpmGHC52DH/tp8pIVsD2SSxaOFqW3AQr0EpdzYIfkZ331xe7l9Vn9NlJsBG6viU3mjBA==",
-      "deprecated": "This is a stub types definition. del provides its own type definitions, so you do not need this installed.",
-      "dependencies": {
-        "del": "*"
       }
     },
     "node_modules/@types/diff": {
@@ -9343,14 +9333,6 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
-      }
-    },
-    "@types/del": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/del/-/del-4.0.0.tgz",
-      "integrity": "sha512-LDE5atstX5kKnTobWknpmGHC52DH/tp8pIVsD2SSxaOFqW3AQr0EpdzYIfkZ331xe7l9Vn9NlJsBG6viU3mjBA==",
-      "requires": {
-        "del": "*"
       }
     },
     "@types/diff": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "homepage": "https://github.com/sass/sass-spec#readme",
   "dependencies": {
     "@jest/types": "^26.6.2",
-    "@types/del": "^4.0.0",
     "@types/diff": "^4.0.2",
     "@types/js-yaml": "^3.12.5",
     "@types/lodash": "^4.14.168",


### PR DESCRIPTION
As of version 4, `del` ships its own type definitions.