### PR TITLE
Fix and add specs for relative imports with `compileString()`

### DIFF
--- a/js-api-spec/compile.test.ts
+++ b/js-api-spec/compile.test.ts
@@ -121,7 +121,7 @@ describe('compileString', () => {
       });
     });
 
-    it('url is used to resolve relative loads', () =>
+    it('file: url is used to resolve relative loads', () =>
       sandbox(dir => {
         dir.write({'foo/bar/_other.scss': 'a {b: c}'});
 
@@ -244,11 +244,27 @@ describe('compileString', () => {
 
     it('relative loads fail without a URL', () =>
       sandbox(dir => {
-        dir.write({'other.scss': 'a {b: c}'});
+        dir.write({'_other.scss': 'a {b: c}'});
 
-        expect(() => compileString('@use "other";')).toThrowSassException({
+        expect(() =>
+          compileString(`@use "${dir.relativeUrl('other')}";`)
+        ).toThrowSassException({
           line: 0,
           noUrl: true,
+        });
+      }));
+
+    it('relative loads fail with a non-file: URL', () =>
+      sandbox(dir => {
+        dir.write({'_other.scss': 'a {b: c}'});
+
+        expect(() =>
+          compileString(`@use "${dir.relativeUrl('other')}";`, {
+            url: new URL('unknown:style.scss'),
+          })
+        ).toThrowSassException({
+          line: 0,
+          url: 'unknown:style.scss',
         });
       }));
 

--- a/js-api-spec/sandbox.ts
+++ b/js-api-spec/sandbox.ts
@@ -36,6 +36,12 @@ export async function sandbox(
       Object.assign((...paths: string[]) => p.join(testDir, ...paths), {
         root: testDir,
         url: (...paths: string[]) => pathToFileURL(p.join(testDir, ...paths)),
+        relativeUrl: (...paths: string[]) => {
+          const path = p.relative(process.cwd(), p.join(testDir, ...paths));
+          const components =
+            p.sep === '\\' ? path.split(/[/\\]/) : path.split('/');
+          return components.map(encodeURIComponent).join('/');
+        },
         write: (paths: {[path: string]: string}) => {
           for (const [path, contents] of Object.entries(paths)) {
             const fullPath = p.join(testDir, path);
@@ -73,6 +79,12 @@ interface SandboxDirectory {
    * Joins `paths` underneath `root` and converts the result to a `file:` URL.
    */
   url(...paths: string[]): URL;
+
+  /**
+   * Joins `paths` underneath `root` and converts the result to a relative
+   * `file:`-style URL.
+   */
+  relativeUrl(...paths: string[]): string;
 
   /**
    * Writes `paths` to disk within this directory.


### PR DESCRIPTION
The newly-tested behavior matches the specification as updated by
sass/sass#3278.

[skip sass-embedded]