### PR TITLE
Remove unused import

### DIFF
--- a/js-api-spec/legacy/render.test.ts
+++ b/js-api-spec/legacy/render.test.ts
@@ -4,7 +4,7 @@
 
 import * as sass from 'sass';
 
-import {skipForImpl, captureStdio, captureStdioAsync} from '../utils';
+import {skipForImpl, captureStdioAsync} from '../utils';
 
 describe('render()', () => {
   it('renders a string', done => {


### PR DESCRIPTION
This avoids getting a warning from the static analysis on each PR.