### PR TITLE
Fix test for legacy JS API warning

### DIFF
--- a/js-api-spec/deprecations.node.test.ts
+++ b/js-api-spec/deprecations.node.test.ts
@@ -14,7 +14,7 @@ describe('a warning from the JS API', () => {
         data: 'a { b: c; }',
       });
     });
-    expect(stdio.err).toContain('legacy-js-api');
+    expect(stdio.err).toContain('legacy JS API');
   });
 
   it('is not emitted when deprecation silenced', () => {


### PR DESCRIPTION
I think this test got changed to work with the embedded host after the tests had already passed on Dart Sass