### PR TITLE
Fix abs-percent warning span

### DIFF
--- a/spec/values/calculation/abs.hrx
+++ b/spec/values/calculation/abs.hrx
@@ -92,9 +92,9 @@ To emit a CSS abs() now: abs(#{-7.5%})
 More info: https://sass-lang.com/d/abs-percent
   ,
 1 | a {b: abs(-7.5%)}
-  | ^^^^^^^^^^^^^^^^^
+  |       ^^^^^^^^^^
   '
-    input.scss 1:1  root stylesheet
+    input.scss 1:7  root stylesheet
 
 <===>
 ================================================================================


### PR DESCRIPTION
https://github.com/sass/dart-sass/pull/2084