### PR TITLE
Fix a race condition in the Dart compiler

### DIFF
--- a/lib/compiler.ts
+++ b/lib/compiler.ts
@@ -94,9 +94,14 @@ export class DartCompiler implements Compiler {
     this.stdin.write(`!cd ${path}\n`);
     this.stdin.write([...this.initArgs, ...opts].join(' ') + '\n');
 
+    const [stdout, stderr] = (await Promise.all([
+      this.stdout.next(),
+      this.stderr.next()
+    ])).map(event => event.value);
+
     return {
-      stdout: (await this.stdout.next()).value,
-      stderr: (await this.stderr.next()).value,
+      stdout,
+      stderr,
       status: +(await this.stdout.next()).value,
     };
   }

--- a/lib/compiler.ts
+++ b/lib/compiler.ts
@@ -94,10 +94,9 @@ export class DartCompiler implements Compiler {
     this.stdin.write(`!cd ${path}\n`);
     this.stdin.write([...this.initArgs, ...opts].join(' ') + '\n');
 
-    const [stdout, stderr] = (await Promise.all([
-      this.stdout.next(),
-      this.stderr.next()
-    ])).map(event => event.value);
+    const [stdout, stderr] = (
+      await Promise.all([this.stdout.next(), this.stderr.next()])
+    ).map(event => event.value);
 
     return {
       stdout,


### PR DESCRIPTION
If Dart chose to block while writing stdout or stderr, only requesting
one of them could cause the runner to deadlock.