### PR TITLE
[Color 4] Add tests for `lab()`

### DIFF
--- a/spec/core_functions/color/hsl/error/one_arg.hrx
+++ b/spec/core_functions/color/hsl/error/one_arg.hrx
@@ -159,7 +159,7 @@ Error: $channels: Expected lightness "var(--foo) / 0.4" to be a number.
 a {b: hsl(append((), 0 100% 100%, $separator: slash))}
 
 <===> slash_list/too_few_elements/error
-Error: Only 2 slash-separated elements allowed, but 1 was passed.
+Error: $channels: Only 2 slash-separated elements allowed, but 1 was passed.
   ,
 1 | a {b: hsl(append((), 0 100% 100%, $separator: slash))}
   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -173,7 +173,7 @@ Error: Only 2 slash-separated elements allowed, but 1 was passed.
 a {b: hsl(list.slash(0 100% 100%, 0.4, 1))}
 
 <===> slash_list/too_many_elements/error
-Error: Only 2 slash-separated elements allowed, but 3 were passed.
+Error: $channels: Only 2 slash-separated elements allowed, but 3 were passed.
   ,
 2 | a {b: hsl(list.slash(0 100% 100%, 0.4, 1))}
   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/spec/core_functions/color/lab/_utils.scss
+++ b/spec/core_functions/color/lab/_utils.scss
@@ -1,0 +1,27 @@
+@use 'sass:color';
+@use 'sass:list';
+@use 'sass:meta';
+
+@function -real-channel($color, $channel) {
+  @if color.is-missing($color, $channel) {
+    @return none;
+  } @else {
+    @return color.channel($color, $channel);
+  }
+}
+
+@mixin inspect($color) {
+  a {
+    value: $color;
+    @if meta.type-of($color) == string {
+      type: string;
+    } @else {
+      channels: list.slash(
+        -real-channel($color, 'lightness')
+          -real-channel($color, 'a')
+          -real-channel($color, 'b'),
+        -real-channel($color, 'alpha')
+      );
+    }
+  }
+}

--- a/spec/core_functions/color/lab/alpha.hrx
+++ b/spec/core_functions/color/lab/alpha.hrx
@@ -1,0 +1,145 @@
+<===> transparent/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(0 255 127 / 0));
+
+<===> transparent/output.css
+a {
+  value: lab(0% 255 127 / 0);
+  channels: 0% 255 127 / 0;
+}
+
+<===>
+================================================================================
+<===> opaque/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 3 / 1));
+
+<===> opaque/output.css
+a {
+  value: lab(1% 2 3);
+  channels: 1% 2 3 / 1;
+}
+
+<===>
+================================================================================
+<===> partial/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 3 / 0.4));
+
+<===> partial/output.css
+a {
+  value: lab(1% 2 3 / 0.4);
+  channels: 1% 2 3 / 0.4;
+}
+
+<===>
+================================================================================
+<===> percent/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 3 / 40%));
+
+<===> percent/output.css
+a {
+  value: lab(1% 2 3 / 0.4);
+  channels: 1% 2 3 / 0.4;
+}
+
+<===>
+================================================================================
+<===> named/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab($channels: 1% 2 3 / 0.4));
+
+<===> named/output.css
+a {
+  value: lab(1% 2 3 / 0.4);
+  channels: 1% 2 3 / 0.4;
+}
+
+<===>
+================================================================================
+<===> slash_list/input.scss
+@use "sass:list";
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(list.slash(1% 2 3, 0.4)));
+
+<===> slash_list/output.css
+a {
+  value: lab(1% 2 3 / 0.4);
+  channels: 1% 2 3 / 0.4;
+}
+
+<===>
+================================================================================
+<===> none/slash/b/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 none / 0.4));
+
+<===> none/slash/b/output.css
+a {
+  value: lab(1% 2 none / 0.4);
+  channels: 1% 2 none / 0.4;
+}
+
+<===>
+================================================================================
+<===> none/slash/alpha/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 3 / none));
+
+<===> none/slash/alpha/output.css
+a {
+  value: lab(1% 2 3 / none);
+  channels: 1% 2 3 / none;
+}
+
+<===>
+================================================================================
+<===> none/slash/b_and_alpha/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 none / none));
+
+<===> none/slash/b_and_alpha/output.css
+a {
+  value: lab(1% 2 none / none);
+  channels: 1% 2 none / none;
+}
+
+<===>
+================================================================================
+<===> none/slash_list/b/input.scss
+@use 'sass:list';
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(list.slash(1% 2 none, 0.4)));
+
+<===> none/slash_list/b/output.css
+a {
+  value: lab(1% 2 none / 0.4);
+  channels: 1% 2 none / 0.4;
+}
+
+<===>
+================================================================================
+<===> none/slash_list/alpha/input.scss
+@use 'sass:list';
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(list.slash(1% 2 3, none)));
+
+<===> none/slash_list/alpha/output.css
+a {
+  value: lab(1% 2 3 / none);
+  channels: 1% 2 3 / none;
+}
+
+<===>
+================================================================================
+<===> none/slash_list/b_and_alpha/input.scss
+@use 'sass:list';
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(list.slash(1% 2 none, none)));
+
+<===> none/slash_list/b_and_alpha/output.css
+a {
+  value: lab(1% 2 none / none);
+  channels: 1% 2 none / none;
+}

