### PR TITLE
Add tests for strict whitespace in JS function signatures

### DIFF
--- a/js-api-spec/function.test.ts
+++ b/js-api-spec/function.test.ts
@@ -197,4 +197,22 @@ describe('rejects a function signature that', () => {
       compileString('', {functions: {'$foo()': () => sassNull}})
     ).toThrow();
   });
+
+  it('has whitespace before the signature', () => {
+    expect(() =>
+      compileString('', {functions: {' foo()': () => sassNull}})
+    ).toThrow();
+  });
+
+  it('has whitespace after the signature', () => {
+    expect(() =>
+      compileString('', {functions: {'foo() ': () => sassNull}})
+    ).toThrow();
+  });
+
+  it('has whitespace between the identifier and the arguments', () => {
+    expect(() =>
+      compileString('', {functions: {'foo ()': () => sassNull}})
+    ).toThrow();
+  });
 });

--- a/js-api-spec/legacy/function.test.ts
+++ b/js-api-spec/legacy/function.test.ts
@@ -92,7 +92,7 @@ describe('allows a signature', () => {
     expect(
       sass.renderSync({
         data: 'a {b: foo()}',
-        functions: {' foo()': () => sass.types.Number(12)},
+        functions: {' foo()': () => new sass.types.Number(12)},
       })
     ).toEqualIgnoringWhitespace('a { b: 12; }');
   });

--- a/js-api-spec/legacy/function.test.ts
+++ b/js-api-spec/legacy/function.test.ts
@@ -89,12 +89,12 @@ describe('allows a signature', () => {
   });
 
   it('with whitespace before the function', () => {
-    expect(() =>
+    expect(
       sass.renderSync({
-        data: '',
-        functions: {' foo()': () => sass.types.Null.NULL},
+        data: 'a {b: foo()}',
+        functions: {' foo()': () => sass.types.Number(12)},
       })
-    ).toThrowLegacyException();
+    ).toEqualIgnoringWhitespace('a { b: 12; }');
   });
 });
 

--- a/js-api-spec/legacy/function.test.ts
+++ b/js-api-spec/legacy/function.test.ts
@@ -90,10 +90,12 @@ describe('allows a signature', () => {
 
   it('with whitespace before the function', () => {
     expect(
-      sass.renderSync({
-        data: 'a {b: foo()}',
-        functions: {' foo()': () => new sass.types.Number(12)},
-      })
+      sass
+        .renderSync({
+          data: 'a {b: foo()}',
+          functions: {' foo()': () => new sass.types.Number(12)},
+        })
+        .css.toString()
     ).toEqualIgnoringWhitespace('a { b: 12; }');
   });
 });

--- a/js-api-spec/legacy/function.test.ts
+++ b/js-api-spec/legacy/function.test.ts
@@ -41,6 +41,24 @@ describe('rejects a signature', () => {
       })
     ).toThrowLegacyException();
   });
+
+  it('with whitespace between the function name and arguments', () => {
+    expect(() =>
+      sass.renderSync({
+        data: '',
+        functions: {'foo ()': () => sass.types.Null.NULL},
+      })
+    ).toThrowLegacyException();
+  });
+
+  it('with whitespace after the function', () => {
+    expect(() =>
+      sass.renderSync({
+        data: '',
+        functions: {'foo() ': () => sass.types.Null.NULL},
+      })
+    ).toThrowLegacyException();
+  });
 });
 
 describe('allows a signature', () => {
@@ -68,6 +86,15 @@ describe('allows a signature', () => {
         })
         .css.toString()
     ).toEqualIgnoringWhitespace('a { b: 12; }');
+  });
+
+  it('with whitespace before the function', () => {
+    expect(() =>
+      sass.renderSync({
+        data: '',
+        functions: {' foo()': () => sass.types.Null.NULL},
+      })
+    ).toThrowLegacyException();
   });
 });
 


### PR DESCRIPTION
cc @ntkme

[skip dart-sass]
[skip sass-embedded]