### PR TITLE
Fix runaway promise

### DIFF
--- a/js-api-spec/importer.test.ts
+++ b/js-api-spec/importer.test.ts
@@ -623,7 +623,7 @@ describe('FileImporter', () => {
       }));
 
     it('wraps an error', async () => {
-      expect(() =>
+      await expect(() =>
         compileStringAsync('@import "other";', {
           importers: [
             {


### PR DESCRIPTION
This await is actually needed or the promise returned by `expect()` would run away because the promise is created but the funciton returns `undefined` immmedately after constuct the promise. Or alternatively the curly bracket before `expect` needs to be removed, so that the async function returns a promise that will be waited.