--- a/spec/core_functions/color/lab/error.hrx
+++ b/spec/core_functions/color/lab/error.hrx
@@ -1,0 +1,259 @@
+<===> unit/lightness/input.scss
+a {b: lab(1px 2 3)}
+
+<===> unit/lightness/error
+Error: $lightness: Expected 1px to have no units or "%".
+  ,
+1 | a {b: lab(1px 2 3)}
+  |       ^^^^^^^^^^^^
+  '
+  input.scss 1:7  root stylesheet
+
+<===>
+================================================================================
+<===> unit/a/input.scss
+a {b: lab(1% 2px 3)}
+
+<===> unit/a/error
+Error: $a: Expected 2px to have no units or "%".
+  ,
+1 | a {b: lab(1% 2px 3)}
+  |       ^^^^^^^^^^^^^
+  '
+  input.scss 1:7  root stylesheet
+
+<===>
+================================================================================
+<===> unit/b/input.scss
+a {b: lab(1% 2 3px)}
+
+<===> unit/b/error
+Error: $b: Expected 3px to have no units or "%".
+  ,
+1 | a {b: lab(1% 2 3px)}
+  |       ^^^^^^^^^^^^^
+  '
+  input.scss 1:7  root stylesheet
+
+<===>
+================================================================================
+<===> unit/alpha/slash/input.scss
+a {b: lab(1% 2 3/0.4px)}
+
+<===> unit/alpha/slash/error
+Error: $alpha: Expected 0.4px to have no units or "%".
+  ,
+1 | a {b: lab(1% 2 3/0.4px)}
+  |       ^^^^^^^^^^^^^^^^^
+  '
+  input.scss 1:7  root stylesheet
+
+<===>
+================================================================================
+<===> unit/alpha/slash_list/input.scss
+@use 'sass:list';
+a {b: lab(list.slash(1% 2 3, 0.4px))}
+
+<===> unit/alpha/slash_list/error
+Error: $alpha: Expected 0.4px to have no units or "%".
+  ,
+2 | a {b: lab(list.slash(1% 2 3, 0.4px))}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet
+
+<===>
+================================================================================
+<===> type/lightness/input.scss
+a {b: lab(c 2 3)}
+
+<===> type/lightness/error
+Error: $channels: Expected lightness c to be a number.
+  ,
+1 | a {b: lab(c 2 3)}
+  |       ^^^^^^^^^^
+  '
+  input.scss 1:7  root stylesheet
+
+<===>
+================================================================================
+<===> type/a/input.scss
+a {b: lab(1% c 3)}
+
+<===> type/a/error
+Error: $channels: Expected a c to be a number.
+  ,
+1 | a {b: lab(1% c 3)}
+  |       ^^^^^^^^^^^
+  '
+  input.scss 1:7  root stylesheet
+
+<===>
+================================================================================
+<===> type/b/input.scss
+a {b: lab(1% 2 c)}
+
+<===> type/b/error
+Error: $channels: Expected b c to be a number.
+  ,
+1 | a {b: lab(1% 2 c)}
+  |       ^^^^^^^^^^^
+  '
+  input.scss 1:7  root stylesheet
+
+<===>
+================================================================================
+<===> type/alpha/slash_list/input.scss
+@use 'sass:list';
+a {b: lab(list.slash(1% 2 3, c))}
+
+<===> type/alpha/slash_list/error
+Error: $channels: c is not a number.
+  ,
+2 | a {b: lab(list.slash(1% 2 3, c))}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet
+
+<===>
+================================================================================
+<===> list/bracketed/input.scss
+a {b: lab([1% 2 3])}
+
+<===> list/bracketed/error
+Error: $channels: Expected an unbracketed list, was [1% 2 3]
+  ,
+1 | a {b: lab([1% 2 3])}
+  |       ^^^^^^^^^^^^^
+  '
+  input.scss 1:7  root stylesheet
+
+<===>
+================================================================================
+<===> list/comma/input.scss
+a {b: lab((1%, 2, 3))}
+
+<===> list/comma/error
+Error: $channels: Expected a space- or slash-separated list, was (1%, 2, 3)
+  ,
+1 | a {b: lab((1%, 2, 3))}
+  |       ^^^^^^^^^^^^^^^
+  '
+  input.scss 1:7  root stylesheet
+
+<===>
+================================================================================
+<===> list/slash/three/input.scss
+@use 'sass:list';
+a {b: lab(list.slash(1%, 2, 3))}
+
+<===> list/slash/three/error
+Error: $channels: Only 2 slash-separated elements allowed, but 3 were passed.
+  ,
+2 | a {b: lab(list.slash(1%, 2, 3))}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet
+
+<===>
+================================================================================
+<===> list/slash/one/input.scss
+@use 'sass:list';
+$single-arg-slash-separated: list.append((), 1% 2 3, $separator: slash);
+a {b: lab($single-arg-slash-separated)}
+
+<===> list/slash/one/error
+Error: $channels: Only 2 slash-separated elements allowed, but 1 was passed.
+  ,
+3 | a {b: lab($single-arg-slash-separated)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 3:7  root stylesheet
+
+<===>
+================================================================================
+<===> list/empty/input.scss
+a {b: lab(())}
+
+<===> list/empty/error
+Error: $channels: Color component list may not be empty.
+  ,
+1 | a {b: lab(())}
+  |       ^^^^^^^
+  '
+  input.scss 1:7  root stylesheet
+
+<===>
+================================================================================
+<===> list/empty_space/input.scss
+@use 'sass:list';
+$empty-space: list.join((), (), $separator: space);
+a {b: lab(())}
+
+<===> list/empty_space/error
+Error: $channels: Color component list may not be empty.
+  ,
+3 | a {b: lab(())}
+  |       ^^^^^^^
+  '
+  input.scss 3:7  root stylesheet
+
+<===>
+================================================================================
+<===> list/too_few_channels/input.scss
+a {b: lab(1% 2)}
+
+<===> list/too_few_channels/error
+Error: $channels: The lab color space has 3 channels but (1% 2) has 2.
+  ,
+1 | a {b: lab(1% 2)}
+  |       ^^^^^^^^^
+  '
+  input.scss 1:7  root stylesheet
+
+<===>
+================================================================================
+<===> list/too_many_channels/input.scss
+a {b: lab(1% 2 3 0.4)}
+
+<===> list/too_many_channels/error
+Error: $channels: The lab color space has 3 channels but (1% 2 3 0.4) has 4.
+  ,
+1 | a {b: lab(1% 2 3 0.4)}
+  |       ^^^^^^^^^^^^^^^
+  '
+  input.scss 1:7  root stylesheet
+
+<===>
+================================================================================
+<===> too_few_args/input.scss
+a {b: lab()}
+
+<===> too_few_args/error
+Error: Missing argument $channels.
+  ,--> input.scss
+1 | a {b: lab()}
+  |       ^^^^^ invocation
+  '
+  ,--> sass:color
+1 | @function lab($channels) {
+  |           ============== declaration
+  '
+  input.scss 1:7  root stylesheet
+
+<===>
+================================================================================
+<===> too_many_args/input.scss
+a {b: lab(1%, 2, 3, 0.4)}
+
+<===> too_many_args/error
+Error: Only 1 argument allowed, but 4 were passed.
+  ,--> input.scss
+1 | a {b: lab(1%, 2, 3, 0.4)}
+  |       ^^^^^^^^^^^^^^^^^^ invocation
+  '
+  ,--> sass:color
+1 | @function lab($channels) {
+  |           ============== declaration
+  '
+  input.scss 1:7  root stylesheet

--- a/spec/core_functions/color/lab/no_alpha.hrx
+++ b/spec/core_functions/color/lab/no_alpha.hrx
@@ -1,0 +1,189 @@
+<===> unitless/ab/in_range/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 -3));
+
+<===> unitless/ab/in_range/output.css
+a {
+  value: lab(1% 2 -3);
+  channels: 1% 2 -3 / 1;
+}
+
+<===>
+================================================================================
+<===> unitless/ab/above_range/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 126 300));
+
+<===> unitless/ab/above_range/output.css
+a {
+  value: lab(1% 126 300);
+  channels: 1% 126 300 / 1;
+}
+
+<===>
+================================================================================
+<===> unitless/ab/below_range/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% -126 -300));
+
+<===> unitless/ab/below_range/output.css
+a {
+  value: lab(1% -126 -300);
+  channels: 1% -126 -300 / 1;
+}
+
+<===>
+================================================================================
+<===> unitless/lightness/in_range/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(10 2 -3));
+
+<===> unitless/lightness/in_range/output.css
+a {
+  value: lab(10% 2 -3);
+  channels: 10% 2 -3 / 1;
+}
+
+<===>
+================================================================================
+<===> unitless/lightness/above_range/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(101 2 3));
+
+<===> unitless/lightness/above_range/output.css
+a {
+  value: lab(100% 2 3);
+  channels: 100% 2 3 / 1;
+}
+
+<===>
+================================================================================
+<===> unitless/lightness/below_range/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(-1 2 3));
+
+<===> unitless/lightness/below_range/output.css
+a {
+  value: lab(0% 2 3);
+  channels: 0% 2 3 / 1;
+}
+
+<===>
+================================================================================
+<===> percent/ab/in_range/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2% -3%));
+
+<===> percent/ab/in_range/output.css
+a {
+  value: lab(1% 2.5 -3.75);
+  channels: 1% 2.5 -3.75 / 1;
+}
+
+<===>
+================================================================================
+<===> percent/ab/above_range/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 101% 150%));
+
+<===> percent/ab/above_range/output.css
+a {
+  value: lab(1% 126.25 187.5);
+  channels: 1% 126.25 187.5 / 1;
+}
+
+<===>
+================================================================================
+<===> percent/ab/below_range/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% -101% -150%));
+
+<===> percent/ab/below_range/output.css
+a {
+  value: lab(1% -126.25 -187.5);
+  channels: 1% -126.25 -187.5 / 1;
+}
+
+<===>
+================================================================================
+<===> percent/lightness/in_range/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2% -3%));
+
+<===> percent/lightness/in_range/output.css
+a {
+  value: lab(1% 2.5 -3.75);
+  channels: 1% 2.5 -3.75 / 1;
+}
+
+<===>
+================================================================================
+<===> percent/lightness/above_range/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(110% 2 3));
+
+<===> percent/lightness/above_range/output.css
+a {
+  value: lab(100% 2 3);
+  channels: 100% 2 3 / 1;
+}
+
+<===>
+================================================================================
+<===> percent/lightness/below_range/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(-1% 2 3));
+
+<===> percent/lightness/below_range/output.css
+a {
+  value: lab(0% 2 3);
+  channels: 0% 2 3 / 1;
+}
+
+<===>
+================================================================================
+<===> none/lightness/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(none 2 3));
+
+<===> none/lightness/output.css
+a {
+  value: lab(none 2 3);
+  channels: none 2 3 / 1;
+}
+
+<===>
+================================================================================
+<===> none/a/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% none 3));
+
+<===> none/a/output.css
+a {
+  value: lab(1% none 3);
+  channels: 1% none 3 / 1;
+}
+
+<===>
+================================================================================
+<===> none/b/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 none));
+
+<===> none/b/output.css
+a {
+  value: lab(1% 2 none);
+  channels: 1% 2 none / 1;
+}
+
+<===>
+================================================================================
+<===> named/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab($channels: 1% 2 3));
+
+<===> named/output.css
+a {
+  value: lab(1% 2 3);
+  channels: 1% 2 3 / 1;
+}

