### PR TITLE
Proposal: Add map-fetch as a stricter implementation of map-get

### DIFF
--- a/spec/values/maps/map-fetch/fetch-missing-key.hrx
+++ b/spec/values/maps/map-fetch/fetch-missing-key.hrx
@@ -1,0 +1,11 @@
+<===> input.scss
+$map: (foo: bar);
+test { baz: map-fetch($map, baz); }
+
+<===> error
+Error: Key not found: baz.
+  ,
+2 | test { baz: map-fetch($map, baz); }
+  |             ^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:13  root stylesheet

--- a/spec/values/maps/map-fetch/fetch.hrx
+++ b/spec/values/maps/map-fetch/fetch.hrx
@@ -1,0 +1,13 @@
+<===> input.scss
+$map: (a: 100, b: (c: 200));
+
+test {
+  a: map-fetch($map, a);
+  bc: map-fetch($map, b, c);
+}
+
+<===> output.css
+test {
+  a: 100;
+  bc: 200;
+}

--- a/spec/values/maps/map-fetch/not-map.hrx
+++ b/spec/values/maps/map-fetch/not-map.hrx
@@ -1,0 +1,11 @@
+<===> input.scss
+$map: (foo: bar);
+test { baz: map-fetch($map, foo, baz); }
+
+<===> error
+Error: Map not found at foo.
+  ,
+2 | test { baz: map-fetch($map, foo, baz); }
+  |             ^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:13  root stylesheet

--- a/spec/values/maps/map-fetch/options.yml
+++ b/spec/values/maps/map-fetch/options.yml
@@ -1,0 +1,3 @@
+---
+:ignore_for:
+ - libsass


### PR DESCRIPTION
When map-get is called with a key that doesn't exist, the function returns null. When there is a simple typo, the null value may still end up as valid CSS leading to a confusing rendered result that is missing the expected styling. The developer must then debug the typo to fix it.

To help catch typos earlier, provide a stricter version of map-get that fails on a missing key rather than returning null. The error should provide enough information to quickly spot the typo.

The name "fetch" is inspired from Ruby's Hash#fetch method: https://ruby-doc.org/core-3.1.2/Hash.html#method-i-fetch

[skip dart-sass]