### PR TITLE
Remove global-builtin deprecation for plain-CSS `invert()`

### DIFF
--- a/spec/core_functions/color/invert/error.hrx
+++ b/spec/core_functions/color/invert/error.hrx
@@ -38,17 +38,6 @@ Error: Only 3 arguments allowed, but 4 were passed.
 a {b: invert(1, 50%)}
 
 <===> global/number_with_weight/error
-DEPRECATION WARNING: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
-Use color.invert instead.
-
-More info and automated migrator: https://sass-lang.com/d/import
-
-  ,
-1 | a {b: invert(1, 50%)}
-  |       ^^^^^^^^^^^^^^
-  '
-    input.scss 1:7  root stylesheet
-
 Error: Only one argument may be passed to the plain-CSS invert() function.
   ,
 1 | a {b: invert(1, 50%)}

--- a/spec/core_functions/color/invert/global.hrx
+++ b/spec/core_functions/color/invert/global.hrx
@@ -50,18 +50,6 @@ a {
   b: invert(10%);
 }
 
-<===> number/warning
-DEPRECATION WARNING: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
-Use color.invert instead.
-
-More info and automated migrator: https://sass-lang.com/d/import
-
-  ,
-1 | a {b: invert(10%)}
-  |       ^^^^^^^^^^^
-  '
-    input.scss 1:7  root stylesheet
-
 <===>
 ================================================================================
 <===> with_css_var/input.scss
@@ -72,18 +60,6 @@ a {
   b: invert(var(--c));
 }
 
-<===> with_css_var/warning
-DEPRECATION WARNING: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
-Use color.invert instead.
-
-More info and automated migrator: https://sass-lang.com/d/import
-
-  ,
-1 | a {b: invert(var(--c))}
-  |       ^^^^^^^^^^^^^^^^
-  '
-    input.scss 1:7  root stylesheet
-
 <===>
 ================================================================================
 <===> with_calc/input.scss
@@ -93,18 +69,6 @@ a {b: invert(calc(1 + 2))}
 a {
   b: invert(3);
 }
-
-<===> with_calc/warning
-DEPRECATION WARNING: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
-Use color.invert instead.
-
-More info and automated migrator: https://sass-lang.com/d/import
-
-  ,
-1 | a {b: invert(calc(1 + 2))}
-  |       ^^^^^^^^^^^^^^^^^^^
-  '
-    input.scss 1:7  root stylesheet
 
 <===>
 ================================================================================
@@ -127,14 +91,3 @@ More info and automated migrator: https://sass-lang.com/d/import
   |              ^^^^^^^^^^^^^^^^^^
   '
     input.scss 1:14  root stylesheet
-
-DEPRECATION WARNING: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
-Use color.invert instead.
-
-More info and automated migrator: https://sass-lang.com/d/import
-
-  ,
-1 | a {b: invert(unquote('calc(1)'))}
-  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  '
-    input.scss 1:7  root stylesheet

--- a/spec/core_functions/global/color/invert.hrx
+++ b/spec/core_functions/global/color/invert.hrx
@@ -28,18 +28,6 @@ a {
   b: invert(10%);
 }
 
-<===> with_number/warning
-DEPRECATION WARNING: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
-Use color.invert instead.
-
-More info and automated migrator: https://sass-lang.com/d/import
-
-  ,
-1 | a {b: invert(10%)}
-  |       ^^^^^^^^^^^
-  '
-    input.scss 1:7  root stylesheet
-
 <===>
 ================================================================================
 <===> with_css_var/input.scss
@@ -49,18 +37,6 @@ a {b: invert(var(--c))}
 a {
   b: invert(var(--c));
 }
-
-<===> with_css_var/warning
-DEPRECATION WARNING: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
-Use color.invert instead.
-
-More info and automated migrator: https://sass-lang.com/d/import
-
-  ,
-1 | a {b: invert(var(--c))}
-  |       ^^^^^^^^^^^^^^^^
-  '
-    input.scss 1:7  root stylesheet
 
 <===>
 ================================================================================
@@ -72,18 +48,6 @@ a {
   b: invert(3);
 }
 
-<===> with_calc/warning
-DEPRECATION WARNING: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
-Use color.invert instead.
-
-More info and automated migrator: https://sass-lang.com/d/import
-
-  ,
-1 | a {b: invert(calc(1 + 2))}
-  |       ^^^^^^^^^^^^^^^^^^^
-  '
-    input.scss 1:7  root stylesheet
-
 <===>
 ================================================================================
 <===> with_unquoted_calc/input.scss
@@ -94,15 +58,3 @@ a {b: invert(string.unquote('calc(1)'))}
 a {
   b: invert(calc(1));
 }
-
-<===> with_unquoted_calc/warning
-DEPRECATION WARNING: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
-Use color.invert instead.
-
-More info and automated migrator: https://sass-lang.com/d/import
-
-  ,
-2 | a {b: invert(string.unquote('calc(1)'))}
-  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  '
-    input.scss 2:7  root stylesheet

--- a/spec/libsass-closed-issues/issue_456.hrx
+++ b/spec/libsass-closed-issues/issue_456.hrx
@@ -7,15 +7,3 @@ body {
 body {
   -webkit-filter: invert(100%);
 }
-
-<===> warning
-DEPRECATION WARNING: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
-Use color.invert instead.
-
-More info and automated migrator: https://sass-lang.com/d/import
-
-  ,
-2 |   -webkit-filter: invert(100%);
-  |                   ^^^^^^^^^^^^
-  '
-    input.scss 2:19  root stylesheet


### PR DESCRIPTION
[skip dart-sass]
