### PR TITLE
Add regression test for escaped backslash

### DIFF
--- a/spec/parser/selector.hrx
+++ b/spec/parser/selector.hrx
@@ -1,3 +1,16 @@
+<===> escaped_backslash/input.scss
+// Regression test for sass/dart-sass#1855.
+\\{
+  b: c;
+}
+
+<===> escaped_backslash/output.css
+\\ {
+  b: c;
+}
+
+<===>
+================================================================================
 <===> error/empty_placeholder/input.scss
 % {
   a: b;


### PR DESCRIPTION
See https://github.com/sass/dart-sass/issues/1855

[skip dart-sass]