### PR TITLE
Update tests for fixing unifyCompound() and unifyComplex() ordering of pseudo class/element selectors

### DIFF
--- a/spec/core_functions/selector/unify/complex/combinators/child.hrx
+++ b/spec/core_functions/selector/unify/complex/combinators/child.hrx
@@ -48,7 +48,7 @@ a {b: selector.unify(".c > .d", ".e > .f")}
 
 <===> and_child/distinct/output.css
 a {
-  b: .e.c > .d.f;
+  b: .c.e > .d.f;
 }
 
 <===>
@@ -70,7 +70,7 @@ a {b: selector.unify(".c.s1-1 > .s1-2", ".c.s2-1 > .s2-2")}
 
 <===> and_child/overlap/output.css
 a {
-  b: .c.s2-1.s1-1 > .s1-2.s2-2;
+  b: .c.s1-1.s2-1 > .s1-2.s2-2;
 }
 
 <===>

--- a/spec/core_functions/selector/unify/complex/combinators/multiple.hrx
+++ b/spec/core_functions/selector/unify/complex/combinators/multiple.hrx
@@ -4,7 +4,7 @@ a {b: selector.unify(".c > .d + .e", ".f .g ~ .h")}
 
 <===> isolated/output.css
 a {
-  b: .f .c > .g ~ .d + .e.h, .f .c > .d.g + .e.h;
+  b: .f .c > .g ~ .d + .e.h, .f .c > .g.d + .e.h;
 }
 
 <===>

--- a/spec/core_functions/selector/unify/complex/combinators/next_sibling.hrx
+++ b/spec/core_functions/selector/unify/complex/combinators/next_sibling.hrx
@@ -26,7 +26,7 @@ a {b: selector.unify(".c + .d", ".e ~ .f")}
 
 <===> and_sibling/distinct/output.css
 a {
-  b: .e ~ .c + .d.f, .c.e + .d.f;
+  b: .e ~ .c + .d.f, .e.c + .d.f;
 }
 
 <===>
@@ -59,7 +59,7 @@ a {b: selector.unify(".c.s1-1 + .s1-2", ".c.s2-1 ~ .s2-2")}
 
 <===> and_sibling/overlap/output.css
 a {
-  b: .c.s2-1 ~ .c.s1-1 + .s1-2.s2-2, .c.s1-1.s2-1 + .s1-2.s2-2;
+  b: .c.s2-1 ~ .c.s1-1 + .s1-2.s2-2, .c.s2-1.s1-1 + .s1-2.s2-2;
 }
 
 <===>
@@ -81,7 +81,7 @@ a {b: selector.unify(".c + .d", ".e + .f")}
 
 <===> and_next_sibling/distinct/output.css
 a {
-  b: .e.c + .d.f;
+  b: .c.e + .d.f;
 }
 
 <===>
@@ -103,7 +103,7 @@ a {b: selector.unify(".c.s1-1 + .s1-2", ".c.s2-1 + .s2-2")}
 
 <===> and_next_sibling/overlap/output.css
 a {
-  b: .c.s2-1.s1-1 + .s1-2.s2-2;
+  b: .c.s1-1.s2-1 + .s1-2.s2-2;
 }
 
 <===>

--- a/spec/core_functions/selector/unify/complex/combinators/sibling.hrx
+++ b/spec/core_functions/selector/unify/complex/combinators/sibling.hrx
@@ -26,7 +26,7 @@ a {b: selector.unify(".c ~ .d", ".e ~ .f")}
 
 <===> and_sibling/distinct/output.css
 a {
-  b: .c ~ .e ~ .d.f, .e ~ .c ~ .d.f, .e.c ~ .d.f;
+  b: .c ~ .e ~ .d.f, .e ~ .c ~ .d.f, .c.e ~ .d.f;
 }
 
 <===>
@@ -59,7 +59,7 @@ a {b: selector.unify(".c.s1-1 ~ .s1-2", ".c.s2-1 ~ .s2-2")}
 
 <===> and_sibling/overlap/output.css
 a {
-  b: .c.s1-1 ~ .c.s2-1 ~ .s1-2.s2-2, .c.s2-1 ~ .c.s1-1 ~ .s1-2.s2-2, .c.s2-1.s1-1 ~ .s1-2.s2-2;
+  b: .c.s1-1 ~ .c.s2-1 ~ .s1-2.s2-2, .c.s2-1 ~ .c.s1-1 ~ .s1-2.s2-2, .c.s1-1.s2-1 ~ .s1-2.s2-2;
 }
 
 <===>
