### PR TITLE
Fix compile spec grouping

### DIFF
--- a/js-api-spec/compile.test.ts
+++ b/js-api-spec/compile.test.ts
@@ -220,7 +220,6 @@ describe('compileString', () => {
         expect(sourceMap.mappings).toBeString();
       });
 
-
       it('includes one with source content if sourceMapIncludeSources is true', () => {
         const result = compileString('a {b: c}', {
           sourceMap: true,


### PR DESCRIPTION
Some tests were incorrectly grouped. Below is the before and after of this PR.

Before:
```
 PASS  js-api-spec/compile.test.ts (17.176 s)
  compileString
    success
      ✓ doesn't throw a Sass exception for an argument error (1 ms)
      ✓ is an instance of Error (82 ms)
      input
        ✓ compiles SCSS by default (187 ms)
        ✓ compiles SCSS with explicit syntax (154 ms)
        ✓ compiles indented syntax with explicit syntax (166 ms)
        ✓ compiles plain CSS with explicit syntax (170 ms)
        ✓ doesn't take its syntax from the URL's extension (194 ms)
      loadedUrls
        ✓ is empty with no URL (189 ms)
        ✓ contains the URL if one is passed (1149 ms)
        ✓ contains an immediate dependency (147 ms)
        ✓ contains a transitive dependency (121 ms)
        ✓ url is used to resolve relative loads (104 ms)
        ✓ recognizes the expanded output style (111 ms)
        contains a dependency only once
          ✓ for @use (125 ms)
          ✓ for @import (109 ms)
        loadPaths
          ✓ is used to resolve loads (103 ms)
          ✓ resolves relative paths (90 ms)
          ✓ resolves loads using later paths if earlier ones don't match (93 ms)
          ✓ doesn't take precedence over loads relative to the url (117 ms)
          ✓ uses earlier paths in preference to later ones (104 ms)
        sourceMap
          ✓ doesn't include one by default (106 ms)
          ✓ includes one if sourceMap is true (103 ms)
          [skipped for sass-embedded]
            ○ skipped includes one with source content if sourceMapIncludeSources is true
      error
        ✓ requires plain CSS with explicit syntax (123 ms)
        ✓ relative loads fail without a URL (101 ms)
        ✓ throws an error for an unrecognized style (31 ms)
        includes source span information
          ✓ in syntax errors (92 ms)
          ✓ in runtime errors (76 ms)
```

After:

```
PASS  js-api-spec/compile.test.ts (17.232 s)
  compileString
    success
      ✓ url is used to resolve relative loads (209 ms)
      ✓ recognizes the expanded output style (98 ms)
      input
        ✓ compiles SCSS by default (215 ms)
        ✓ compiles SCSS with explicit syntax (158 ms)
        ✓ compiles indented syntax with explicit syntax (218 ms)
        ✓ compiles plain CSS with explicit syntax (140 ms)
        ✓ doesn't take its syntax from the URL's extension (210 ms)
      loadedUrls
        ✓ is empty with no URL (1202 ms)
        ✓ contains the URL if one is passed (135 ms)
        ✓ contains an immediate dependency (170 ms)
        ✓ contains a transitive dependency (139 ms)
        contains a dependency only once
          ✓ for @use (118 ms)
          ✓ for @import (109 ms)
      loadPaths
        ✓ is used to resolve loads (154 ms)
        ✓ resolves relative paths (102 ms)
        ✓ resolves loads using later paths if earlier ones don't match (121 ms)
        ✓ doesn't take precedence over loads relative to the url (103 ms)
        ✓ uses earlier paths in preference to later ones (108 ms)
      sourceMap
        ✓ doesn't include one by default (114 ms)
        ✓ includes one if sourceMap is true (88 ms)
        [skipped for sass-embedded]
          ○ skipped includes one with source content if sourceMapIncludeSources is true
    error
      ✓ requires plain CSS with explicit syntax (86 ms)
      ✓ relative loads fail without a URL (92 ms)
      ✓ throws an error for an unrecognized style (37 ms)
      ✓ doesn't throw a Sass exception for an argument error (1 ms)
      ✓ is an instance of Error (112 ms)
      includes source span information
        ✓ in syntax errors (88 ms)
        ✓ in runtime errors (101 ms)
```