### PR TITLE
Update Node for JS API to 18/16/14, leave other tests at 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ defaults:
 
 env:
   PROTOC_VERSION: 3.x
+  # TODO(jathak): Update this to Node 18 once unit tests are fixed.
   NODE_VERSION: 14
 
 on:
@@ -115,13 +116,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node_version: [16]
+        node_version: [18]
         # Only test LTS versions on Ubuntu
         include:
         - os: ubuntu-latest
-          node_version: 12
-        - os: ubuntu-latest
           node_version: 14
+        - os: ubuntu-latest
+          node_version: 16
 
     steps:
       - uses: actions/checkout@v2
@@ -163,13 +164,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node_version: [16]
+        node_version: [18]
         # Only test LTS versions on Ubuntu
         include:
         - os: ubuntu-latest
-          node_version: 12
-        - os: ubuntu-latest
           node_version: 14
+        - os: ubuntu-latest
+          node_version: 16
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Our unit tests are having issues on Node >14, so we're leaving most tests as-is for now.

For the JS API, this updates to test on 18/16/14 instead of 16/14/12, since Node 12 no longer works.