### PR TITLE
Add specs covering the sourceMapIncludeSources option

### DIFF
--- a/js-api-spec/compile.test.ts
+++ b/js-api-spec/compile.test.ts
@@ -13,7 +13,7 @@ import {
   OutputStyle,
 } from 'sass';
 
-import {sandbox} from './utils';
+import {sandbox, skipForImpl} from './utils';
 
 describe('compileString', () => {
   describe('success', () => {
@@ -217,6 +217,21 @@ describe('compileString', () => {
           expect(sourceMap.sources).toBeArray();
           expect(sourceMap.names).toBeArray();
           expect(sourceMap.mappings).toBeString();
+        });
+
+        skipForImpl('sass-embedded', () => {
+          it('includes one with source content if sourceMapIncludeSources is true', () => {
+            const result = compileString('a {b: c}', {
+              sourceMap: true,
+              sourceMapIncludeSources: true,
+            });
+            expect(result).toHaveProperty('sourceMap');
+
+            const sourceMap = result.sourceMap!;
+            expect(sourceMap).toHaveProperty('sourcesContent');
+            expect(sourceMap.sourcesContent!).toBeArray();
+            expect(sourceMap.sourcesContent!.length).toBeGreaterThanOrEqual(1);
+          });
         });
       });
     });


### PR DESCRIPTION
https://github.com/sass/sass/pull/3226

skip dart-sass