### PR TITLE
Don't auto-skip dart-sass-embedded along with dart-sass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,10 +154,7 @@ jobs:
   js_api_sass_embedded:
     name: "JS API | sass-embedded | Node ${{ matrix.node_version }} | ${{ matrix.os }}"
     runs-on: "${{ matrix.os }}"
-    if: >-
-      github.event_name != 'pull_request' ||
-          (!contains(github.event.pull_request.body, 'skip sass-embedded') &&
-              !contains(github.event.pull_request.body, 'skip dart-sass'))
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.body, 'skip sass-embedded')
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
I added this under the erroneous impression that we ran *language*
tests against Dart Sass rather than just *JS API* tests.