### PR TITLE
Runner: Allow directories to be passed with trailing slashes/`.hrx`

### DIFF
--- a/lib-js/spec-directory/index.ts
+++ b/lib-js/spec-directory/index.ts
@@ -1,16 +1,21 @@
-import path from 'path';
 import SpecDirectory from './spec-directory';
 import RealDirectory from './real-directory';
 import VirtualDirectory from './virtual-directory';
+import {resolveSpecPath} from './spec-path';
 
 /**
- * Creates either a physical SpecDirectory from a directory or a virtual one from an hrx archive
+ * Creates either a physical SpecDirectory from a directory or a virtual one
+ * from an hrx archive.
+ *
+ * The `path` parameter may end in `/`, `.hrx`, both, or neither, and will be
+ * able to load both HRX archives and physical directories regardless of which
+ * suffix it uses.
  */
-export async function fromPath(dirPath: string): Promise<SpecDirectory> {
-  if (path.parse(dirPath).ext === '.hrx') {
-    return await VirtualDirectory.fromArchive(dirPath);
-  }
-  return new RealDirectory(dirPath);
+export async function fromPath(path: string): Promise<SpecDirectory> {
+  const resolved = resolveSpecPath(path);
+  return resolved.endsWith('.hrx')
+    ? await VirtualDirectory.fromArchive(resolved)
+    : new RealDirectory(resolved);
 }
 
 export function fromContents(contents: string): Promise<SpecDirectory> {

--- a/lib-js/spec-directory/real-directory.ts
+++ b/lib-js/spec-directory/real-directory.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import SpecOptions from './options';
 import SpecDirectory from './spec-directory';
 import VirtualDirectory from './virtual-directory';
+import {resolveSpecPath} from './spec-path';
 
 export default class RealDirectory extends SpecDirectory {
   path: string;
@@ -41,13 +42,10 @@ export default class RealDirectory extends SpecDirectory {
 
   async getSubdir(name: string): Promise<SpecDirectory> {
     const options = await this.options();
-    const fullPath = path.resolve(this.path, name);
-    const archive = fullPath + '.hrx';
-    if (fs.existsSync(archive)) {
-      return await VirtualDirectory.fromArchive(archive, this.root, options);
-    } else {
-      return new RealDirectory(fullPath, this.root, options);
-    }
+    const resolved = resolveSpecPath(path.resolve(this.path, name));
+    return resolved.endsWith('.hrx')
+      ? await VirtualDirectory.fromArchive(resolved, this.root, options)
+      : new RealDirectory(resolved, this.root, options);
   }
 
   async writeFile(filename: string, contents: string): Promise<void> {

--- a/lib-js/spec-directory/spec-directory.ts
+++ b/lib-js/spec-directory/spec-directory.ts
@@ -124,7 +124,10 @@ export default abstract class SpecDirectory {
    */
   async forEachTest(iteratee: SpecIteratee, only?: string[]): Promise<void> {
     const relPath = this.relPath();
-    if (only === undefined || only.some(path => normalizeSpecPath(path) === relPath)) {
+    if (
+      only === undefined ||
+      only.some(path => normalizeSpecPath(path) === relPath)
+    ) {
       if (this.isTestDir()) {
         // If this is a test directory, run the test
         await iteratee(this);
@@ -144,9 +147,8 @@ export default abstract class SpecDirectory {
 
     // A map from the first component of each path in `only` (for example, `foo`
     // in `foo/bar/baz`) to the full paths under that component.
-    const onlyByFirstComponent = _.groupBy(
-      only,
-      path => normalizeSpecPath(pathSplit(p.relative(relPath, path))[0])
+    const onlyByFirstComponent = _.groupBy(only, path =>
+      normalizeSpecPath(pathSplit(p.relative(relPath, path))[0])
     );
 
     for (const [component, paths] of _.toPairs(onlyByFirstComponent)) {

--- a/lib-js/spec-directory/spec-directory.ts
+++ b/lib-js/spec-directory/spec-directory.ts
@@ -3,6 +3,7 @@ import * as _ from 'lodash';
 
 import SpecOptions from './options';
 import {toHrx} from './hrx';
+import {normalizeSpecPath} from './spec-path';
 
 export type SpecIteratee = (subdir: SpecDirectory) => Promise<void>;
 
@@ -123,7 +124,7 @@ export default abstract class SpecDirectory {
    */
   async forEachTest(iteratee: SpecIteratee, only?: string[]): Promise<void> {
     const relPath = this.relPath();
-    if (only === undefined || only.includes(relPath)) {
+    if (only === undefined || only.some(path => normalizeSpecPath(path) === relPath)) {
       if (this.isTestDir()) {
         // If this is a test directory, run the test
         await iteratee(this);
@@ -145,7 +146,7 @@ export default abstract class SpecDirectory {
     // in `foo/bar/baz`) to the full paths under that component.
     const onlyByFirstComponent = _.groupBy(
       only,
-      path => pathSplit(p.relative(relPath, path))[0]
+      path => normalizeSpecPath(pathSplit(p.relative(relPath, path))[0])
     );
 
     for (const [component, paths] of _.toPairs(onlyByFirstComponent)) {

--- a/lib-js/spec-directory/spec-directory.ts
+++ b/lib-js/spec-directory/spec-directory.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import p from 'path';
 import * as _ from 'lodash';
 
 import SpecOptions from './options';
@@ -28,8 +28,8 @@ export default abstract class SpecDirectory {
   relPath(): string {
     // make sure to include the root dir as part of the name
     // (e.g. if the root path is `spec`, everything should be listed as `spec/thing`)
-    const rootDir = path.dirname(this.root.path);
-    return path.relative(rootDir, this.path);
+    const rootDir = p.dirname(this.root.path);
+    return p.relative(rootDir, this.path);
   }
 
   // File manipulation
@@ -50,12 +50,10 @@ export default abstract class SpecDirectory {
   /** Get the subdirectory at the provided path relative to this directory */
   async atPath(subpath: string): Promise<SpecDirectory> {
     if (!subpath) return this;
-    const i = subpath.indexOf(path.sep);
-    if (i === -1) {
-      return await this.subdir(subpath);
-    }
-    const child = await this.subdir(subpath.slice(0, i));
-    return await child.atPath(subpath.slice(i + 1));
+    const components = pathSplit(subpath);
+    if (components.length === 1) return await this.subdir(components[0]);
+    const child = await this.subdir(components[0]);
+    return await child.atPath(components.slice(1).join(p.sep));
   }
 
   // helper to get the subitem with the given name
@@ -140,14 +138,14 @@ export default abstract class SpecDirectory {
 
     // A map from the basename of each subdirectory to that subdirectory
     const subdirsByBasename = _.fromPairs(
-      (await this.subdirs()).map(subdir => [path.basename(subdir.path), subdir])
+      (await this.subdirs()).map(subdir => [p.basename(subdir.path), subdir])
     );
 
     // A map from the first component of each path in `only` (for example, `foo`
     // in `foo/bar/baz`) to the full paths under that component.
     const onlyByFirstComponent = _.groupBy(
       only,
-      p => path.normalize(path.relative(relPath, p)).split(path.sep)[0]
+      path => pathSplit(p.relative(relPath, path))[0]
     );
 
     for (const [component, paths] of _.toPairs(onlyByFirstComponent)) {
@@ -163,4 +161,12 @@ export default abstract class SpecDirectory {
   toString(): string {
     return this.path;
   }
+}
+
+/// Splits a relative path into its constituent components.
+function pathSplit(path: string): string[] {
+  if (p.isAbsolute(path)) throw new Error(`Expected ${path} to be relative.`);
+  path = p.normalize(path);
+  if (path.endsWith(p.sep)) path = path.substring(0, path.length - 1);
+  return path.split(p.sep);
 }

--- a/lib-js/spec-directory/spec-path.ts
+++ b/lib-js/spec-directory/spec-path.ts
@@ -1,0 +1,38 @@
+import fs from 'fs';
+import p from 'path';
+
+/**
+ * Given a directory path, returns the directory to load for that path.
+ *
+ * This can return the path to a virtual HRX directory, in which case the return
+ * value will end with `.hrx`.
+ */
+export function resolveSpecPath(path: string): string {
+  path = normalizeSpecPath(path);
+  const archivePath = `${path}.hrx`;
+  const archiveExists = fs.existsSync(archivePath);
+  const dirExists = fs.existsSync(path);
+  if (archiveExists && dirExists) {
+    throw new Error(`Both ${path} and ${archivePath} exist.`);
+  } else if (archiveExists) {
+    return archivePath;
+  } else if (dirExists) {
+    return path;
+  } else {
+    throw new Error(`Neither ${path} nor ${archivePath} exist.`);
+  }
+}
+
+/**
+ * Normalizes a path to a spec directory, removing trailing slashes and an
+ * `.hrx` extension.
+ */
+export function normalizeSpecPath(path: string): string {
+  if (path.endsWith('/') || path.endsWith(p.sep)) {
+    path = path.substring(0, path.length - 1);
+  }
+
+  return path.endsWith('.hrx')
+    ? path.substring(0, path.length - '.hrx'.length)
+    : path;
+}

--- a/lib-js/spec-directory/spec-path.ts
+++ b/lib-js/spec-directory/spec-path.ts
@@ -28,10 +28,8 @@ export function resolveSpecPath(path: string): string {
  * `.hrx` extension.
  */
 export function normalizeSpecPath(path: string): string {
-  if (path.endsWith('/') || path.endsWith(p.sep)) {
-    path = path.substring(0, path.length - 1);
-  }
-
+  path = p.normalize(path);
+  if (path.endsWith(p.sep)) path = path.substring(0, path.length - 1);
   return path.endsWith('.hrx')
     ? path.substring(0, path.length - '.hrx'.length)
     : path;

--- a/lib-js/spec-directory/virtual-directory.ts
+++ b/lib-js/spec-directory/virtual-directory.ts
@@ -139,6 +139,7 @@ export default class VirtualDirectory extends SpecDirectory {
     if (this.subdirCache[filename]) {
       throw new Error(`${message}: ${filename} is a directory`);
     }
+    // `/` is a valid separator everywhere, but `path.sep` is `\` on Windows.
     if (filename.includes('/') || filename.includes(path.sep)) {
       throw new Error(`${message}: multi-level paths not supported`);
     }

--- a/lib-js/spec-directory/virtual-directory.ts
+++ b/lib-js/spec-directory/virtual-directory.ts
@@ -137,7 +137,7 @@ export default class VirtualDirectory extends SpecDirectory {
     if (this.subdirCache[filename]) {
       throw new Error(`${message}: ${filename} is a directory`);
     }
-    if (filename.includes(path.sep)) {
+    if (filename.includes('/') || filename.includes(path.sep)) {
       throw new Error(`${message}: multi-level paths not supported`);
     }
   }

--- a/lib-js/spec-directory/virtual-directory.ts
+++ b/lib-js/spec-directory/virtual-directory.ts
@@ -1,10 +1,12 @@
 import fs from 'fs';
 import path from 'path';
+
 import {Readable} from 'stream';
 import SpecDirectory, {SpecIteratee} from './spec-directory';
 import {archiveFromStream, Directory as HrxDirectory} from 'node-hrx';
 import SpecOptions from './options';
 import {withAsyncCleanup} from './cleanup';
+import {normalizeSpecPath} from './spec-path';
 
 function createFileCache(dir: HrxDirectory): Record<string, string> {
   const cache: Record<string, string> = {};
@@ -148,13 +150,13 @@ export default class VirtualDirectory extends SpecDirectory {
     return this.subdirNames;
   }
 
-  async getSubdir(itemName: string): Promise<VirtualDirectory> {
-    const subitem = this.subdirCache[itemName];
-    if (!subitem) {
-      throw new Error(`Item does not exist: ${itemName}`);
+  async getSubdir(name: string): Promise<VirtualDirectory> {
+    const subdir = this.subdirCache[normalizeSpecPath(name)];
+    if (!subdir) {
+      throw new Error(`Subdirectory does not exist: ${path}/${name}`);
     }
     const options = await this.options();
-    return new VirtualDirectory(this.basePath, subitem, this.root, options);
+    return new VirtualDirectory(this.basePath, subdir, this.root, options);
   }
 
   // Iteration

--- a/test/spec-directory/iteration.test.ts
+++ b/test/spec-directory/iteration.test.ts
@@ -4,7 +4,7 @@ import {fromPath, SpecDirectory} from '../../lib-js/spec-directory';
 describe('SpecDirectory iteration', () => {
   describe('forEachTest', () => {
     let dir: SpecDirectory;
-    beforeAll(async () => {
+    beforeEach(async () => {
       dir = await fromPath(path.resolve(__dirname, './fixtures/iterate'));
     });
 
@@ -70,6 +70,116 @@ describe('SpecDirectory iteration', () => {
           ['iterate/archive', 'iterate/unknown']
         )
       ).rejects.toThrow("Path iterate/unknown doesn't exist");
+    });
+
+    describe('supports a trailing slash', () => {
+      describe('in fromPath()', () => {
+        it('for a physical directory', async () => {
+          dir = await fromPath(
+            path.resolve(__dirname, './fixtures/iterate/physical/')
+          );
+
+          const testCases: string[] = [];
+          await dir.forEachTest(async subdir => {
+            testCases.push(subdir.relPath());
+          });
+          expect(testCases).toEqual(['physical']);
+        });
+
+        it('for an HRX archive', async () => {
+          dir = await fromPath(
+            path.resolve(__dirname, './fixtures/iterate/archive/')
+          );
+
+          const testCases: string[] = [];
+          await dir.forEachTest(async subdir => {
+            testCases.push(subdir.relPath());
+          });
+          expect(testCases).toEqual(['archive/scss', 'archive/indented']);
+        });
+      });
+
+      describe('in only parameter()', () => {
+        it('for a physical directory', async () => {
+          const testCases: string[] = [];
+          await dir.forEachTest(
+            async subdir => {
+              testCases.push(subdir.relPath());
+            },
+            ['iterate/physical/']
+          );
+          expect(testCases).toEqual(['iterate/physical']);
+        });
+
+        it('for an HRX archive', async () => {
+          const testCases: string[] = [];
+          await dir.forEachTest(
+            async subdir => {
+              testCases.push(subdir.relPath());
+            },
+            ['iterate/archive/']
+          );
+          expect(testCases).toEqual([
+            'iterate/archive/scss',
+            'iterate/archive/indented',
+          ]);
+        });
+      });
+    });
+
+    describe('supports a .hrx extension', () => {
+      describe('in fromPath()', () => {
+        it('for a physical directory', async () => {
+          dir = await fromPath(
+            path.resolve(__dirname, './fixtures/iterate/physical.hrx')
+          );
+
+          const testCases: string[] = [];
+          await dir.forEachTest(async subdir => {
+            testCases.push(subdir.relPath());
+          });
+          expect(testCases).toEqual(['physical']);
+        });
+
+        it('for an HRX archive', async () => {
+          dir = await fromPath(
+            path.resolve(__dirname, './fixtures/iterate/archive.hrx')
+          );
+
+          const testCases: string[] = [];
+          await dir.forEachTest(async subdir => {
+            testCases.push(subdir.relPath());
+          });
+          expect(testCases).toEqual(['archive/scss', 'archive/indented']);
+        });
+      });
+
+      describe('in only parameter()', () => {
+        it('for a physical directory', async () => {
+          const testCases: string[] = [];
+          await dir.forEachTest(
+            async subdir => {
+              testCases.push(subdir.relPath());
+            },
+            ['iterate/physical.hrx']
+          );
+          expect(testCases).toEqual(['iterate/physical']);
+        });
+
+        it('for an HRX archive', async () => {
+          const testCases: string[] = [];
+          await dir.forEachTest(
+            async subdir => {
+              testCases.push(subdir.relPath());
+            },
+            ['iterate/archive.hrx']
+          );
+          expect(testCases).toEqual([
+            'iterate/archive/scss',
+            'iterate/archive/indented',
+          ]);
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
This makes directory addressing transparent across both of these, so 
passing `spec/expressions/` or `spec/expressions/syntax.hrx` will no longer
break the runner.