@@ -81,7 +81,7 @@ a {b: selector.unify(".c ~ .d", ".e + .f")}
 
 <===> and_next_sibling/distinct/output.css
 a {
-  b: .c ~ .e + .d.f, .e.c + .d.f;
+  b: .c ~ .e + .d.f, .c.e + .d.f;
 }
 
 <===>
@@ -114,7 +114,7 @@ a {b: selector.unify(".c.s1-1 ~ .s1-2", ".c.s2-1 + .s2-2")}
 
 <===> and_next_sibling/overlap/output.css
 a {
-  b: .c.s1-1 ~ .c.s2-1 + .s1-2.s2-2, .c.s2-1.s1-1 + .s1-2.s2-2;
+  b: .c.s1-1 ~ .c.s2-1 + .s1-2.s2-2, .c.s1-1.s2-1 + .s1-2.s2-2;
 }
 
 <===>

--- a/spec/core_functions/selector/unify/complex/rootish.hrx
+++ b/spec/core_functions/selector/unify/complex/rootish.hrx
@@ -77,7 +77,7 @@ a {b: selector.unify(".c:root .d", ".e:root .f")}
 
 <===> root/in_both/can_unify/output.css
 a {
-  b: .e.c:root .d.f;
+  b: .c.e:root .d.f;
 }
 
 <===>
@@ -121,5 +121,5 @@ a {b: selector.unify(":root .c .d", ":scope .e .f")}
 
 <===> mixed/output.css
 a {
-  b: :scope:root .c .e .d.f, :scope:root .e .c .d.f;
+  b: :root:scope .c .e .d.f, :root:scope .e .c .d.f;
 }

--- a/spec/core_functions/selector/unify/compound.hrx
+++ b/spec/core_functions/selector/unify/compound.hrx
@@ -94,3 +94,66 @@ a {b: selector.unify(":c", "::d")}
 a {
   b: :c::d;
 }
+
+<===>
+================================================================================
+<===> order/do_not_cross_pseudo_element/pseudo_class_and_element/into_simple/input.scss
+@use "sass:selector";
+a {b: selector.unify(".x::scrollbar:horizontal", ".y")}
+
+<===> order/do_not_cross_pseudo_element/pseudo_class_and_element/into_simple/output.css
+a {
+  b: .x.y::scrollbar:horizontal;
+}
+
+<===>
+================================================================================
+<===> order/do_not_cross_pseudo_element/pseudo_class_and_element/into_pseudo_element/input.scss
+@use "sass:selector";
+a {b: selector.unify("::bar:baz", ":foo")}
+
+<===> order/do_not_cross_pseudo_element/pseudo_class_and_element/into_pseudo_element/output.css
+a {
+  b: :foo::bar:baz;
+}
+
+<===>
+================================================================================
+<===> order/do_not_cross_pseudo_element/pseudo_class_and_element/into_same_pseudo_element_and_different_pseudo_class/input.scss
+@use "sass:selector";
+a {b: selector.unify("::foo:bar", "::foo:baz")}
+
+<===> order/do_not_cross_pseudo_element/pseudo_class_and_element/into_same_pseudo_element_and_different_pseudo_class/output.css
+a {
+  b: ::foo:bar:baz;
+}
+
+<===>
+================================================================================
+<===> order/do_not_cross_pseudo_element/pseudo_class_and_element/into_different_pseudo_element_and_different_pseudo_class/input.scss
+@use "sass:selector";
+a {b: selector.unify("::foo:bar", "::other:baz")}
+
+<===> order/do_not_cross_pseudo_element/pseudo_class_and_element/into_different_pseudo_element_and_different_pseudo_class/output.css
+
+<===>
+================================================================================
+<===> order/do_not_cross_pseudo_element/simple/into_pseudo_class_and_element/input.scss
+@use "sass:selector";
+a {b: selector.unify(".x", ".y::scrollbar:horizontal")}
+
+<===> order/do_not_cross_pseudo_element/simple/into_pseudo_class_and_element/output.css
+a {
+  b: .x.y::scrollbar:horizontal;
+}
+
+<===>
+================================================================================
+<===> order/do_not_cross_pseudo_element/pseudo_element/into_pseudo_class_and_element/input.scss
+@use "sass:selector";
+a {b: selector.unify(":foo", "::bar:baz")}
+
+<===> order/do_not_cross_pseudo_element/pseudo_element/into_pseudo_class_and_element/output.css
+a {
+  b: :foo::bar:baz;
+}