--- a/spec/core_functions/color/lab/options.yml
+++ b/spec/core_functions/color/lab/options.yml
@@ -1,0 +1,3 @@
+---
+:ignore_for:
+- libsass

--- a/spec/core_functions/color/lab/special_functions/alpha.hrx
+++ b/spec/core_functions/color/lab/special_functions/alpha.hrx
@@ -1,0 +1,430 @@
+<===> calc/string/arg_1/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(unquote("calc(1%)") 2 3 / 0.4));
+
+<===> calc/string/arg_1/output.css
+a {
+  value: lab(calc(1%) 2 3/0.4);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> calc/string/arg_2/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% unquote("calc(2)") 3 / 0.4));
+
+<===> calc/string/arg_2/output.css
+a {
+  value: lab(1% calc(2) 3/0.4);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> calc/string/arg_3/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 unquote("calc(3)") / 0.4));
+
+<===> calc/string/arg_3/output.css
+a {
+  value: lab(1% 2 calc(3)/0.4);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> calc/string/arg_4/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 3 / unquote("calc(0.4)")));
+
+<===> calc/string/arg_4/output.css
+a {
+  value: lab(1% 2 3/calc(0.4));
+  type: string;
+}
+
+<===>
+================================================================================
+<===> calc/calculation/arg_1/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(calc(1px + 1%) 2 3 / 0.4));
+
+<===> calc/calculation/arg_1/output.css
+a {
+  value: lab(calc(1px + 1%) 2 3/0.4);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> calc/calculation/arg_2/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% calc(1px + 1%) 3 / 0.4));
+
+<===> calc/calculation/arg_2/output.css
+a {
+  value: lab(1% calc(1px + 1%) 3/0.4);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> calc/calculation/arg_3/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 calc(1px + 1%) / 0.4));
+
+<===> calc/calculation/arg_3/output.css
+a {
+  value: lab(1% 2 calc(1px + 1%)/0.4);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> calc/calculation/arg_4/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 3 / calc(1px + 1%)));
+
+<===> calc/calculation/arg_4/output.css
+a {
+  value: lab(1% 2 3/calc(1px + 1%));
+  type: string;
+}
+
+<===>
+================================================================================
+<===> var/arg_1/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(var(--foo) 2 3 / 0.4));
+
+<===> var/arg_1/output.css
+a {
+  value: lab(var(--foo) 2 3/0.4);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> var/arg_2/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% var(--foo) 3 / 0.4));
+
+<===> var/arg_2/output.css
+a {
+  value: lab(1% var(--foo) 3/0.4);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> var/arg_3/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 var(--foo) / 0.4));
+
+<===> var/arg_3/output.css
+a {
+  value: lab(1% 2 var(--foo)/0.4);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> var/arg_4/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 3 / var(--foo)));
+
+<===> var/arg_4/output.css
+a {
+  value: lab(1% 2 3/var(--foo));
+  type: string;
+}
+
+<===>
+================================================================================
+<===> env/arg_1/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(env(--foo) 2 3 / 0.4));
+
+<===> env/arg_1/output.css
+a {
+  value: lab(env(--foo) 2 3/0.4);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> env/arg_2/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% env(--foo) 3 / 0.4));
+
+<===> env/arg_2/output.css
+a {
+  value: lab(1% env(--foo) 3/0.4);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> env/arg_3/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 env(--foo) / 0.4));
+
+<===> env/arg_3/output.css
+a {
+  value: lab(1% 2 env(--foo)/0.4);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> env/arg_4/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 3 / env(--foo)));
+
+<===> env/arg_4/output.css
+a {
+  value: lab(1% 2 3/env(--foo));
+  type: string;
+}
+
+<===>
+================================================================================
+<===> min/string/arg_1/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(unquote("min(1%)") 2 3 / 0.4));
+
+<===> min/string/arg_1/output.css
+a {
+  value: lab(min(1%) 2 3/0.4);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> min/string/arg_2/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% unquote("min(2)") 3 / 0.4));
+
+<===> min/string/arg_2/output.css
+a {
+  value: lab(1% min(2) 3/0.4);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> min/string/arg_3/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 unquote("min(3)") / 0.4));
+
+<===> min/string/arg_3/output.css
+a {
+  value: lab(1% 2 min(3)/0.4);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> min/string/arg_4/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 3 / unquote("min(0.4)")));
+
+<===> min/string/arg_4/output.css
+a {
+  value: lab(1% 2 3/min(0.4));
+  type: string;
+}
+
+<===>
+================================================================================
+<===> max/string/arg_1/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(unquote("max(1%)") 2 3 / 0.4));
+
+<===> max/string/arg_1/output.css
+a {
+  value: lab(max(1%) 2 3/0.4);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> max/string/arg_2/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% unquote("max(2)") 3 / 0.4));
+
+<===> max/string/arg_2/output.css
+a {
+  value: lab(1% max(2) 3/0.4);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> max/string/arg_3/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 unquote("max(3)") / 0.4));
+
+<===> max/string/arg_3/output.css
+a {
+  value: lab(1% 2 max(3)/0.4);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> max/string/arg_4/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 3 / unquote("max(0.4)")));
+
+<===> max/string/arg_4/output.css
+a {
+  value: lab(1% 2 3/max(0.4));
+  type: string;
+}
+
+<===>
+================================================================================
+<===> clamp/string/arg_1/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(unquote("clamp(1%, 2, 3)") 2 3 / 0.4));
+
+<===> clamp/string/arg_1/output.css
+a {
+  value: lab(clamp(1%, 2, 3) 2 3/0.4);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> clamp/string/arg_2/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% unquote("clamp(2, 3, 4)") 3 / 0.4));
+
+<===> clamp/string/arg_2/output.css
+a {
+  value: lab(1% clamp(2, 3, 4) 3/0.4);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> clamp/string/arg_3/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 unquote("clamp(3, 4, 5)") / 0.4));
+
+<===> clamp/string/arg_3/output.css
+a {
+  value: lab(1% 2 clamp(3, 4, 5)/0.4);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> clamp/string/arg_4/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 3 / unquote("clamp(0.4, 0.5, 0.6)")));
+
+<===> clamp/string/arg_4/output.css
+a {
+  value: lab(1% 2 3/clamp(0.4, 0.5, 0.6));
+  type: string;
+}
+
+<===>
+================================================================================
+<===> unknown/arg_3/with_number/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 b / 0.4));
+
+<===> unknown/arg_3/with_number/output.css
+a {
+  value: lab(1% 2 b/0.4);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> unknown/arg_3/with_none/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 b / none));
+
+<===> unknown/arg_3/with_none/output.css
+a {
+  value: lab(1% 2 b/none);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> unknown/arg_4/with_number/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 3 / b));
+
+<===> unknown/arg_4/with_number/output.css
+a {
+  value: lab(1% 2 3/b);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> unknown/arg_4/with_none/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 none / b));
+
+<===> unknown/arg_4/with_none/output.css
+a {
+  value: lab(1% 2 none/b);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> unknown/arg_3_and_4/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 b / c));
+
+<===> unknown/arg_3_and_4/output.css
+a {
+  value: lab(1% 2 b/c);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> multi_argument_var/1_of_2/input.scss
+// var() is substituted before parsing, so it may contain multiple arguments.
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(var(--foo) 2 / 0.4));
+
+<===> multi_argument_var/1_of_2/output.css
+a {
+  value: lab(var(--foo) 2/0.4);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> multi_argument_var/2_of_2/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% var(--foo) / 0.4));
+
+<===> multi_argument_var/2_of_2/output.css
+a {
+  value: lab(1% var(--foo)/0.4);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> multi_argument_var/1_of_1/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(var(--foo) / 0.4));
+
+<===> multi_argument_var/1_of_1/output.css
+a {
+  value: lab(var(--foo)/0.4);
+  type: string;
+}

