### PR TITLE
JS API tests for loading multiple nested paths with renderSync

### DIFF
--- a/js-api-spec/legacy/importer.node.test.ts
+++ b/js-api-spec/legacy/importer.node.test.ts
@@ -941,14 +941,14 @@ it('compiles multiple nested relative imports and incorrect load path with rende
   await sandbox(dir => {
     dir.write({
       'src/index.scss': `
-        @import "./foo/_a.scss";
+        @import "./_a.scss";
         @import "./_includes.scss";
       `,
-      'include/foo/_a.scss': '/* A */',
-      'include/foo/_b.scss': '/* B */',
+      'include/_a.scss': '/* A */',
+      'include/_b.scss': '/* B */',
       'src/_includes.scss': `
-        @import "./foo/_a.scss";
-        @import "./foo/_b.scss";
+        @import "./_a.scss";
+        @import "./_b.scss";
       `,
     });
 

--- a/js-api-spec/legacy/importer.node.test.ts
+++ b/js-api-spec/legacy/importer.node.test.ts
@@ -937,7 +937,8 @@ describe('when importer returns non-string contents', () => {
   });
 });
 
-it('compiles multiple nested relative imports and incorrect load path with renderSync', async () => {
+// Regression test for sass/dart-sass#1962
+it('compiles multiple nested relative imports loaded multiple times across different files', async () => {
   await sandbox(dir => {
     dir.write({
       'src/index.scss': `

--- a/js-api-spec/legacy/importer.node.test.ts
+++ b/js-api-spec/legacy/importer.node.test.ts
@@ -937,8 +937,8 @@ describe('when importer returns non-string contents', () => {
   });
 });
 
-it('compiles multiple nested relative imports and incorrect load path with renderSync', () => {
-  sandbox(dir => {
+it('compiles multiple nested relative imports and incorrect load path with renderSync', async () => {
+  await sandbox(dir => {
     dir.write({
       'src/index.scss': `
         @import "./foo/_a.scss";

--- a/js-api-spec/legacy/importer.node.test.ts
+++ b/js-api-spec/legacy/importer.node.test.ts
@@ -965,6 +965,6 @@ it('compiles multiple nested relative imports loaded multiple times across diffe
         return null;
       },
     });
-    expect(result.css.toString()).toBe('/* A */\n/* A */ /* B */');
+    expect(result.css.toString()).toBe('/* A */\n/* A */\n/* B */');
   });
 });


### PR DESCRIPTION
Issue: https://github.com/sass/dart-sass/issues/1962

[skip sass-embedded]

See: https://github.com/sass/embedded-host-node/pull/226