### PR TITLE
Stop using arduino/setup-protoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ defaults:
   run: {shell: bash}
 
 env:
-  PROTOC_VERSION: 3.x
   NODE_VERSION: 14
 
 on:
@@ -178,10 +177,6 @@ jobs:
       - run: npm install
       - uses: dart-lang/setup-dart@v1
         with: {sdk: stable}
-      - uses: arduino/setup-protoc@v1
-        with:
-          version: ${{ env.PROTOC_VERSION }}
-          repo-token: '${{ github.token }}'
 
       - name: Install sass-embedded
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ defaults:
   run: {shell: bash}
 
 env:
-  NODE_VERSION: 14
+  NODE_VERSION: 18
 
 on:
   push: {branches: [main, feature.*]}
@@ -114,13 +114,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node_version: [16]
+        node_version: [18]
         # Only test LTS versions on Ubuntu
         include:
         - os: ubuntu-latest
-          node_version: 12
-        - os: ubuntu-latest
           node_version: 14
+        - os: ubuntu-latest
+          node_version: 12
 
     steps:
       - uses: actions/checkout@v2
@@ -162,13 +162,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node_version: [16]
+        node_version: [18]
         # Only test LTS versions on Ubuntu
         include:
         - os: ubuntu-latest
-          node_version: 12
-        - os: ubuntu-latest
           node_version: 14
+        - os: ubuntu-latest
+          node_version: 16
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The embedded host now uses buf to compile its protobufs, which it can
install through npm.