### PR TITLE
Add specs covering the scientific notation in keyframe selectors

### DIFF
--- a/spec/css/keyframes.hrx
+++ b/spec/css/keyframes.hrx
@@ -132,6 +132,84 @@ $a: b;
 
 <===>
 ================================================================================
+<===> selector/percentage/scientific/int/input.scss
+@keyframes a {
+  1e2% {
+    c: d;
+  }
+}
+
+<===> selector/percentage/scientific/int/output.css
+@keyframes a {
+  1e2% {
+    c: d;
+  }
+}
+
+<===>
+================================================================================
+<===> selector/percentage/scientific/double/input.scss
+@keyframes a {
+  1.5e2% {
+    c: d;
+  }
+}
+
+<===> selector/percentage/scientific/double/output.css
+@keyframes a {
+  1.5e2% {
+    c: d;
+  }
+}
+
+<===>
+================================================================================
+<===> selector/percentage/scientific/positive_exponent/input.scss
+@keyframes a {
+  13E+1% {
+    c: d;
+  }
+}
+
+<===> selector/percentage/scientific/positive_exponent/output.css
+@keyframes a {
+  13e+1% {
+    c: d;
+  }
+}
+
+<===> selector/percentage/scientific/positive_exponent/output-libsass.css
+@keyframes a {
+  13E+1% {
+    c: d;
+  }
+}
+
+<===>
+================================================================================
+<===> selector/percentage/scientific/negative_exponent/input.scss
+@keyframes a {
+  130E-1% {
+    c: d;
+  }
+}
+
+<===> selector/percentage/scientific/negative_exponent/output.css
+@keyframes a {
+  130e-1% {
+    c: d;
+  }
+}
+
+<===> selector/percentage/scientific/negative_exponent/output-libsass.css
+@keyframes a {
+  130E-1% {
+    c: d;
+  }
+}
+
+<===>
+================================================================================
 <===> selector/interpolated/input.scss
 @keyframes a {
   $b: 10%;


### PR DESCRIPTION
sass/dart-sass#1509

skip dart-sass

Recreates #1720 