### PR TITLE
Test invalid contents for importer results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ tmp
 .DS_Store
 Gemfile.*.lock
 node_modules
+spec/sandbox

--- a/js-api-spec/importer.test.ts
+++ b/js-api-spec/importer.test.ts
@@ -675,7 +675,7 @@ describe('when importer does not return string contents', () => {
                 return {
                   // Need to force an invalid type to test bad-type handling.
                   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  contents: fs.readFileSync(url.pathname) as any,
+                  contents: fs.readFileSync(url) as any,
                   syntax: 'scss',
                 };
               },
@@ -704,7 +704,7 @@ describe('when importer does not return string contents', () => {
                 return {
                   // Need to force an invalid type to test bad-type handling.
                   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  contents: fs.readFileSync(url.pathname) as any,
+                  contents: fs.readFileSync(url) as any,
                   syntax: 'scss',
                 };
               },
@@ -732,7 +732,7 @@ it('throws an ArgumentError when the result sourceMapUrl is missing a scheme', (
             canonicalize: url => dir.url(`dir/_${url}.scss`),
             load: url => {
               return {
-                contents: fs.readFileSync(url.pathname, {encoding: 'utf-8'}),
+                contents: fs.readFileSync(url, {encoding: 'utf-8'}),
                 syntax: 'scss',
                 sourceMapUrl: {},
               };

--- a/js-api-spec/importer.test.ts
+++ b/js-api-spec/importer.test.ts
@@ -685,7 +685,7 @@ describe('when importer does not return string contents', () => {
         });
       }).toThrowSassException({
         line: 0,
-        message:
+        includes:
           'Invalid argument (contents): must be a string but was: Buffer: ' +
           "Instance of 'NativeUint8List'",
       });
@@ -714,7 +714,7 @@ describe('when importer does not return string contents', () => {
         });
       }).toThrowSassException({
         line: 0,
-        message:
+        includes:
           'Invalid argument (contents): must be a string but was: Buffer: ' +
           "Instance of 'NativeUint8List'",
       });
@@ -743,7 +743,7 @@ it('throws an ArgumentError when the result sourceMapUrl is missing a scheme', (
       });
     }).toThrowSassException({
       line: 0,
-      message:
+      includes:
         "Invalid argument (sourceMapUrl): must be absolute: Instance of '_Uri'",
     });
   }));

--- a/js-api-spec/importer.test.ts
+++ b/js-api-spec/importer.test.ts
@@ -661,33 +661,6 @@ it(
     })
 );
 
