### PR TITLE
Fix assertion for the selector-unify specs

### DIFF
--- a/spec/core_functions/selector/unify/simple/type.hrx
+++ b/spec/core_functions/selector/unify/simple/type.hrx
@@ -179,11 +179,11 @@ a {
 <===>
 ================================================================================
 <===> and_type/empty/and_any/different_type/input.scss
-a {b: selector-unify("|c", "*|c")}
+a {b: inspect(selector-unify("|c", "*|d"))}
 
 <===> and_type/empty/and_any/different_type/output.css
 a {
-  b: |c;
+  b: null;
 }
 
 <===>


### PR DESCRIPTION
This case was copying the previous one instead of doing what its name implies.