--- a/spec/core_functions/selector/unify/compound.hrx
+++ b/spec/core_functions/selector/unify/compound.hrx
@@ -31,24 +31,35 @@ a {
 
 <===>
 ================================================================================
-<===> full_overlap/pseudo_element/class_after/input.scss
+<===> full_overlap/pseudo_element/input.scss
 @use "sass:selector";
-a {b: selector.unify("::c.d", "::c.d")}
+a {b: selector.unify(".c::d", ".c::d")}
 
-<===> full_overlap/pseudo_element/class_after/output.css
+<===> full_overlap/pseudo_element/output.css
 a {
-  b: ::c.d;
+  b: .c::d;
 }
 
 <===>
 ================================================================================
-<===> full_overlap/pseudo/different_order/input.scss
+<===> full_overlap/pseudo_class/input.scss
 @use "sass:selector";
-a {b: selector.unify("::c.d", ".d::c")}
+a {b: selector.unify(".c:d", ".c:d")}
 
-<===> full_overlap/pseudo/different_order/output.css
+<===> full_overlap/pseudo_class/output.css
 a {
-  b: ::c.d;
+  b: .c:d;
+}
+
+<===>
+================================================================================
+<===> full_overlap/pseudo_selector_and_class/input.scss
+@use "sass:selector";
+a {b: selector.unify(".c:d::e", ".c:d::e")}
+
+<===> full_overlap/pseudo_selector_and_class/output.css
+a {
+  b: .c:d::e;
 }
 
 <===>

--- a/spec/core_functions/selector/unify/compound.hrx
+++ b/spec/core_functions/selector/unify/compound.hrx
@@ -37,7 +37,7 @@ a {b: selector.unify("::c.d", "::c.d")}
 
 <===> full_overlap/pseudo_element/class_after/output.css
 a {
-  b: .d::c;
+  b: ::c.d;
 }
 
 <===>
@@ -48,24 +48,8 @@ a {b: selector.unify("::c.d", ".d::c")}
 
 <===> full_overlap/pseudo/different_order/output.css
 a {
-  b: .d::c;
+  b: ::c.d;
 }
-
-<===>
-================================================================================
-<===> multiple_pseudo_elements/first_argument/input.scss
-@use "sass:selector";
-a {b: selector.unify("::y::z", ".x")}
-
-<===> multiple_pseudo_elements/first_argument/output.css
-
-<===>
-================================================================================
-<===> multiple_pseudo_elements/second_argument/input.scss
-@use "sass:selector";
-a {b: selector.unify(".x", "::y::z")}
-
-<===> multiple_pseudo_elements/second_argument/output.css
 
 <===>
 ================================================================================
@@ -194,15 +178,4 @@ a {b: selector.unify(":foo", "::bar:baz")}
 <===> order/do_not_cross_pseudo_element/pseudo_element/into_pseudo_class_and_element/output.css
 a {
   b: :foo::bar:baz;
-}
-
-<===>
-================================================================================
-<===> order/cross_pseudo_element/input.scss
-@use "sass:selector";
-a {b: selector.unify(".x", "::y.z")}
-
-<===> order/cross_pseudo_element/output.css
-a {
-  b: .x.z::y;
 }

--- a/spec/core_functions/selector/unify/compound.hrx
+++ b/spec/core_functions/selector/unify/compound.hrx
@@ -20,13 +20,35 @@ a {
 
 <===>
 ================================================================================
-<===> full_overlap/input.scss
+<===> full_overlap/class/input.scss
 @use "sass:selector";
 a {b: selector.unify(".c.d", ".c.d")}
 
-<===> full_overlap/output.css
+<===> full_overlap/class/output.css
 a {
   b: .c.d;
+}
+
+<===>
+================================================================================
+<===> full_overlap/pseudo_element/class_after/input.scss
+@use "sass:selector";
+a {b: selector.unify("::c.d", "::c.d")}
+
+<===> full_overlap/pseudo_element/class_after/output.css
+a {
+  b: ::c.d;
+}
+
+<===>
+================================================================================
+<===> full_overlap/pseudo/different_order/input.scss
+@use "sass:selector";
+a {b: selector.unify("::c.d", ".d::c")}
+
+<===> full_overlap/pseudo/different_order/output.css
+a {
+  b: ::c.d;
 }
 
 <===>
@@ -156,4 +178,15 @@ a {b: selector.unify(":foo", "::bar:baz")}
 <===> order/do_not_cross_pseudo_element/pseudo_element/into_pseudo_class_and_element/output.css
 a {
   b: :foo::bar:baz;
+}
+
+<===>
+================================================================================
+<===> order/cross_pseudo_element/input.scss
+@use "sass:selector";
+a {b: selector.unify(".x", "::y.z")}
+
+<===> order/cross_pseudo_element/output.css
+a {
+  b: .x.z::y;
 }

--- a/spec/core_functions/selector/unify/compound.hrx
+++ b/spec/core_functions/selector/unify/compound.hrx
@@ -53,6 +53,22 @@ a {
 
 <===>
 ================================================================================
+<===> multiple_pseudo_elements/first_argument/input.scss
+@use "sass:selector";
+a {b: selector.unify("::y::z", ".x")}
+
+<===> multiple_pseudo_elements/first_argument/output.css
+
+<===>
+================================================================================
+<===> multiple_pseudo_elements/second_argument/input.scss
+@use "sass:selector";
+a {b: selector.unify(".x", "::y::z")}
+
+<===> multiple_pseudo_elements/second_argument/output.css
+
+<===>
+================================================================================
 <===> order/preserved_by_default/input.scss
 @use "sass:selector";
 a {b: selector.unify(".c.d", ".e.f")}

--- a/spec/core_functions/selector/unify/compound.hrx
+++ b/spec/core_functions/selector/unify/compound.hrx
@@ -37,7 +37,7 @@ a {b: selector.unify("::c.d", "::c.d")}
 
 <===> full_overlap/pseudo_element/class_after/output.css
 a {
-  b: ::c.d;
+  b: .d::c;
 }
 
 <===>
@@ -48,7 +48,7 @@ a {b: selector.unify("::c.d", ".d::c")}
 
 <===> full_overlap/pseudo/different_order/output.css
 a {
-  b: ::c.d;
+  b: .d::c;
 }
 
 <===>

--- a/spec/libsass-closed-issues/issue_2289.hrx
+++ b/spec/libsass-closed-issues/issue_2289.hrx
@@ -8,6 +8,6 @@
 }
 
 <===> output.css
-.foo:baz:baz, .bar:baz:baz {
+.foo:baz:baz, .bar:baz {
   float: left;
 }

--- a/spec/libsass-closed-issues/issue_2289.hrx
+++ b/spec/libsass-closed-issues/issue_2289.hrx
@@ -8,6 +8,6 @@
 }
 
 <===> output.css
-.foo:baz:baz, .bar:baz {
+.foo:baz:baz, .bar:baz:baz {
   float: left;
 }

--- a/spec/non_conformant/extend-tests/127_test_nested_extender_with_early_child_selector.hrx
+++ b/spec/non_conformant/extend-tests/127_test_nested_extender_with_early_child_selector.hrx
@@ -3,6 +3,6 @@
 .bip > .baz {@extend .bar}
 
 <===> output.css
-.foo > .bar, .bip.foo > .baz {
+.foo > .bar, .foo.bip > .baz {
   a: b;
 }

--- a/spec/non_conformant/extend-tests/142_test_combinator_unification_double_tilde.hrx
+++ b/spec/non_conformant/extend-tests/142_test_combinator_unification_double_tilde.hrx
@@ -3,6 +3,6 @@
 .b ~ y {@extend x}
 
 <===> output.css
-.a ~ x, .a ~ .b ~ y, .b ~ .a ~ y, .b.a ~ y {
+.a ~ x, .a ~ .b ~ y, .b ~ .a ~ y, .a.b ~ y {
   a: b;
 }

--- a/spec/non_conformant/extend-tests/146_test_combinator_unification_tilde_plus.hrx
+++ b/spec/non_conformant/extend-tests/146_test_combinator_unification_tilde_plus.hrx
@@ -3,6 +3,6 @@
 .b ~ y {@extend x}
 
 <===> output.css
-.a + x, .b ~ .a + y, .a.b + y {
+.a + x, .b ~ .a + y, .b.a + y {
   a: b;
 }

--- a/spec/non_conformant/extend-tests/150_test_combinator_unification_tilde_plus.hrx
+++ b/spec/non_conformant/extend-tests/150_test_combinator_unification_tilde_plus.hrx
@@ -3,6 +3,6 @@
 .b + y {@extend x}
 
 <===> output.css
-.a ~ x, .a ~ .b + y, .b.a + y {
+.a ~ x, .a ~ .b + y, .a.b + y {
   a: b;
 }

--- a/spec/non_conformant/extend-tests/156_test_combinator_unification_double_angle.hrx
+++ b/spec/non_conformant/extend-tests/156_test_combinator_unification_double_angle.hrx
@@ -3,6 +3,6 @@
 .b > y {@extend x}
 
 <===> output.css
-.a.b > x, .b.a > y {
+.a.b > x, .a.b > y {
   a: b;
 }

--- a/spec/non_conformant/extend-tests/158_test_combinator_unification_double_angle.hrx
+++ b/spec/non_conformant/extend-tests/158_test_combinator_unification_double_angle.hrx
@@ -3,6 +3,6 @@
 .b > y {@extend x}
 
 <===> output.css
-.a > x, .b.a > y {
+.a > x, .a.b > y {
   a: b;
 }

--- a/spec/non_conformant/extend-tests/160_test_combinator_unification_double_plus.hrx
+++ b/spec/non_conformant/extend-tests/160_test_combinator_unification_double_plus.hrx
@@ -3,6 +3,6 @@
 .b + y {@extend x}
 
 <===> output.css
-.a.b + x, .b.a + y {
+.a.b + x, .a.b + y {
   a: b;
 }

--- a/spec/non_conformant/extend-tests/162_test_combinator_unification_double_plus.hrx
+++ b/spec/non_conformant/extend-tests/162_test_combinator_unification_double_plus.hrx
@@ -3,6 +3,6 @@
 .b + y {@extend x}
 
 <===> output.css
-.a + x, .b.a + y {
+.a + x, .a.b + y {
   a: b;
 }

--- a/spec/non_conformant/extend-tests/176_test_combinator_unification_nested.hrx
+++ b/spec/non_conformant/extend-tests/176_test_combinator_unification_nested.hrx
@@ -3,6 +3,6 @@
 .c > .d + y {@extend x}
 
 <===> output.css
-.a > .b + x, .c.a > .d.b + y {
+.a > .b + x, .a.c > .b.d + y {
   a: b;
 }

--- a/spec/non_conformant/extend-tests/177_test_combinator_unification_nested.hrx
+++ b/spec/non_conformant/extend-tests/177_test_combinator_unification_nested.hrx
@@ -3,6 +3,6 @@
 .c > y {@extend x}
 
 <===> output.css
-.a > .b + x, .c.a > .b + y {
+.a > .b + x, .a.c > .b + y {
   a: b;
 }

--- a/spec/non_conformant/extend-tests/178_test_combinator_unification_with_newlines.hrx
+++ b/spec/non_conformant/extend-tests/178_test_combinator_unification_with_newlines.hrx
@@ -7,6 +7,6 @@
 y {@extend x}
 
 <===> output.css
-.a > .b + x, .c.a > .d.b + y {
+.a > .b + x, .a.c > .b.d + y {
   a: b;
 }

--- a/spec/non_conformant/extend-tests/238_unify_root_pseudoelement.hrx
+++ b/spec/non_conformant/extend-tests/238_unify_root_pseudoelement.hrx
@@ -20,7 +20,7 @@ xml:root .bang-3 { @extend .bar-3}
   test: 1;
 }
 
-.foo-2:root .bar-2, .baz-2.foo-2:root .bang-2 {
+.foo-2:root .bar-2, .foo-2.baz-2:root .bang-2 {
   test: 2;
 }
 
@@ -28,6 +28,6 @@ html:root .bar-3 {
   test: 3;
 }
 
-.foo-4:root > .bar-4 .x-4, .baz-4.foo-4:root > .bar-4 .bang-4 .y-4 {
+.foo-4:root > .bar-4 .x-4, .foo-4.baz-4:root > .bar-4 .bang-4 .y-4 {
   test: 4;
 }


### PR DESCRIPTION
See https://github.com/sass/dart-sass/issues/2335
See https://github.com/sass/dart-sass/pull/2350

[skip dart-sass]