### PR TITLE
Fix specs covering prefixed :is() for superselector specs

### DIFF
--- a/spec/core_functions/selector/is_superselector/simple/pseudo/selector_arg/is.hrx
+++ b/spec/core_functions/selector/is_superselector/simple/pseudo/selector_arg/is.hrx
@@ -148,7 +148,7 @@ a {
 - sass/libsass#2972
 
 <===> prefix/superset/input.scss
-a {b: is-superselector(":-pfx-matches(c d, e f, g h)", "c d.i, e j f")}
+a {b: is-superselector(":-pfx-is(c d, e f, g h)", "c d.i, e j f")}
 
 <===> prefix/superset/output.css
 a {
@@ -158,7 +158,7 @@ a {
 <===>
 ================================================================================
 <===> prefix/subset/input.scss
-a {b: is-superselector(":-pfx-matches(c d.i, e j f)", "c d, e f, g h")}
+a {b: is-superselector(":-pfx-is(c d.i, e j f)", "c d, e f, g h")}
 
 <===> prefix/subset/output.css
 a {
@@ -184,7 +184,7 @@ a {
 <===>
 ================================================================================
 <===> not_superselector_of/prefixed/input.scss
-a {b: is-superselector(":is(c, d)", ":-pfx-matches(c, d)")}
+a {b: is-superselector(":is(c, d)", ":-pfx-is(c, d)")}
 
 <===> not_superselector_of/prefixed/output.css
 a {


### PR DESCRIPTION
When reflecting changes from `matches.hrx` to `is.hrx`, the prefixed pseudos have not been replaced properly.