### PR TITLE
Update specs for Dart-3-style Dart Sass

### DIFF
--- a/spec/core_functions/selector/unify/complex/combinators/multiple.hrx
+++ b/spec/core_functions/selector/unify/complex/combinators/multiple.hrx
@@ -3,6 +3,11 @@ a {b: selector-unify(".c > .d + .e", ".f .g ~ .h")}
 
 <===> isolated/output.css
 a {
+  b: .f .c > .g ~ .d + .e.h, .f .c > .d.g + .e.h;
+}
+
+<===> isolated/output-libsass.css
+a {
   b: .f .c > .g ~ .d + .e.h, .f .c > .g.d + .e.h;
 }
 

--- a/spec/core_functions/selector/unify/complex/combinators/next_sibling.hrx
+++ b/spec/core_functions/selector/unify/complex/combinators/next_sibling.hrx
@@ -23,6 +23,11 @@ a {b: selector-unify(".c + .d", ".e ~ .f")}
 
 <===> and_sibling/distinct/output.css
 a {
+  b: .e ~ .c + .d.f, .c.e + .d.f;
+}
+
+<===> and_sibling/distinct/output-libsass.css
+a {
   b: .e ~ .c + .d.f, .e.c + .d.f;
 }
 
@@ -52,6 +57,11 @@ a {
 a {b: selector-unify(".c.s1-1 + .s1-2", ".c.s2-1 ~ .s2-2")}
 
 <===> and_sibling/overlap/output.css
+a {
+  b: .c.s2-1 ~ .c.s1-1 + .s1-2.s2-2, .c.s1-1.s2-1 + .s1-2.s2-2;
+}
+
+<===> and_sibling/overlap/output-libsass.css
 a {
   b: .c.s2-1 ~ .c.s1-1 + .s1-2.s2-2, .c.s2-1.s1-1 + .s1-2.s2-2;
 }

--- a/spec/non_conformant/extend-tests/146_test_combinator_unification_tilde_plus.hrx
+++ b/spec/non_conformant/extend-tests/146_test_combinator_unification_tilde_plus.hrx
@@ -3,6 +3,11 @@
 .b ~ y {@extend x}
 
 <===> output.css
+.a + x, .b ~ .a + y, .a.b + y {
+  a: b;
+}
+
+<===> output-libsass.css
 .a + x, .b ~ .a + y, .b.a + y {
   a: b;
 }


### PR DESCRIPTION
This really _shouldn't_ affect any CSS output, but these changes are
semantically irrelevant and arguably better-looking than the old
versions.

[skip dart-sass]