### PR TITLE
Fix the specs for multiple combinators in selector-unify

### DIFF
--- a/spec/core_functions/selector/unify/complex/combinators.hrx
+++ b/spec/core_functions/selector/unify/complex/combinators.hrx
@@ -395,10 +395,10 @@ a {
 
 <===>
 ================================================================================
-<===> multiple/input.scss
+<===> multiple/isolated/input.scss
 a {b: selector-unify(".c > .d + .e", ".f .g ~ .h")}
 
-<===> multiple/output.css
+<===> multiple/isolated/output.css
 a {
   b: .f .c > .g ~ .d + .e.h, .f .c > .g.d + .e.h;
 }


### PR DESCRIPTION
Nesting spec directories inside another spec directory is not supported, and will ignore the nested ones.