### PR TITLE
Run specs against the JS API doc typedefs

### DIFF
--- a/js-api-spec.ts
+++ b/js-api-spec.ts
@@ -76,7 +76,10 @@ fs.writeFileSync(
   `module.exports = require(${packageRequire});`
 );
 
-const specPath = p.join(argv.sassSassRepo, 'spec/js-api');
+// Load the APIs from the doc folder, since it uses plain .d.ts files instead of
+// literate .d.ts.md files. The language repo's CI ensures the two remain in
+// sync.
+const specPath = p.join(argv.sassSassRepo, 'js-api-doc');
 const specIndex = p.join(specPath, 'index.d.ts');
 if (!fs.existsSync(specIndex)) {
   console.error(`${specIndex} doesn't exist!`);


### PR DESCRIPTION
This fixes a breakage caused by moving the specs to a literate
programming style in sass/sass#3552.