-it('throws an error when importer does not return string contents', () =>
-  sandbox(dir => {
-    dir.write({'dir/_other.scss': '// non empty file'});
-
-    expect(() => {
-      compileString('@import "other";', {
-        importers: [
-          {
-            canonicalize: url => dir.url(`dir/_${url}.scss`),
-            load: url => {
-              return {
-                contents: fs.readFileSync(url.pathname) as any,
-                syntax: 'scss',
-              };
-            },
-          },
-        ],
-        loadPaths: [dir('dir')],
-      });
-    }).toThrowSassException({
-      line: 0,
-      message:
-        'Invalid argument (contents): must be a string but was: Buffer: ' +
-        "Instance of 'NativeUint8List'",
-    });
-  }));
-
 describe('when importer does not return string contents', () => {
   it('throws an error in sync mode', () =>
     sandbox(dir => {
@@ -700,6 +673,8 @@ describe('when importer does not return string contents', () => {
               canonicalize: url => dir.url(`dir/_${url}.scss`),
               load: url => {
                 return {
+                  // Need to force an invalid type to test bad-type handling.
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
                   contents: fs.readFileSync(url.pathname) as any,
                   syntax: 'scss',
                 };
@@ -727,6 +702,8 @@ describe('when importer does not return string contents', () => {
               canonicalize: url => dir.url(`dir/_${url}.scss`),
               load: url => {
                 return {
+                  // Need to force an invalid type to test bad-type handling.
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
                   contents: fs.readFileSync(url.pathname) as any,
                   syntax: 'scss',
                 };

--- a/js-api-spec/legacy/importer.test.ts
+++ b/js-api-spec/legacy/importer.test.ts
@@ -4,6 +4,7 @@
 
 import * as p from 'path';
 import * as sass from 'sass';
+import * as fs from 'fs';
 
 import {sandbox} from '../sandbox';
 import {sassImpl, skipForImpl} from '../utils';
@@ -858,4 +859,59 @@ describe('render()', () => {
       expect(err).toBeObject();
       done();
     }));
+});
+
+describe('when importer returns non-string contents', () => {
+  it('throws an error in sync mode', () =>
+    sandbox(dir => {
+      dir.write({'dir/_other.scss': '// non empty file'});
+
+      expect(() => {
+        sass.renderSync({
+          data: '@import "other";',
+          importer(path: string) {
+            const url = dir.url(`dir/_${path}.scss`);
+            return {
+              contents: fs.readFileSync(url.pathname) as any,
+              syntax: 'scss',
+            };
+          },
+        });
+      }).toThrowLegacyException({
+        line: 1,
+        includes:
+          'Invalid argument (contents): must be a string but was: Buffer: ' +
+          "Instance of 'NativeUint8List'",
+      });
+    }));
+
+  it('throws an error in async mode', done => {
+    sandbox(dir => {
+      dir.write({'dir/_other.scss': '// non empty file'});
+
+      sass.render(
+        {
+          data: '@import "other";',
+          importer(path: string) {
+            const url = dir.url(`dir/_${path}.scss`);
+            return {
+              contents: fs.readFileSync(url.pathname) as any,
+              syntax: 'scss',
+            };
+          },
+        },
+        err => {
+          expect(() => {
+            throw err;
+          }).toThrowLegacyException({
+            line: 1,
+            includes:
+              'Invalid argument (contents): must be a string but was: ' +
+              "Buffer: Instance of 'NativeUint8List'",
+          });
+          done();
+        }
+      );
+    });
+  });
 });

--- a/js-api-spec/legacy/importer.test.ts
+++ b/js-api-spec/legacy/importer.test.ts
@@ -872,6 +872,8 @@ describe('when importer returns non-string contents', () => {
           importer(path: string) {
             const url = dir.url(`dir/_${path}.scss`);
             return {
+              // Need to force an invalid type to test bad-type handling.
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
               contents: fs.readFileSync(url.pathname) as any,
               syntax: 'scss',
             };
@@ -895,6 +897,8 @@ describe('when importer returns non-string contents', () => {
           importer(path: string) {
             const url = dir.url(`dir/_${path}.scss`);
             return {
+              // Need to force an invalid type to test bad-type handling.
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
               contents: fs.readFileSync(url.pathname) as any,
               syntax: 'scss',
             };

--- a/js-api-spec/legacy/importer.test.ts
+++ b/js-api-spec/legacy/importer.test.ts
@@ -874,7 +874,7 @@ describe('when importer returns non-string contents', () => {
             return {
               // Need to force an invalid type to test bad-type handling.
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              contents: fs.readFileSync(url.pathname) as any,
+              contents: fs.readFileSync(url) as any,
               syntax: 'scss',
             };
           },
@@ -899,7 +899,7 @@ describe('when importer returns non-string contents', () => {
             return {
               // Need to force an invalid type to test bad-type handling.
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              contents: fs.readFileSync(url.pathname) as any,
+              contents: fs.readFileSync(url) as any,
               syntax: 'scss',
             };
           },

--- a/js-api-spec/utils.ts
+++ b/js-api-spec/utils.ts
@@ -27,8 +27,15 @@ declare global {
        *
        * If `url` is passed, asserts that the exception has a span with the
        * given URL.
+       *
+       * If `message` is passed, asserts that the exception's `sassMessage` is
+       * equal to the given `message`.
        */
-      toThrowSassException(object?: {line?: number; url?: string | URL}): R;
+      toThrowSassException(object?: {
+        line?: number;
+        url?: string | URL;
+        message?: string;
+      }): R;
 
       /**
        * Matches a callback that throws a `sass.Exception` with a span that has
@@ -62,6 +69,7 @@ interface ToThrowSassExceptionOptions {
   line?: number;
   url?: string | URL;
   noUrl?: boolean;
+  message?: string;
 }
 
 interface SyncExpectationResult {
@@ -258,7 +266,7 @@ expect.extend({
  */
 function verifyThrown(
   thrown: unknown,
-  {line, url, noUrl}: ToThrowSassExceptionOptions
+  {line, url, noUrl, message}: ToThrowSassExceptionOptions
 ): SyncExpectationResult {
   if (!(thrown instanceof sass.Exception)) {
     return {
@@ -286,6 +294,14 @@ function verifyThrown(
   } else if (!thrown.sassMessage) {
     return {
       message: () => `expected a sassMessage field:\n${thrown}`,
+      pass: false,
+    };
+  } else if (message && thrown.sassMessage !== message) {
+    return {
+      message: () =>
+        `expected sassMessage to be ${message}, was ` +
+        `${thrown.sassMessage}:\n` +
+        `${thrown}`,
       pass: false,
     };
   } else if (!thrown.sassStack) {

--- a/js-api-spec/utils.ts
+++ b/js-api-spec/utils.ts
@@ -28,8 +28,8 @@ declare global {
        * If `url` is passed, asserts that the exception has a span with the
        * given URL.
        *
-       * If `message` is passed, asserts that the exception's `sassMessage` is
-       * equal to the given `message`.
+       * If `includes` is passed, asserts that the exception's `sassMessage`
+       * contains the given `includes` string.
        */
       toThrowSassException(object?: {
         line?: number;
@@ -69,7 +69,7 @@ interface ToThrowSassExceptionOptions {
   line?: number;
   url?: string | URL;
   noUrl?: boolean;
-  message?: string;
+  includes?: string;
 }
 
 interface SyncExpectationResult {
@@ -266,7 +266,7 @@ expect.extend({
  */
 function verifyThrown(
   thrown: unknown,
-  {line, url, noUrl, message}: ToThrowSassExceptionOptions
+  {line, url, noUrl, includes}: ToThrowSassExceptionOptions
 ): SyncExpectationResult {
   if (!(thrown instanceof sass.Exception)) {
     return {
@@ -296,10 +296,10 @@ function verifyThrown(
       message: () => `expected a sassMessage field:\n${thrown}`,
       pass: false,
     };
-  } else if (message && thrown.sassMessage !== message) {
+  } else if (includes && !thrown.sassMessage.includes(includes)) {
     return {
       message: () =>
-        `expected sassMessage to be ${message}, was ` +
+        `expected sassMessage to contain ${includes}, was ` +
         `${thrown.sassMessage}:\n` +
         `${thrown}`,
       pass: false,

--- a/js-api-spec/utils.ts
+++ b/js-api-spec/utils.ts
@@ -34,7 +34,7 @@ declare global {
       toThrowSassException(object?: {
         line?: number;
         url?: string | URL;
-        message?: string;
+        includes?: string;
       }): R;
 
       /**


### PR DESCRIPTION
Test invalid arguments for importer results.
    
- Tests contents not being string values
- Tests SassException argument errors have better output
- Adds sandbox directory to .gitignore

See https://github.com/sass/dart-sass/pull/1816

[skip dart-sass]
[skip sass-embedded]