### PR TITLE
Update importer 'contents' invalid type tests to bogus object rather …

### DIFF
--- a/js-api-spec/importer.test.ts
+++ b/js-api-spec/importer.test.ts
@@ -670,7 +670,7 @@ describe('when importer does not return string contents', () => {
               return {
                 // Need to force an invalid type to test bad-type handling.
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                contents: Buffer.from('not a string') as any,
+                contents: {whatever: 123} as any,
                 syntax: 'scss',
               };
             },
@@ -679,9 +679,7 @@ describe('when importer does not return string contents', () => {
       });
     }).toThrowSassException({
       line: 0,
-      includes:
-        'Invalid argument (contents): must be a string but was: Buffer: ' +
-        "Instance of 'NativeUint8List'",
+      includes: 'Invalid argument (contents): must be a string but was:',
     });
   });
 
@@ -695,7 +693,7 @@ describe('when importer does not return string contents', () => {
               return {
                 // Need to force an invalid type to test bad-type handling.
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                contents: Buffer.from('not a string') as any,
+                contents: {whatever: 123} as any,
                 syntax: 'scss',
               };
             },
@@ -704,9 +702,7 @@ describe('when importer does not return string contents', () => {
       });
     }).toThrowSassException({
       line: 0,
-      includes:
-        'Invalid argument (contents): must be a string but was: Buffer: ' +
-        "Instance of 'NativeUint8List'",
+      includes: 'Invalid argument (contents): must be a string but was:',
     });
   });
 });
@@ -729,8 +725,7 @@ it('throws an ArgumentError when the result sourceMapUrl is missing a scheme', (
     });
   }).toThrowSassException({
     line: 0,
-    includes:
-      "Invalid argument (sourceMapUrl): must be absolute: Instance of '_Uri'",
+    includes: 'Invalid argument (sourceMapUrl): must be absolute:',
   });
 });
 

--- a/js-api-spec/legacy/importer.test.ts
+++ b/js-api-spec/legacy/importer.test.ts
@@ -869,16 +869,14 @@ describe('when importer returns non-string contents', () => {
           return {
             // Need to force an invalid type to test bad-type handling.
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            contents: Buffer.from('not a string') as any,
+            contents: {whatever: 123} as any,
             syntax: 'scss',
           };
         },
       });
     }).toThrowLegacyException({
       line: 1,
-      includes:
-        'Invalid argument (contents): must be a string but was: Buffer: ' +
-        "Instance of 'NativeUint8List'",
+      includes: 'Invalid argument (contents): must be a string but was:',
     });
   });
 
@@ -890,7 +888,7 @@ describe('when importer returns non-string contents', () => {
           return {
             // Need to force an invalid type to test bad-type handling.
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            contents: Buffer.from('not a string') as any,
+            contents: {whatever: 123} as any,
             syntax: 'scss',
           };
         },
@@ -900,9 +898,7 @@ describe('when importer returns non-string contents', () => {
           throw err;
         }).toThrowLegacyException({
           line: 1,
-          includes:
-            'Invalid argument (contents): must be a string but was: ' +
-            "Buffer: Instance of 'NativeUint8List'",
+          includes: 'Invalid argument (contents): must be a string but was',
         });
         done();
       }


### PR DESCRIPTION
…than a Buffer

The Buffer seems to be replaced as a string correctly in dart-sass-embedded, making these tests fail for the wrong reason. Instead of failing for the wrong type it was failing for invalid Sass.

See - https://github.com/sass/sass-spec/pull/1834