### PR TITLE
Add `SpecDirectory.parent()`

### DIFF
--- a/lib/spec-directory/index.ts
+++ b/lib/spec-directory/index.ts
@@ -18,6 +18,9 @@ export async function fromRoot(path: string): Promise<SpecDirectory> {
     : new RealDirectory(resolved);
 }
 
+/**
+ * Create a virtual directory from string contents, for testing purposes.
+ */
 export function fromContents(contents: string): Promise<SpecDirectory> {
   return VirtualDirectory.fromContents(contents);
 }

--- a/lib/spec-directory/real-directory.ts
+++ b/lib/spec-directory/real-directory.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
 
-import SpecOptions from './options';
 import SpecDirectory from './spec-directory';
 import VirtualDirectory from './virtual-directory';
 import {resolveSpecPath} from './spec-path';
@@ -9,8 +8,8 @@ import {resolveSpecPath} from './spec-path';
 export default class RealDirectory extends SpecDirectory {
   path: string;
 
-  constructor(path: string, root?: SpecDirectory, parentOpts?: SpecOptions) {
-    super(root, parentOpts);
+  constructor(path: string, root?: SpecDirectory) {
+    super(root);
     this.path = path;
   }
 
@@ -41,11 +40,10 @@ export default class RealDirectory extends SpecDirectory {
   }
 
   async getSubdir(name: string): Promise<SpecDirectory> {
-    const options = await this.options();
     const resolved = resolveSpecPath(path.resolve(this.path, name));
     return resolved.endsWith('.hrx')
-      ? await VirtualDirectory.fromArchive(resolved, this.root, options)
-      : new RealDirectory(resolved, this.root, options);
+      ? await VirtualDirectory.fromArchive(resolved, this)
+      : new RealDirectory(resolved, this.root);
   }
 
   async writeFile(filename: string, contents: string): Promise<void> {

--- a/lib/spec-directory/virtual-directory.ts
+++ b/lib/spec-directory/virtual-directory.ts
@@ -91,17 +91,12 @@ export default class VirtualDirectory extends SpecDirectory {
   }
 
   /**
-   * Create a virtual directory from string contents, and an optional path.
-   * If no path is given (e.g. in testing), it is set to an empty string.
+   * Create a virtual directory from string contents, for testing purposes.
    */
-  static async fromContents(
-    contents: string,
-    path = ''
-  ): Promise<VirtualDirectory> {
+  static async fromContents(contents: string): Promise<VirtualDirectory> {
     const stream = Readable.from(contents);
     const archive = await archiveFromStream(stream);
-    // TODO where should the temp path be?
-    return new VirtualDirectory(path, archive);
+    return new VirtualDirectory('<test>', archive);
   }
 
   // File access

--- a/lib/spec-directory/virtual-directory.ts
+++ b/lib/spec-directory/virtual-directory.ts
@@ -2,9 +2,9 @@ import fs from 'fs';
 import path from 'path';
 
 import {Readable} from 'stream';
+import RealDirectory from './real-directory';
 import SpecDirectory, {SpecIteratee} from './spec-directory';
 import {archiveFromStream, Directory as HrxDirectory} from 'node-hrx';
-import SpecOptions from './options';
 import {withAsyncCleanup} from './cleanup';
 import {normalizeSpecPath} from './spec-path';
 
@@ -33,24 +33,28 @@ function createSubdirCache(dir: HrxDirectory): Record<string, HrxDirectory> {
 export default class VirtualDirectory extends SpecDirectory {
   path: string;
   basePath: string;
+
+  // The directory that contains this, or `null` if this is the root directory.
+  private _parent: SpecDirectory | null;
+
   // Names of direct files in archive order
   private fileNames: string[];
+
   // Mapping from file names to file contents
   private fileContents: Record<string, string>;
+
   // Names of direct subdirectories in archive order
   private subdirNames: string[];
+
   // mapping from subdir names to the HRX Directory object
   private subdirCache: Record<string, HrxDirectory>;
+
   private isArchiveRoot: boolean;
   private modified = false;
 
-  constructor(
-    basePath: string,
-    hrxDir: HrxDirectory,
-    root?: SpecDirectory,
-    parentOpts?: SpecOptions
-  ) {
-    super(root, parentOpts);
+  constructor(basePath: string, hrxDir: HrxDirectory, parent?: SpecDirectory) {
+    super(parent?.root);
+    this._parent = parent ?? null;
     this.path = path.resolve(basePath, hrxDir.path);
     this.basePath = basePath;
     // Separate the contents of the HrxDirectory into files and subdirs.
@@ -65,13 +69,21 @@ export default class VirtualDirectory extends SpecDirectory {
     this.isArchiveRoot = hrxDir.path === '';
   }
 
+  async parent(): Promise<SpecDirectory | null> {
+    return this._parent;
+  }
+
   // Factories
 
-  // Unarchive the given .hrx file and turn it into a spec path
+  /**
+   * Loads a spec directory from the HRX file at `hrxPath`.
+   *
+   * If this isn't the root of the test suite, `parent` must be the directory
+   * that contains this file.
+   */
   static async fromArchive(
     hrxPath: string,
-    root?: SpecDirectory,
-    parentOpts?: SpecOptions
+    parent?: RealDirectory
   ): Promise<VirtualDirectory> {
     const stream = fs.createReadStream(hrxPath, {encoding: 'utf-8'});
     let archive;
@@ -82,12 +94,7 @@ export default class VirtualDirectory extends SpecDirectory {
     }
 
     const {dir, name} = path.parse(hrxPath);
-    return new VirtualDirectory(
-      path.resolve(dir, name),
-      archive,
-      root,
-      parentOpts
-    );
+    return new VirtualDirectory(path.resolve(dir, name), archive, parent);
   }
 
   /**
@@ -151,8 +158,7 @@ export default class VirtualDirectory extends SpecDirectory {
     if (!subdir) {
       throw new Error(`Subdirectory does not exist: ${path}/${name}`);
     }
-    const options = await this.options();
-    return new VirtualDirectory(this.basePath, subdir, this.root, options);
+    return new VirtualDirectory(this.basePath, subdir, this);
   }
 
   // Iteration

--- a/lib/spec-directory/virtual-directory.ts
+++ b/lib/spec-directory/virtual-directory.ts
@@ -34,19 +34,21 @@ export default class VirtualDirectory extends SpecDirectory {
   path: string;
   basePath: string;
 
-  // The directory that contains this, or `null` if this is the root directory.
+  /**
+   * The directory that contains this, or `null` if this is the root directory.
+   */
   private _parent: SpecDirectory | null;
 
-  // Names of direct files in archive order
+  /** Names of direct files in archive order. */
   private fileNames: string[];
 
-  // Mapping from file names to file contents
+  /** Mapping from file names to file contents. */
   private fileContents: Record<string, string>;
 
-  // Names of direct subdirectories in archive order
+  /** Names of direct subdirectories in archive order. */
   private subdirNames: string[];
 
-  // mapping from subdir names to the HRX Directory object
+  /** The mapping from subdir names to the HRX Directory object. */
   private subdirCache: Record<string, HrxDirectory>;
 
   private isArchiveRoot: boolean;


### PR DESCRIPTION
This allows us to stop eagerly fetching options to pass to subdirectories,
which helps ensure correctness when parent directory options are modified.
Having access to the parent directory also makes more complex and powerful
automated refactors possible.