--- a/spec/core_functions/color/lab/special_functions/no_alpha.hrx
+++ b/spec/core_functions/color/lab/special_functions/no_alpha.hrx
@@ -1,0 +1,280 @@
+<===> calc/string/arg_1/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(unquote("calc(1%)") 2 3));
+
+<===> calc/string/arg_1/output.css
+a {
+  value: lab(calc(1%) 2 3);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> calc/string/arg_2/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% unquote("calc(2)") 3));
+
+<===> calc/string/arg_2/output.css
+a {
+  value: lab(1% calc(2) 3);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> calc/string/arg_3/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 unquote("calc(3)")));
+
+<===> calc/string/arg_3/output.css
+a {
+  value: lab(1% 2 calc(3));
+  type: string;
+}
+
+<===>
+================================================================================
+<===> calc/calculation/arg_1/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(calc(1px + 1%) 2 3));
+
+<===> calc/calculation/arg_1/output.css
+a {
+  value: lab(calc(1px + 1%) 2 3);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> calc/calculation/arg_2/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% calc(1px + 1%) 3));
+
+<===> calc/calculation/arg_2/output.css
+a {
+  value: lab(1% calc(1px + 1%) 3);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> calc/calculation/arg_3/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 calc(1px + 1%)));
+
+<===> calc/calculation/arg_3/output.css
+a {
+  value: lab(1% 2 calc(1px + 1%));
+  type: string;
+}
+
+<===>
+================================================================================
+<===> var/arg_1/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(var(--foo) 2 3));
+
+<===> var/arg_1/output.css
+a {
+  value: lab(var(--foo) 2 3);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> var/arg_2/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% var(--foo) 3));
+
+<===> var/arg_2/output.css
+a {
+  value: lab(1% var(--foo) 3);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> var/arg_3/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 var(--foo)));
+
+<===> var/arg_3/output.css
+a {
+  value: lab(1% 2 var(--foo));
+  type: string;
+}
+
+<===>
+================================================================================
+<===> env/arg_1/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(env(--foo) 2 3));
+
+<===> env/arg_1/output.css
+a {
+  value: lab(env(--foo) 2 3);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> env/arg_2/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% env(--foo) 3));
+
+<===> env/arg_2/output.css
+a {
+  value: lab(1% env(--foo) 3);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> env/arg_3/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 env(--foo)));
+
+<===> env/arg_3/output.css
+a {
+  value: lab(1% 2 env(--foo));
+  type: string;
+}
+
+<===>
+================================================================================
+<===> min/string/arg_1/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(unquote("min(1%)") 2 3));
+
+<===> min/string/arg_1/output.css
+a {
+  value: lab(min(1%) 2 3);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> min/string/arg_2/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% unquote("min(2)") 3));
+
+<===> min/string/arg_2/output.css
+a {
+  value: lab(1% min(2) 3);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> min/string/arg_3/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 unquote("min(3)")));
+
+<===> min/string/arg_3/output.css
+a {
+  value: lab(1% 2 min(3));
+  type: string;
+}
+
+<===>
+================================================================================
+<===> max/string/arg_1/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(unquote("max(1%)") 2 3));
+
+<===> max/string/arg_1/output.css
+a {
+  value: lab(max(1%) 2 3);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> max/string/arg_2/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% unquote("max(2)") 3));
+
+<===> max/string/arg_2/output.css
+a {
+  value: lab(1% max(2) 3);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> max/string/arg_3/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 unquote("max(3)")));
+
+<===> max/string/arg_3/output.css
+a {
+  value: lab(1% 2 max(3));
+  type: string;
+}
+
+<===>
+================================================================================
+<===> clamp/string/arg_1/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(unquote("clamp(1%, 2, 3)") 2 3));
+
+<===> clamp/string/arg_1/output.css
+a {
+  value: lab(clamp(1%, 2, 3) 2 3);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> clamp/string/arg_2/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% unquote("clamp(2, 3, 4)") 3));
+
+<===> clamp/string/arg_2/output.css
+a {
+  value: lab(1% clamp(2, 3, 4) 3);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> clamp/string/arg_3/input.scss
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(1% 2 unquote("clamp(3, 4, 5)")));
+
+<===> clamp/string/arg_3/output.css
+a {
+  value: lab(1% 2 clamp(3, 4, 5));
+  type: string;
+}
+
+<===>
+================================================================================
+<===> multi_argument_var/1_of_2/input.scss
+// var() is substituted before parsing, so it may contain multiple arguments.
+a {b: lab(var(--foo) 2)}
+
+<===> multi_argument_var/1_of_2/output.css
+a {
+  b: lab(var(--foo) 2);
+}
+
+<===>
+================================================================================
+<===> multi_argument_var/2_of_2/input.scss
+a {b: lab(1% var(--foo))}
+
+<===> multi_argument_var/2_of_2/output.css
+a {
+  b: lab(1% var(--foo));
+}
+
+<===>
+================================================================================
+<===> multi_argument_var/1_of_1/input.scss
+a {b: lab(var(--foo))}
+
+<===> multi_argument_var/1_of_1/output.css
+a {
+  b: lab(var(--foo));
+}

