### PR TITLE
Rename `fromPath()` to `fromRoot()`

### DIFF
--- a/lib/spec-directory/index.ts
+++ b/lib/spec-directory/index.ts
@@ -5,13 +5,13 @@ import {resolveSpecPath} from './spec-path';
 
 /**
  * Creates either a physical SpecDirectory from a directory or a virtual one
- * from an hrx archive.
+ * from an hrx archive representing the root of a test suite.
  *
  * The `path` parameter may end in `/`, `.hrx`, both, or neither, and will be
  * able to load both HRX archives and physical directories regardless of which
  * suffix it uses.
  */
-export async function fromPath(path: string): Promise<SpecDirectory> {
+export async function fromRoot(path: string): Promise<SpecDirectory> {
   const resolved = resolveSpecPath(path);
   return resolved.endsWith('.hrx')
     ? await VirtualDirectory.fromArchive(resolved)

--- a/lint-spec.ts
+++ b/lint-spec.ts
@@ -9,20 +9,20 @@ import RealDirectory from './lib/spec-directory/real-directory';
 import VirtualDirectory from './lib/spec-directory/virtual-directory';
 
 async function lintAllTests(fix: boolean) {
-  //try {
-  const rootPath = p.resolve(process.cwd(), 'spec');
-  const rootDir = (await fromRoot(rootPath)) as RealDirectory;
-  const reporter = new LintReporter(process.stdout, rootPath);
+  try {
+    const rootPath = p.resolve(process.cwd(), 'spec');
+    const rootDir = (await fromRoot(rootPath)) as RealDirectory;
+    const reporter = new LintReporter(process.stdout, rootPath);
 
-  await lintDirectory(rootDir, reporter, {canBeHrxRoot: true, fix});
-  await lintHrxSize(rootDir, reporter, {fix});
+    await lintDirectory(rootDir, reporter, {canBeHrxRoot: true, fix});
+    await lintHrxSize(rootDir, reporter, {fix});
 
-  reporter.writeSummary();
-  process.exitCode = reporter.exitCode();
-  // } catch (error) {
-  //   console.log(`${error}`);
-  //   process.exitCode = 255;
-  // }
+    reporter.writeSummary();
+    process.exitCode = reporter.exitCode();
+  } catch (error) {
+    console.log(`${error}`);
+    process.exitCode = 255;
+  }
 }
 
 async function lintDirectory(

--- a/lint-spec.ts
+++ b/lint-spec.ts
@@ -4,25 +4,25 @@ import p from 'path';
 import yargs from 'yargs/yargs';
 
 import {LintReporter} from './lib/lint-reporter';
-import {fromPath, SpecDirectory} from './lib/spec-directory';
+import {fromRoot, SpecDirectory} from './lib/spec-directory';
 import RealDirectory from './lib/spec-directory/real-directory';
 import VirtualDirectory from './lib/spec-directory/virtual-directory';
 
 async function lintAllTests(fix: boolean) {
-  try {
+  //try {
     const rootPath = p.resolve(process.cwd(), 'spec');
-    const rootDir = await fromPath(rootPath);
+    const rootDir = await fromRoot(rootPath) as RealDirectory;
     const reporter = new LintReporter(process.stdout, rootPath);
 
     await lintDirectory(rootDir, reporter, {canBeHrxRoot: true, fix});
-    await lintHrxSize(rootPath, reporter, {fix});
+    await lintHrxSize(rootDir, reporter, {fix});
 
     reporter.writeSummary();
     process.exitCode = reporter.exitCode();
-  } catch (error) {
-    console.log(`${error}`);
-    process.exitCode = 255;
-  }
+  // } catch (error) {
+  //   console.log(`${error}`);
+  //   process.exitCode = 255;
+  // }
 }
 
 async function lintDirectory(
@@ -161,33 +161,31 @@ async function lintNonHrxTestDir(
 const LINE_THRESHOLD = 500;
 
 /**
- * Verifies all HRX files in the {@link rootPath} directory are under the
- * {@link LINE_THRESHOLD}.
+ * Verifies all HRX files in {@link dir} directory are under the {@link
+ * LINE_THRESHOLD}.
  *
  * HRX files are unwrapped and transformed into real files when {@link fix} is
  * `true`.
  */
 async function lintHrxSize(
-  rootPath: string,
+  dir: RealDirectory,
   reporter: LintReporter,
   {fix = false}
 ) {
-  const rootDir = await fromPath(rootPath);
-  const tooBig = await bigHrxInTree(rootDir, reporter);
+  const tooBig = await bigHrx(dir, reporter);
 
   // No Errors.
   if (tooBig.length === 0) return;
 
   if (!fix) {
-    const tooBigRelative = tooBig.map(getRelativePath);
-    for (const f of tooBigRelative) {
-      reporter.reportError(`HRX file exceeds ${LINE_THRESHOLD} lines`, f, true);
+    for (const dir of tooBig) {
+      reporter.reportError(`HRX file exceeds ${LINE_THRESHOLD} lines`, getRelativePath(dir.path), true);
     }
   } else {
-    for (const archivePath of tooBig) {
-      await hrxToRealFiles(archivePath);
+    for (const archive of tooBig) {
+      await hrxToRealFiles(archive);
       // Fixes files recursively.
-      await lintHrxSize(archivePath, reporter, {fix});
+      await lintHrxSize((await dir.atPath(archive.relPath())) as RealDirectory, reporter, {fix});
     }
   }
 }
@@ -222,39 +220,18 @@ async function lintHrxSize(
  * ```
  *
  */
-async function hrxToRealFiles(archivePath: string) {
-  const virtualDir = (await fromPath(archivePath)) as VirtualDirectory;
-  fs.mkdirSync(virtualDir.path, {recursive: true});
+async function hrxToRealFiles(archive: VirtualDirectory) {
+  fs.mkdirSync(archive.path, {recursive: true});
 
-  for (const f of await virtualDir.listFiles()) {
-    const contents = await virtualDir.readFile(f);
-    fs.writeFileSync(p.join(virtualDir.path, f), contents);
+  for (const file of await archive.listFiles()) {
+    const contents = await archive.readFile(file);
+    fs.writeFileSync(p.join(archive.path, file), contents);
   }
-  for (const d of await virtualDir.subdirs()) {
-    const subArchivePath = `${d.path}.hrx`;
-    fs.writeFileSync(subArchivePath, await d.asArchive());
+  for (const subdir of await archive.subdirs()) {
+    const subArchivePath = `${subdir.path}.hrx`;
+    fs.writeFileSync(subArchivePath, await subdir.asArchive());
   }
-  fs.unlinkSync(archivePath);
-}
-
-/**
- * Navigates a directory tree to verify all HRX files follow the style guide,
- * such as number of lines in an HRX file.
- */
-async function bigHrxInTree(
-  dir: SpecDirectory,
-  reporter: LintReporter
-): Promise<string[]> {
-  if (!(dir instanceof RealDirectory)) return [];
-
-  return [
-    ...(await bigHrx(dir, reporter)),
-    ...(
-      await Promise.all(
-        (await dir.subdirs()).map(d => bigHrxInTree(d, reporter))
-      )
-    ).flat(),
-  ];
+  fs.unlinkSync(archive.path);
 }
 
 /**
@@ -282,27 +259,27 @@ async function bigHrxInTree(
 async function bigHrx(
   dir: RealDirectory,
   reporter: LintReporter
-): Promise<string[]> {
-  const hrxFiles = (await dir.listFiles())
-    .filter(f => p.extname(f) === '.hrx')
-    .map(f => p.join(dir.path, f));
+): Promise<VirtualDirectory[]> {
+  const tooBig: VirtualDirectory[] = [];
+  for (const subdir of await dir.subdirs()) {
+    if (subdir.isTestDir()) continue;
+    if (subdir instanceof RealDirectory) {
+      tooBig.push(...await bigHrx(subdir, reporter));
+      continue;
+    }
 
-  const tooBig: string[] = [];
-  for (const f of hrxFiles) {
-    const subDir = await fromPath(f);
-    if (subDir.isTestDir()) continue;
+    const hrxPath = subdir.path + '.hrx';
+    reporter.reportLintedFile(hrxPath);
 
-    reporter.reportLintedFile(f);
-
-    const options = await subDir.options();
+    const options = await subdir.options();
     const linterAnnotation =
       options.getMode('lint-hrx') ?? options.getMode('sass/sass-spec#');
     // Skip XHR files annotated with :ignore-for: or :todo: containing
     // `lint-hrx` or `sass/sass-spec#...`
     if (linterAnnotation !== undefined) continue;
 
-    const lines = await fileLinesCount(f);
-    if (lines > LINE_THRESHOLD) tooBig.push(f);
+    const lines = await fileLinesCount(hrxPath);
+    if (lines > LINE_THRESHOLD) tooBig.push(subdir as VirtualDirectory);
   }
   return tooBig;
 }

--- a/lint-spec.ts
+++ b/lint-spec.ts
@@ -10,15 +10,15 @@ import VirtualDirectory from './lib/spec-directory/virtual-directory';
 
 async function lintAllTests(fix: boolean) {
   //try {
-    const rootPath = p.resolve(process.cwd(), 'spec');
-    const rootDir = await fromRoot(rootPath) as RealDirectory;
-    const reporter = new LintReporter(process.stdout, rootPath);
+  const rootPath = p.resolve(process.cwd(), 'spec');
+  const rootDir = (await fromRoot(rootPath)) as RealDirectory;
+  const reporter = new LintReporter(process.stdout, rootPath);
 
-    await lintDirectory(rootDir, reporter, {canBeHrxRoot: true, fix});
-    await lintHrxSize(rootDir, reporter, {fix});
+  await lintDirectory(rootDir, reporter, {canBeHrxRoot: true, fix});
+  await lintHrxSize(rootDir, reporter, {fix});
 
-    reporter.writeSummary();
-    process.exitCode = reporter.exitCode();
+  reporter.writeSummary();
+  process.exitCode = reporter.exitCode();
   // } catch (error) {
   //   console.log(`${error}`);
   //   process.exitCode = 255;
@@ -179,13 +179,21 @@ async function lintHrxSize(
 
   if (!fix) {
     for (const dir of tooBig) {
-      reporter.reportError(`HRX file exceeds ${LINE_THRESHOLD} lines`, getRelativePath(dir.path), true);
+      reporter.reportError(
+        `HRX file exceeds ${LINE_THRESHOLD} lines`,
+        getRelativePath(dir.path),
+        true
+      );
     }
   } else {
     for (const archive of tooBig) {
       await hrxToRealFiles(archive);
       // Fixes files recursively.
-      await lintHrxSize((await dir.atPath(archive.relPath())) as RealDirectory, reporter, {fix});
+      await lintHrxSize(
+        (await dir.atPath(archive.relPath())) as RealDirectory,
+        reporter,
+        {fix}
+      );
     }
   }
 }
@@ -264,7 +272,7 @@ async function bigHrx(
   for (const subdir of await dir.subdirs()) {
     if (subdir.isTestDir()) continue;
     if (subdir instanceof RealDirectory) {
-      tooBig.push(...await bigHrx(subdir, reporter));
+      tooBig.push(...(await bigHrx(subdir, reporter)));
       continue;
     }
 

--- a/sass-spec.ts
+++ b/sass-spec.ts
@@ -1,4 +1,4 @@
-import {fromPath} from './lib/spec-directory';
+import {fromRoot} from './lib/spec-directory';
 import {Interactor} from './lib/interactor';
 import {parseArgs, CliArgs} from './lib/cli-args';
 import TestCase from './lib/test-case';
@@ -11,7 +11,7 @@ async function runAllTests() {
     const start = Date.now();
     const args = (args_ = await parseArgs(process.argv.slice(2)));
     const rootPath = args.root;
-    const rootDir = await fromPath(rootPath);
+    const rootDir = await fromRoot(rootPath);
     const tabulator = new Tabulator(process.stdout, args.verbose);
 
     const dirsToTest =

--- a/test/spec-directory/iteration.test.ts
+++ b/test/spec-directory/iteration.test.ts
@@ -1,11 +1,11 @@
 import path from 'path';
-import {fromPath, SpecDirectory} from '../../lib/spec-directory';
+import {fromRoot, SpecDirectory} from '../../lib/spec-directory';
 
 describe('SpecDirectory iteration', () => {
   describe('forEachTest', () => {
     let dir: SpecDirectory;
     beforeEach(async () => {
-      dir = await fromPath(path.resolve(__dirname, './fixtures/iterate'));
+      dir = await fromRoot(path.resolve(__dirname, './fixtures/iterate'));
     });
 
     it('iterates through all test directories', async () => {
@@ -73,9 +73,9 @@ describe('SpecDirectory iteration', () => {
     });
 
     describe('supports a trailing slash', () => {
-      describe('in fromPath()', () => {
+      describe('in fromRoot()', () => {
         it('for a physical directory', async () => {
-          dir = await fromPath(
+          dir = await fromRoot(
             path.resolve(__dirname, './fixtures/iterate/physical/')
           );
 
@@ -87,7 +87,7 @@ describe('SpecDirectory iteration', () => {
         });
 
         it('for an HRX archive', async () => {
-          dir = await fromPath(
+          dir = await fromRoot(
             path.resolve(__dirname, './fixtures/iterate/archive/')
           );
 
@@ -128,9 +128,9 @@ describe('SpecDirectory iteration', () => {
     });
 
     describe('supports a .hrx extension', () => {
-      describe('in fromPath()', () => {
+      describe('in fromRoot()', () => {
         it('for a physical directory', async () => {
-          dir = await fromPath(
+          dir = await fromRoot(
             path.resolve(__dirname, './fixtures/iterate/physical.hrx')
           );
 
@@ -142,7 +142,7 @@ describe('SpecDirectory iteration', () => {
         });
 
         it('for an HRX archive', async () => {
-          dir = await fromPath(
+          dir = await fromRoot(
             path.resolve(__dirname, './fixtures/iterate/archive.hrx')
           );
 

--- a/test/spec-directory/mutations.test.ts
+++ b/test/spec-directory/mutations.test.ts
@@ -1,11 +1,11 @@
 import path from 'path';
-import {fromPath} from '../../lib/spec-directory';
+import {fromRoot} from '../../lib/spec-directory';
 
 // Tests for methods on SpecDirectory that mutate its contents
 describe('SpecDirectory mutations', () => {
   describe('writeFile', () => {
     it('replaces the contents of a virtual file', async () => {
-      const dir = await fromPath(
+      const dir = await fromRoot(
         path.resolve(__dirname, './fixtures/basic.hrx')
       );
       await dir.writeFile('output.css', 'NEW OUTPUT');
@@ -13,7 +13,7 @@ describe('SpecDirectory mutations', () => {
     });
 
     it('writes contents to a file that does not exist yet', async () => {
-      const dir = await fromPath(
+      const dir = await fromRoot(
         path.resolve(__dirname, './fixtures/basic.hrx')
       );
       await dir.writeFile('output-libsass.css', 'MORE OUTPUT');
@@ -22,7 +22,7 @@ describe('SpecDirectory mutations', () => {
     });
 
     it('errors when passed in a multi-level path', async () => {
-      const dir = await fromPath(
+      const dir = await fromRoot(
         path.resolve(__dirname, './fixtures/basic.hrx')
       );
       await expect(() =>
@@ -33,7 +33,7 @@ describe('SpecDirectory mutations', () => {
 
   describe('deleteFile', () => {
     it('removes the contents of the virtual file', async () => {
-      const dir = await fromPath(
+      const dir = await fromRoot(
         path.resolve(__dirname, './fixtures/basic.hrx')
       );
       await dir.removeFile('output.css');
@@ -42,7 +42,7 @@ describe('SpecDirectory mutations', () => {
     });
 
     it('no-ops when removing a file that does not exist', async () => {
-      const dir = await fromPath(
+      const dir = await fromRoot(
         path.resolve(__dirname, './fixtures/basic.hrx')
       );
       const files = await dir.listFiles();
@@ -51,14 +51,14 @@ describe('SpecDirectory mutations', () => {
     });
 
     it('errors when trying to remove a directory', async () => {
-      const dir = await fromPath(
+      const dir = await fromRoot(
         path.resolve(__dirname, './fixtures/basic.hrx')
       );
       await expect(() => dir.removeFile('subdir')).rejects.toThrow();
     });
 
     it('errors when trying to remove multi-level paths', async () => {
-      const dir = await fromPath(
+      const dir = await fromRoot(
         path.resolve(__dirname, './fixtures/basic.hrx')
       );
       await expect(() =>

--- a/test/spot-check.test.ts
+++ b/test/spot-check.test.ts
@@ -25,5 +25,5 @@ it('every directory contains or is contained by a test', async () => {
     }
   }
 
-  await verifyDirectory(await specDirectory.fromPath('spec'));
+  await verifyDirectory(await specDirectory.fromRoot('spec'));
 });


### PR DESCRIPTION
This clarifies that this should only be used for the root directory of
a test suite, since it won't consider any options that come from
parent directories. This also refactors lint-spec.ts to avoid using
this function for subdirectories.