### PR TITLE
Migrate deprecation warnings to sass-lang short links

### DIFF
--- a/spec/css/moz_document/functions/interpolated.hrx
+++ b/spec/css/moz_document/functions/interpolated.hrx
@@ -94,7 +94,7 @@
 DEPRECATION WARNING on line 1, column 1 of input.scss: 
 @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
 
-For details, see http://bit.ly/MozDocument.
+For details, see https://sass-lang.com/d/moz-document.
   ,
 1 | / @-moz-document url(#{"sass-lang.com"}) {
 2 | |   a {type: unquoted full url}
@@ -104,7 +104,7 @@ For details, see http://bit.ly/MozDocument.
 DEPRECATION WARNING on line 4, column 1 of input.scss: 
 @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
 
-For details, see http://bit.ly/MozDocument.
+For details, see https://sass-lang.com/d/moz-document.
   ,
 4 | / @-moz-document url(#{sa + ss}-lang.com) {
 5 | |   a {type: unquoted partial url}
@@ -114,7 +114,7 @@ For details, see http://bit.ly/MozDocument.
 DEPRECATION WARNING on line 7, column 1 of input.scss: 
 @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
 
-For details, see http://bit.ly/MozDocument.
+For details, see https://sass-lang.com/d/moz-document.
   ,
 7 | / @-moz-document url("#{sa + ss}-lang.com") {
 8 | |   a {type: quoted partial url}
@@ -124,7 +124,7 @@ For details, see http://bit.ly/MozDocument.
 DEPRECATION WARNING on line 11, column 1 of input.scss: 
 @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
 
-For details, see http://bit.ly/MozDocument.
+For details, see https://sass-lang.com/d/moz-document.
    ,
 11 | / @-moz-document url-prefix(#{"https://sass-lang.com/docs"}) {
 12 | |   a {type: unquoted full url-prefix}
@@ -134,7 +134,7 @@ For details, see http://bit.ly/MozDocument.
 DEPRECATION WARNING on line 14, column 1 of input.scss: 
 @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
 
-For details, see http://bit.ly/MozDocument.
+For details, see https://sass-lang.com/d/moz-document.
    ,
 14 | / @-moz-document url-prefix(#{ht + tps}://sass-lang.com/docs) {
 15 | |   a {type: unquoted partial url-prefix}
@@ -144,7 +144,7 @@ For details, see http://bit.ly/MozDocument.
 DEPRECATION WARNING on line 17, column 1 of input.scss: 
 @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
 
-For details, see http://bit.ly/MozDocument.
+For details, see https://sass-lang.com/d/moz-document.
    ,
 17 | / @-moz-document url-prefix("#{ht + tps}://sass-lang.com/docs") {
 18 | |   a {type: quoted partial url-prefix}
@@ -154,7 +154,7 @@ For details, see http://bit.ly/MozDocument.
 DEPRECATION WARNING on line 21, column 1 of input.scss: 
 @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
 
-For details, see http://bit.ly/MozDocument.
+For details, see https://sass-lang.com/d/moz-document.
    ,
 21 | / @-moz-document domain(#{"sass-lang.com"}) {
 22 | |   a {type: unquoted full domain}
@@ -164,7 +164,7 @@ For details, see http://bit.ly/MozDocument.
 DEPRECATION WARNING on line 24, column 1 of input.scss: 
 @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
 
-For details, see http://bit.ly/MozDocument.
+For details, see https://sass-lang.com/d/moz-document.
    ,
 24 | / @-moz-document domain(#{sa + ss}-lang.com) {
 25 | |   a {type: unquoted partial domain}
@@ -174,7 +174,7 @@ For details, see http://bit.ly/MozDocument.
 DEPRECATION WARNING on line 27, column 1 of input.scss: 
 @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
 
-For details, see http://bit.ly/MozDocument.
+For details, see https://sass-lang.com/d/moz-document.
    ,
 27 | / @-moz-document domain("#{sa + ss}-lang.com") {
 28 | |   a {type: quoted partial domain}
@@ -184,7 +184,7 @@ For details, see http://bit.ly/MozDocument.
 DEPRECATION WARNING on line 31, column 1 of input.scss: 
 @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
 
-For details, see http://bit.ly/MozDocument.
+For details, see https://sass-lang.com/d/moz-document.
    ,
 31 | / @-moz-document regexp("#{ht + tp}s:.*") {
 32 | |   a {type: regexp}

--- a/spec/css/moz_document/functions/static.hrx
+++ b/spec/css/moz_document/functions/static.hrx
@@ -69,7 +69,7 @@
 DEPRECATION WARNING on line 1, column 1 of input.scss: 
 @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
 
-For details, see http://bit.ly/MozDocument.
+For details, see https://sass-lang.com/d/moz-document.
   ,
 1 | / @-moz-document url(sass-lang.com) {
 2 | |   a {type: unquoted url}
@@ -79,7 +79,7 @@ For details, see http://bit.ly/MozDocument.
 DEPRECATION WARNING on line 4, column 1 of input.scss: 
 @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
 
-For details, see http://bit.ly/MozDocument.
+For details, see https://sass-lang.com/d/moz-document.
   ,
 4 | / @-moz-document url("sass-lang.com") {
 5 | |   a {type: quoted url}
@@ -89,7 +89,7 @@ For details, see http://bit.ly/MozDocument.
 DEPRECATION WARNING on line 8, column 1 of input.scss: 
 @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
 
-For details, see http://bit.ly/MozDocument.
+For details, see https://sass-lang.com/d/moz-document.
    ,
 8  | / @-moz-document url-prefix(https://sass-lang.com/docs) {
 9  | |   a {type: unquoted url-prefix}
@@ -99,7 +99,7 @@ For details, see http://bit.ly/MozDocument.
 DEPRECATION WARNING on line 11, column 1 of input.scss: 
 @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
 
-For details, see http://bit.ly/MozDocument.
+For details, see https://sass-lang.com/d/moz-document.
    ,
 11 | / @-moz-document url-prefix("https://sass-lang.com/docs") {
 12 | |   a {type: quoted url-prefix}
@@ -109,7 +109,7 @@ For details, see http://bit.ly/MozDocument.
 DEPRECATION WARNING on line 15, column 1 of input.scss: 
 @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
 
-For details, see http://bit.ly/MozDocument.
+For details, see https://sass-lang.com/d/moz-document.
    ,
 15 | / @-moz-document domain(sass-lang.com) {
 16 | |   a {type: unquoted domain}
@@ -119,7 +119,7 @@ For details, see http://bit.ly/MozDocument.
 DEPRECATION WARNING on line 18, column 1 of input.scss: 
 @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
 
-For details, see http://bit.ly/MozDocument.
+For details, see https://sass-lang.com/d/moz-document.
    ,
 18 | / @-moz-document domain("sass-lang.com") {
 19 | |   a {type: quoted domain}
@@ -129,7 +129,7 @@ For details, see http://bit.ly/MozDocument.
 DEPRECATION WARNING on line 22, column 1 of input.scss: 
 @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
 
-For details, see http://bit.ly/MozDocument.
+For details, see https://sass-lang.com/d/moz-document.
    ,
 22 | / @-moz-document regexp("https:.*") {
 23 | |   a {type: regexp}

--- a/spec/css/moz_document/multi_function.hrx
+++ b/spec/css/moz_document/multi_function.hrx
@@ -24,7 +24,7 @@
 DEPRECATION WARNING on line 1, column 1 of input.scss: 
 @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
 
-For details, see http://bit.ly/MozDocument.
+For details, see https://sass-lang.com/d/moz-document.
   ,
 1 | / @-moz-document url(http://www.w3.org/),
 2 | |                url-prefix(http://www.w3.org/Style/),

--- a/spec/directives/extend/error.hrx
+++ b/spec/directives/extend/error.hrx
@@ -46,7 +46,7 @@ See http://bit.ly/ExtendCompound for details.
 <===> compound/error
 Error: compound selectors may no longer be extended.
 Consider `@extend a, :hover` instead.
-See http://bit.ly/ExtendCompound for details.
+See https://sass-lang.com/d/extend-compound for details.
 
   ,
 5 |   @extend a:hover;

--- a/spec/non_conformant/extend-tests/094_test_long_extendee_runs_unification.hrx
+++ b/spec/non_conformant/extend-tests/094_test_long_extendee_runs_unification.hrx
@@ -10,7 +10,7 @@ a.baz {@extend .foo.bar}
 <===> error
 Error: compound selectors may no longer be extended.
 Consider `@extend .foo, .bar` instead.
-See http://bit.ly/ExtendCompound for details.
+See https://sass-lang.com/d/extend-compound for details.
 
   ,
 2 | a.baz {@extend .foo.bar}


### PR DESCRIPTION
[skip dart-sass]