### PR TITLE
Drop the non-nullability annotation from the Dart Sass wrapper

### DIFF
--- a/lib-js/compiler.ts
+++ b/lib-js/compiler.ts
@@ -116,7 +116,6 @@ export class DartCompiler implements Compiler {
       throw new Error(`${repoPath} is not a valid Dart Sass repository`);
     }
     const dartFile = `
-// @dart=2.9
 import "dart:convert";
 import "dart:io";
 


### PR DESCRIPTION
It seems like we may not need this anymore, and it's breaking the Dart
Dev CI.