### PR TITLE
Fix dart-sdk 3.0

### DIFF
--- a/lib-js/compiler.ts
+++ b/lib-js/compiler.ts
@@ -116,7 +116,6 @@ export class DartCompiler implements Compiler {
       throw new Error(`${repoPath} is not a valid Dart Sass repository`);
     }
     const dartFile = `
-// @dart=2.9
 import "dart:convert";
 import "dart:io";
 

--- a/lib/sass_spec/engine_adapter.rb
+++ b/lib/sass_spec/engine_adapter.rb
@@ -66,7 +66,6 @@ class DartEngineAdapter < EngineAdapter
     @path = path
     Tempfile.open("dart-sass-spec") do |f|
       f.write(<<-DART)
-        // @dart=2.9
         import "dart:convert";
         import "dart:io";
 


### PR DESCRIPTION
```
/tmp/dart-sass-spec:2:1: Error: A library can't opt out of null safety by default, when using sound null safety.
// @dart=2.9
^^^^^^^^^^^^
```