### PR TITLE
Use non-white colors for the saturation tests

### DIFF
--- a/spec/core_functions/color/saturation.hrx
+++ b/spec/core_functions/color/saturation.hrx
@@ -1,5 +1,5 @@
 <===> max/input.scss
-a {b: saturation(hsl(0, 100%, 100%))}
+a {b: saturation(hsl(0, 100%, 50%))}
 
 <===> max/output.css
 a {
@@ -9,7 +9,7 @@ a {
 <===>
 ================================================================================
 <===> min/input.scss
-a {b: saturation(hsl(0, 0%, 100%))}
+a {b: saturation(hsl(0, 0%, 50%))}
 
 <===> min/output.css
 a {
@@ -19,7 +19,7 @@ a {
 <===>
 ================================================================================
 <===> middle/input.scss
-a {b: saturation(hsl(0, 50%, 100%))}
+a {b: saturation(hsl(0, 50%, 50%))}
 
 <===> middle/output.css
 a {
@@ -29,7 +29,7 @@ a {
 <===>
 ================================================================================
 <===> fraction/input.scss
-a {b: saturation(hsl(0, 0.5%, 100%))}
+a {b: saturation(hsl(0, 0.5%, 50%))}
 
 <===> fraction/output.css
 a {
@@ -39,7 +39,7 @@ a {
 <===>
 ================================================================================
 <===> named/input.scss
-a {b: saturation($color: hsl(0, 42%, 100%))}
+a {b: saturation($color: hsl(0, 42%, 50%))}
 
 <===> named/output.css
 a {


### PR DESCRIPTION
A color with 100% lightness is white, whatever its hue and saturation. For such colors, a roundtrip to the RGB values will not preserve the original saturation, making them a bad choice for the tests of the saturation function.

This is the same kind of fix than #1709 