### PR TITLE
Improve error messages for incorrect units in color functions

### DIFF
--- a/spec/core_functions/color/adjust_color/error/bounds.hrx
+++ b/spec/core_functions/color/adjust_color/error/bounds.hrx
@@ -40,6 +40,29 @@ Error: argument `$red` of `adjust-color($color, $red: false, $green: false, $blu
 
 <===>
 ================================================================================
+<===> red/unit/input.scss
+// This test covers sass/dart-sass#1745, but should be removed once units are
+// fully forbidden (sass/sass#3374).
+a {b: adjust-color(red, $red: 300px)}
+
+<===> red/unit/error
+Error: $red: Expected 300px to be within -255 and 255.
+  ,
+3 | a {b: adjust-color(red, $red: 300px)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 3:7  root stylesheet
+
+<===> red/unit/error-libsass
+Error: argument `$red` of `adjust-color($color, $red: false, $green: false, $blue: false, $hue: false, $saturation: false, $lightness: false, $alpha: false)` must be between -255 and 255
+        on line 3:7 of input.scss, in function `adjust-color`
+        from line 3:7 of input.scss
+>> a {b: adjust-color(red, $red: 300px)}
+
+   ------^
+
+<===>
+================================================================================
 <===> green/too_low/input.scss
 a {b: adjust-color(green, $green: -256)}
 
@@ -77,6 +100,29 @@ Error: argument `$green` of `adjust-color($color, $red: false, $green: false, $b
         on line 1:7 of input.scss, in function `adjust-color`
         from line 1:7 of input.scss
 >> a {b: adjust-color(green, $green: 256)}
+
+   ------^
+
+<===>
+================================================================================
+<===> green/unit/input.scss
+// This test covers sass/dart-sass#1745, but should be removed once units are
+// fully forbidden (sass/sass#3374).
+a {b: adjust-color(green, $green: 300px)}
+
+<===> green/unit/error
+Error: $green: Expected 300px to be within -255 and 255.
+  ,
+3 | a {b: adjust-color(green, $green: 300px)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 3:7  root stylesheet
+
+<===> green/unit/error-libsass
+Error: argument `$green` of `adjust-color($color, $red: false, $green: false, $blue: false, $hue: false, $saturation: false, $lightness: false, $alpha: false)` must be between -255 and 255
+        on line 3:7 of input.scss, in function `adjust-color`
+        from line 3:7 of input.scss
+>> a {b: adjust-color(green, $green: 300px)}
 
    ------^
 
@@ -124,6 +170,29 @@ Error: argument `$blue` of `adjust-color($color, $red: false, $green: false, $bl
 
 <===>
 ================================================================================
+<===> blue/unit/input.scss
+// This test covers sass/dart-sass#1745, but should be removed once units are
+// fully forbidden (sass/sass#3374).
+a {b: adjust-color(blue, $blue: 300px)}
+
+<===> blue/unit/error
+Error: $blue: Expected 300px to be within -255 and 255.
+  ,
+3 | a {b: adjust-color(blue, $blue: 300px)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 3:7  root stylesheet
+
+<===> blue/unit/error-libsass
+Error: argument `$blue` of `adjust-color($color, $red: false, $green: false, $blue: false, $hue: false, $saturation: false, $lightness: false, $alpha: false)` must be between -255 and 255
+        on line 3:7 of input.scss, in function `adjust-color`
+        from line 3:7 of input.scss
+>> a {b: adjust-color(blue, $blue: 300px)}
+
+   ------^
+
+<===>
+================================================================================
 <===> saturation/too_low/input.scss
 a {b: adjust-color(red, $saturation: -100.001%)}
 
@@ -161,6 +230,39 @@ Error: argument `$saturation` of `adjust-color($color, $red: false, $green: fals
         on line 1:7 of input.scss, in function `adjust-color`
         from line 1:7 of input.scss
 >> a {b: adjust-color(red, $saturation: 100.001)}
+
+   ------^
+
+<===>
+================================================================================
+<===> saturation/unit/input.scss
+// This test covers sass/dart-sass#1745, but should be removed once units are
+// fully forbidden (sass/sass#3374).
+a {b: adjust-color(red, $saturation: 200px)}
+
+<===> saturation/unit/error
+DEPRECATION WARNING: $saturation: Passing a number without unit % (200px) is deprecated.
+
+To preserve current behavior: $saturation / 1px * 1%
+
+  ,
+3 | a {b: adjust-color(red, $saturation: 200px)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+    input.scss 3:7  root stylesheet
+
+Error: $saturation: Expected 200px to be within -100% and 100%.
+  ,
+3 | a {b: adjust-color(red, $saturation: 200px)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 3:7  root stylesheet
+
+<===> saturation/unit/error-libsass
+Error: argument `$saturation` of `adjust-color($color, $red: false, $green: false, $blue: false, $hue: false, $saturation: false, $lightness: false, $alpha: false)` must be between -100 and 100
+        on line 3:7 of input.scss, in function `adjust-color`
+        from line 3:7 of input.scss
+>> a {b: adjust-color(red, $saturation: 200px)}
 
    ------^
 
@@ -208,6 +310,39 @@ Error: argument `$lightness` of `adjust-color($color, $red: false, $green: false
 
 <===>
 ================================================================================
+<===> lightness/unit/input.scss
+// This test covers sass/dart-sass#1745, but should be removed once units are
+// fully forbidden (sass/sass#3374).
+a {b: adjust-color(red, $lightness: 200px)}
+
+<===> lightness/unit/error
+DEPRECATION WARNING: $lightness: Passing a number without unit % (200px) is deprecated.
+
+To preserve current behavior: $lightness / 1px * 1%
+
+  ,
+3 | a {b: adjust-color(red, $lightness: 200px)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+    input.scss 3:7  root stylesheet
+
+Error: $lightness: Expected 200px to be within -100% and 100%.
+  ,
+3 | a {b: adjust-color(red, $lightness: 200px)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 3:7  root stylesheet
+
+<===> lightness/unit/error-libsass
+Error: argument `$lightness` of `adjust-color($color, $red: false, $green: false, $blue: false, $hue: false, $saturation: false, $lightness: false, $alpha: false)` must be between -100 and 100
+        on line 3:7 of input.scss, in function `adjust-color`
+        from line 3:7 of input.scss
+>> a {b: adjust-color(red, $lightness: 200px)}
+
+   ------^
+
+<===>
+================================================================================
 <===> alpha/too_low/input.scss
 a {b: adjust-color(red, $alpha: -1.001)}
 
@@ -247,6 +382,30 @@ Error: argument `$alpha` of `adjust-color($color, $red: false, $green: false, $b
 >> a {b: adjust-color(red, $alpha: 1.001)}
 
    ------^
+
+<===>
+================================================================================
+<===> alpha/unit/input.scss
+// This test covers sass/dart-sass#1745, but should be removed once units are
+// fully forbidden (sass/sass#3374).
+a {b: adjust-color(red, $alpha: 50%)}
+
+<===> alpha/unit/error
+Error: $alpha: Expected 50% to be within -1 and 1.
+  ,
+3 | a {b: adjust-color(red, $alpha: 50%)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 3:7  root stylesheet
+
+<===> alpha/unit/error-libsass
+Error: argument `$alpha` of `adjust-color($color, $red: false, $green: false, $blue: false, $hue: false, $saturation: false, $lightness: false, $alpha: false)` must be between -1 and 1
+        on line 3:7 of input.scss, in function `adjust-color`
+        from line 3:7 of input.scss
+>> a {b: adjust-color(red, $alpha: 50%)}
+
+   ------^
+
 <===>
 ================================================================================
 <===> blackness/options.yml

--- a/spec/core_functions/color/change_color/error/bounds.hrx
+++ b/spec/core_functions/color/change_color/error/bounds.hrx
@@ -40,6 +40,29 @@ Error: argument `$red` of `change-color($color, $red: false, $green: false, $blu
 
 <===>
 ================================================================================
+<===> red/unit/input.scss
+// This test covers sass/dart-sass#1745, but should be removed once units are
+// fully forbidden (sass/sass#3374).
+a {b: change-color(red, $red: 300px)}
+
+<===> red/unit/error
+Error: $red: Expected 300px to be within 0 and 255.
+  ,
+3 | a {b: change-color(red, $red: 300px)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 3:7  root stylesheet
+
+<===> red/unit/error-libsass
+Error: argument `$red` of `change-color($color, $red: false, $green: false, $blue: false, $hue: false, $saturation: false, $lightness: false, $alpha: false)` must be between -0 and 255
+        on line 3:7 of input.scss, in function `change-color`
+        from line 3:7 of input.scss
+>> a {b: change-color(red, $red: 300px)}
+
+   ------^
+
+<===>
+================================================================================
 <===> green/too_low/input.scss
 a {b: change-color(green, $green: -1)}
 
@@ -77,6 +100,29 @@ Error: argument `$green` of `change-color($color, $red: false, $green: false, $b
         on line 1:7 of input.scss, in function `change-color`
         from line 1:7 of input.scss
 >> a {b: change-color(green, $green: 256)}
+
+   ------^
+
+<===>
+================================================================================
+<===> green/unit/input.scss
+// This test covers sass/dart-sass#1745, but should be removed once units are
+// fully forbidden (sass/sass#3374).
+a {b: change-color(green, $green: 300px)}
+
+<===> green/unit/error
+Error: $green: Expected 300px to be within 0 and 255.
+  ,
+3 | a {b: change-color(green, $green: 300px)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 3:7  root stylesheet
+
+<===> green/unit/error-libsass
+Error: argument `$green` of `change-color($color, $red: false, $green: false, $blue: false, $hue: false, $saturation: false, $lightness: false, $alpha: false)` must be between -0 and 255
+        on line 3:7 of input.scss, in function `change-color`
+        from line 3:7 of input.scss
+>> a {b: change-color(green, $green: 300px)}
 
    ------^
 
@@ -124,6 +170,29 @@ Error: argument `$blue` of `change-color($color, $red: false, $green: false, $bl
 
 <===>
 ================================================================================
+<===> blue/unit/input.scss
+// This test covers sass/dart-sass#1745, but should be removed once units are
+// fully forbidden (sass/sass#3374).
+a {b: change-color(blue, $blue: 300px)}
+
+<===> blue/unit/error
+Error: $blue: Expected 300px to be within 0 and 255.
+  ,
+3 | a {b: change-color(blue, $blue: 300px)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 3:7  root stylesheet
+
+<===> blue/unit/error-libsass
+Error: argument `$blue` of `change-color($color, $red: false, $green: false, $blue: false, $hue: false, $saturation: false, $lightness: false, $alpha: false)` must be between -0 and 255
+        on line 3:7 of input.scss, in function `change-color`
+        from line 3:7 of input.scss
+>> a {b: change-color(blue, $blue: 300px)}
+
+   ------^
+
+<===>
+================================================================================
 <===> saturation/too_low/input.scss
 a {b: change-color(red, $saturation: -0.001%)}
 
@@ -161,6 +230,39 @@ Error: argument `$saturation` of `change-color($color, $red: false, $green: fals
         on line 1:7 of input.scss, in function `change-color`
         from line 1:7 of input.scss
 >> a {b: change-color(red, $saturation: 100.001)}
+
+   ------^
+
+<===>
+================================================================================
+<===> saturation/unit/input.scss
+// This test covers sass/dart-sass#1745, but should be removed once units are
+// fully forbidden (sass/sass#3374).
+a {b: change-color(red, $saturation: 200px)}
+
+<===> saturation/unit/error
+DEPRECATION WARNING: $saturation: Passing a number without unit % (200px) is deprecated.
+
+To preserve current behavior: $saturation / 1px * 1%
+
+  ,
+3 | a {b: change-color(red, $saturation: 200px)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+    input.scss 3:7  root stylesheet
+
+Error: $saturation: Expected 200px to be within 0% and 100%.
+  ,
+3 | a {b: change-color(red, $saturation: 200px)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 3:7  root stylesheet
+
+<===> saturation/unit/error-libsass
+Error: argument `$saturation` of `change-color($color, $red: false, $green: false, $blue: false, $hue: false, $saturation: false, $lightness: false, $alpha: false)` must be between -0 and 100
+        on line 3:7 of input.scss, in function `change-color`
+        from line 3:7 of input.scss
+>> a {b: change-color(red, $saturation: 200px)}
 
    ------^
 
@@ -208,6 +310,39 @@ Error: argument `$lightness` of `change-color($color, $red: false, $green: false
 
 <===>
 ================================================================================
+<===> lightness/unit/input.scss
+// This test covers sass/dart-sass#1745, but should be removed once units are
+// fully forbidden (sass/sass#3374).
+a {b: change-color(red, $lightness: 200px)}
+
+<===> lightness/unit/error
+DEPRECATION WARNING: $lightness: Passing a number without unit % (200px) is deprecated.
+
+To preserve current behavior: $lightness / 1px * 1%
+
+  ,
+3 | a {b: change-color(red, $lightness: 200px)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+    input.scss 3:7  root stylesheet
+
+Error: $lightness: Expected 200px to be within 0% and 100%.
+  ,
+3 | a {b: change-color(red, $lightness: 200px)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 3:7  root stylesheet
+
+<===> lightness/unit/error-libsass
+Error: argument `$lightness` of `change-color($color, $red: false, $green: false, $blue: false, $hue: false, $saturation: false, $lightness: false, $alpha: false)` must be between -0 and 100
+        on line 3:7 of input.scss, in function `change-color`
+        from line 3:7 of input.scss
+>> a {b: change-color(red, $lightness: 200px)}
+
+   ------^
+
+<===>
+================================================================================
 <===> alpha/too_low/input.scss
 a {b: change-color(red, $alpha: -0.001)}
 
@@ -247,6 +382,30 @@ Error: argument `$alpha` of `change-color($color, $red: false, $green: false, $b
 >> a {b: change-color(red, $alpha: 1.001)}
 
    ------^
+
+<===>
+================================================================================
+<===> alpha/unit/input.scss
+// This test covers sass/dart-sass#1745, but should be removed once units are
+// fully forbidden (sass/sass#3374).
+a {b: change-color(red, $alpha: 50%)}
+
+<===> alpha/unit/error
+Error: $alpha: Expected 50% to be within 0 and 1.
+  ,
+3 | a {b: change-color(red, $alpha: 50%)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 3:7  root stylesheet
+
+<===> alpha/unit/error-libsass
+Error: argument `$alpha` of `change-color($color, $red: false, $green: false, $blue: false, $hue: false, $saturation: false, $lightness: false, $alpha: false)` must be between -0 and 1
+        on line 3:7 of input.scss, in function `change-color`
+        from line 3:7 of input.scss
+>> a {b: change-color(red, $alpha: 50%)}
+
+   ------^
+
 <===>
 ================================================================================
 <===> blackness/options.yml

--- a/spec/core_functions/color/fade_in.hrx
+++ b/spec/core_functions/color/fade_in.hrx
@@ -187,3 +187,26 @@ Error: argument `$amount` of `fade-in($color, $amount)` must be between -0 and 1
 >> a {b: fade-in(red, 1.001)}
 
    ------^
+
+<===>
+================================================================================
+<===> error/bounds/unit/input.scss
+// This test covers sass/dart-sass#1745, but should be removed once units are
+// fully forbidden (sass/sass#3374).
+a {b: fade-in(red, 50%)}
+
+<===> error/bounds/unit/error
+Error: $amount: Expected 50% to be within 0 and 1.
+  ,
+3 | a {b: fade-in(red, 50%)}
+  |       ^^^^^^^^^^^^^^^^^
+  '
+  input.scss 3:7  root stylesheet
+
+<===> error/bounds/unit/error-libsass
+Error: argument `$amount` of `fade-in($color, $amount)` must be between -0 and 1
+        on line 3:7 of input.scss, in function `fade-in`
+        from line 3:7 of input.scss
+>> a {b: fade-in(red, 50%)}
+
+   ------^

--- a/spec/core_functions/color/fade_out.hrx
+++ b/spec/core_functions/color/fade_out.hrx
@@ -187,3 +187,26 @@ Error: argument `$amount` of `fade-out($color, $amount)` must be between -0 and 
 >> a {b: fade-out(red, 1.001)}
 
    ------^
+
+<===>
+================================================================================
+<===> error/bounds/unit/input.scss
+// This test covers sass/dart-sass#1745, but should be removed once units are
+// fully forbidden (sass/sass#3374).
+a {b: fade-out(red, 50%)}
+
+<===> error/bounds/unit/error
+Error: $amount: Expected 50% to be within 0 and 1.
+  ,
+3 | a {b: fade-out(red, 50%)}
+  |       ^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 3:7  root stylesheet
+
+<===> error/bounds/unit/error-libsass
+Error: argument `$amount` of `fade-out($color, $amount)` must be between -0 and 1
+        on line 3:7 of input.scss, in function `fade-out`
+        from line 3:7 of input.scss
+>> a {b: fade-out(red, 50%)}
+
+   ------^


### PR DESCRIPTION
See sass/dart-sass#1745

[skip dart-sass]