--- a/spec/core_functions/color/lab/special_functions/slash_list.hrx
+++ b/spec/core_functions/color/lab/special_functions/slash_list.hrx
@@ -1,0 +1,36 @@
+<===> channels/input.scss
+@use "sass:list";
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(list.slash(var(--foo), 0.4)));
+
+<===> channels/output.css
+a {
+  value: lab(var(--foo) / 0.4);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> some_channels/input.scss
+@use "sass:list";
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(list.slash(1% var(--foo), 0.4)));
+
+<===> some_channels/output.css
+a {
+  value: lab(1% var(--foo) / 0.4);
+  type: string;
+}
+
+<===>
+================================================================================
+<===> alpha/input.scss
+@use "sass:list";
+@use 'core_functions/color/lab/utils';
+@include utils.inspect(lab(list.slash(1% 2 3, var(--c))));
+
+<===> alpha/output.css
+a {
+  value: lab(1% 2 3 / var(--c));
+  type: string;
+}

--- a/spec/core_functions/color/rgb/error/one_arg.hrx
+++ b/spec/core_functions/color/rgb/error/one_arg.hrx
@@ -159,7 +159,7 @@ Error: $channels: Expected blue "var(--foo) / 0.4" to be a number.
 a {b: rgb(append((), 1 2 3, $separator: slash))}
 
 <===> slash_list/too_few_elements/error
-Error: Only 2 slash-separated elements allowed, but 1 was passed.
+Error: $channels: Only 2 slash-separated elements allowed, but 1 was passed.
   ,
 1 | a {b: rgb(append((), 1 2 3, $separator: slash))}
   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -173,7 +173,7 @@ Error: Only 2 slash-separated elements allowed, but 1 was passed.
 a {b: rgb(list.slash(1 2 3, 0.4, 1))}
 
 <===> slash_list/too_many_elements/error
-Error: Only 2 slash-separated elements allowed, but 3 were passed.
+Error: $channels: Only 2 slash-separated elements allowed, but 3 were passed.
   ,
 2 | a {b: rgb(list.slash(1 2 3, 0.4, 1))}
   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This still needs error output, but Dart Sass currently doesn't support
missing alpha channels or the is-missing() function so they can't be
generated yet.

See https://github.com/sass/sass/issues/2831

[skip dart-sass]