### PR TITLE
Update specs for consistent parse-time warnings

### DIFF
--- a/spec/core_functions/meta/function_exists.hrx
+++ b/spec/core_functions/meta/function_exists.hrx
@@ -39,14 +39,15 @@ a {
 }
 
 <===> same_module/through_import/warning
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 2:9  root stylesheet
 
 <===>
 ================================================================================

--- a/spec/core_functions/meta/get_function/same_module.hrx
+++ b/spec/core_functions/meta/get_function/same_module.hrx
@@ -84,14 +84,15 @@ a {
 }
 
 <===> through_import/warning
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 2:9  root stylesheet
 
 <===>
 ================================================================================

--- a/spec/core_functions/meta/get_mixin/same_module.hrx
+++ b/spec/core_functions/meta/get_mixin/same_module.hrx
@@ -45,14 +45,15 @@ a {
 }
 
 <===> through_import/warning
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 2:9  root stylesheet
 
 <===>
 ================================================================================

--- a/spec/core_functions/meta/global_variable_exists.hrx
+++ b/spec/core_functions/meta/global_variable_exists.hrx
@@ -39,14 +39,15 @@ a {
 }
 
 <===> same_module/through_import/warning
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 2:9  root stylesheet
 
 <===>
 ================================================================================

--- a/spec/core_functions/meta/load_css/with.hrx
+++ b/spec/core_functions/meta/load_css/with.hrx
@@ -167,14 +167,16 @@ b {
 }
 
 <===> through_import/direct/warning
-DEPRECATION WARNING on line 1, column 9 of _loaded.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "imported";
   |         ^^^^^^^^^^
   '
+    _loaded.scss 1:9  load-css()
+    input.scss 2:1    root stylesheet
 
 <===>
 ================================================================================
@@ -198,23 +200,28 @@ b {
 }
 
 <===> through_import/transitive/warning
-DEPRECATION WARNING on line 1, column 9 of _loaded.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "midstream";
   |         ^^^^^^^^^^^
   '
+    _loaded.scss 1:9  load-css()
+    input.scss 2:1    root stylesheet
 
-DEPRECATION WARNING on line 1, column 9 of _midstream.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "upstream";
   |         ^^^^^^^^^^
   '
+    _midstream.scss 1:9  @import
+    _loaded.scss 1:9     load-css()
+    input.scss 2:1       root stylesheet
 
 <===>
 ================================================================================

--- a/spec/core_functions/meta/mixin_exists.hrx
+++ b/spec/core_functions/meta/mixin_exists.hrx
@@ -39,14 +39,15 @@ a {
 }
 
 <===> same_module/through_import/warning
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 2:9  root stylesheet
 
 <===>
 ================================================================================

--- a/spec/core_functions/meta/module_functions.hrx
+++ b/spec/core_functions/meta/module_functions.hrx
@@ -111,14 +111,16 @@ a {
 }
 
 <===> through_import/warning
-DEPRECATION WARNING on line 1, column 9 of _used.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "imported";
   |         ^^^^^^^^^^
   '
+    _used.scss 1:9  @use
+    input.scss 3:1  root stylesheet
 
 <===>
 ================================================================================

--- a/spec/core_functions/meta/module_mixins.hrx
+++ b/spec/core_functions/meta/module_mixins.hrx
@@ -139,14 +139,16 @@ a {
 }
 
 <===> through_import/warning
-DEPRECATION WARNING on line 1, column 9 of _used.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "imported";
   |         ^^^^^^^^^^
   '
+    _used.scss 1:9  @use
+    input.scss 3:1  root stylesheet
 
 <===>
 ================================================================================

--- a/spec/core_functions/meta/module_variables.hrx
+++ b/spec/core_functions/meta/module_variables.hrx
@@ -87,14 +87,16 @@ a {
 }
 
 <===> through_import/warning
-DEPRECATION WARNING on line 1, column 9 of _used.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "imported";
   |         ^^^^^^^^^^
   '
+    _used.scss 1:9  @use
+    input.scss 2:1  root stylesheet
 
 <===>
 ================================================================================

--- a/spec/core_functions/meta/variable_exists.hrx
+++ b/spec/core_functions/meta/variable_exists.hrx
@@ -65,14 +65,15 @@ a {
 }
 
 <===> through_import/warning
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 2:9  root stylesheet
 
 <===>
 ================================================================================

--- a/spec/css/custom_properties/name_interpolation.hrx
+++ b/spec/css/custom_properties/name_interpolation.hrx
@@ -64,11 +64,12 @@ a {
 }
 
 <===> import_nesting_use/warning
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import 'foo';
   |         ^^^^^
   '
+    input.scss 2:9  root stylesheet

--- a/spec/css/font-face.hrx
+++ b/spec/css/font-face.hrx
@@ -89,14 +89,15 @@ c {
 }
 
 <===> bubble/loaded/import/warning
-DEPRECATION WARNING on line 2, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 |   @import 'upstream';
   |           ^^^^^^^^^^
   '
+    input.scss 2:11  root stylesheet
 
 DEPRECATION WARNING: Sass's behavior for declarations that appear after nested
 rules will be changing to match the behavior specified by CSS in an upcoming

--- a/spec/css/moz_document/comment.hrx
+++ b/spec/css/moz_document/comment.hrx
@@ -5,14 +5,15 @@
 @-moz-document url-prefix(a) {}
 
 <===> before_arg/loud/warning
-DEPRECATION WARNING on line 1, column 1 of input.scss: 
-@-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
+DEPRECATION WARNING: @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
 
 For details, see https://sass-lang.com/d/moz-document.
+
   ,
 1 | @-moz-document /**/ url-prefix(a) {}
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   '
+    input.scss 1:1  root stylesheet
 
 <===>
 ================================================================================
@@ -24,14 +25,15 @@ For details, see https://sass-lang.com/d/moz-document.
 @-moz-document url-prefix(a) {}
 
 <===> before_arg/silent/warning
-DEPRECATION WARNING on line 1, column 1 of input.scss: 
-@-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
+DEPRECATION WARNING: @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
 
 For details, see https://sass-lang.com/d/moz-document.
+
   ,
 1 | / @-moz-document //
 2 | \   url-prefix(a) {}
   '
+    input.scss 1:1  root stylesheet
 
 <===>
 ================================================================================
@@ -42,14 +44,15 @@ For details, see https://sass-lang.com/d/moz-document.
 @-moz-document url-prefix(a) {}
 
 <===> after_arg/loud/warning
-DEPRECATION WARNING on line 1, column 1 of input.scss: 
-@-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
+DEPRECATION WARNING: @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
 
 For details, see https://sass-lang.com/d/moz-document.
+
   ,
 1 | @-moz-document url-prefix(a) /**/ {}
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   '
+    input.scss 1:1  root stylesheet
 
 <===>
 ================================================================================
@@ -61,11 +64,12 @@ For details, see https://sass-lang.com/d/moz-document.
 @-moz-document url-prefix(a) {}
 
 <===> after_arg/silent/warning
-DEPRECATION WARNING on line 1, column 1 of input.scss: 
-@-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
+DEPRECATION WARNING: @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
 
 For details, see https://sass-lang.com/d/moz-document.
+
   ,
 1 | / @-moz-document url-prefix(a) //
 2 | \   {}
   '
+    input.scss 1:1  root stylesheet

--- a/spec/css/moz_document/functions/interpolated.hrx
+++ b/spec/css/moz_document/functions/interpolated.hrx
@@ -86,52 +86,112 @@
 }
 
 <===> warning
-DEPRECATION WARNING on line 1, column 1 of input.scss: 
-@-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
+DEPRECATION WARNING: @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
 
 For details, see https://sass-lang.com/d/moz-document.
+
   ,
 1 | / @-moz-document url(#{"sass-lang.com"}) {
 2 | |   a {type: unquoted full url}
 3 | \ }
   '
+    input.scss 1:1  root stylesheet
 
-DEPRECATION WARNING on line 4, column 1 of input.scss: 
-@-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
+DEPRECATION WARNING: @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
 
 For details, see https://sass-lang.com/d/moz-document.
+
   ,
 4 | / @-moz-document url(#{sa + ss}-lang.com) {
 5 | |   a {type: unquoted partial url}
 6 | \ }
   '
+    input.scss 4:1  root stylesheet
 
-DEPRECATION WARNING on line 7, column 1 of input.scss: 
-@-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
+DEPRECATION WARNING: @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
 
 For details, see https://sass-lang.com/d/moz-document.
+
   ,
 7 | / @-moz-document url("#{sa + ss}-lang.com") {
 8 | |   a {type: quoted partial url}
 9 | \ }
   '
+    input.scss 7:1  root stylesheet
 
-DEPRECATION WARNING on line 11, column 1 of input.scss: 
-@-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
+DEPRECATION WARNING: @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
 
 For details, see https://sass-lang.com/d/moz-document.
+
    ,
 11 | / @-moz-document url-prefix(#{"https://sass-lang.com/docs"}) {
 12 | |   a {type: unquoted full url-prefix}
 13 | \ }
    '
+    input.scss 11:1  root stylesheet
 
-DEPRECATION WARNING on line 14, column 1 of input.scss: 
-@-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
+DEPRECATION WARNING: @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
 
 For details, see https://sass-lang.com/d/moz-document.
+
    ,
 14 | / @-moz-document url-prefix(#{ht + tps}://sass-lang.com/docs) {
 15 | |   a {type: unquoted partial url-prefix}
 16 | \ }
    '
+    input.scss 14:1  root stylesheet
+
+DEPRECATION WARNING: @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
+
+For details, see https://sass-lang.com/d/moz-document.
+
+   ,
+17 | / @-moz-document url-prefix("#{ht + tps}://sass-lang.com/docs") {
+18 | |   a {type: quoted partial url-prefix}
+19 | \ }
+   '
+    input.scss 17:1  root stylesheet
+
+DEPRECATION WARNING: @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
+
+For details, see https://sass-lang.com/d/moz-document.
+
+   ,
+21 | / @-moz-document domain(#{"sass-lang.com"}) {
+22 | |   a {type: unquoted full domain}
+23 | \ }
+   '
+    input.scss 21:1  root stylesheet
+
+DEPRECATION WARNING: @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
+
+For details, see https://sass-lang.com/d/moz-document.
+
+   ,
+24 | / @-moz-document domain(#{sa + ss}-lang.com) {
+25 | |   a {type: unquoted partial domain}
+26 | \ }
+   '
+    input.scss 24:1  root stylesheet
+
+DEPRECATION WARNING: @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
+
+For details, see https://sass-lang.com/d/moz-document.
+
+   ,
+27 | / @-moz-document domain("#{sa + ss}-lang.com") {
+28 | |   a {type: quoted partial domain}
+29 | \ }
+   '
+    input.scss 27:1  root stylesheet
+
+DEPRECATION WARNING: @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
+
+For details, see https://sass-lang.com/d/moz-document.
+
+   ,
+31 | / @-moz-document regexp("#{ht + tp}s:.*") {
+32 | |   a {type: regexp}
+33 | \ }
+   '
+    input.scss 31:1  root stylesheet

--- a/spec/css/moz_document/functions/static.hrx
+++ b/spec/css/moz_document/functions/static.hrx
@@ -62,52 +62,79 @@
 }
 
 <===> warning
-DEPRECATION WARNING on line 1, column 1 of input.scss: 
-@-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
+DEPRECATION WARNING: @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
 
 For details, see https://sass-lang.com/d/moz-document.
+
   ,
 1 | / @-moz-document url(sass-lang.com) {
 2 | |   a {type: unquoted url}
 3 | \ }
   '
+    input.scss 1:1  root stylesheet
 
-DEPRECATION WARNING on line 4, column 1 of input.scss: 
-@-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
+DEPRECATION WARNING: @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
 
 For details, see https://sass-lang.com/d/moz-document.
+
   ,
 4 | / @-moz-document url("sass-lang.com") {
 5 | |   a {type: quoted url}
 6 | \ }
   '
+    input.scss 4:1  root stylesheet
 
-DEPRECATION WARNING on line 8, column 1 of input.scss: 
-@-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
+DEPRECATION WARNING: @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
 
 For details, see https://sass-lang.com/d/moz-document.
+
    ,
 8  | / @-moz-document url-prefix(https://sass-lang.com/docs) {
 9  | |   a {type: unquoted url-prefix}
 10 | \ }
    '
+    input.scss 8:1  root stylesheet
 
-DEPRECATION WARNING on line 11, column 1 of input.scss: 
-@-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
+DEPRECATION WARNING: @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
 
 For details, see https://sass-lang.com/d/moz-document.
+
    ,
 11 | / @-moz-document url-prefix("https://sass-lang.com/docs") {
 12 | |   a {type: quoted url-prefix}
 13 | \ }
    '
+    input.scss 11:1  root stylesheet
 
-DEPRECATION WARNING on line 15, column 1 of input.scss: 
-@-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
+DEPRECATION WARNING: @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
 
 For details, see https://sass-lang.com/d/moz-document.
+
    ,
 15 | / @-moz-document domain(sass-lang.com) {
 16 | |   a {type: unquoted domain}
 17 | \ }
    '
+    input.scss 15:1  root stylesheet
+
+DEPRECATION WARNING: @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
+
+For details, see https://sass-lang.com/d/moz-document.
+
+   ,
+18 | / @-moz-document domain("sass-lang.com") {
+19 | |   a {type: quoted domain}
+20 | \ }
+   '
+    input.scss 18:1  root stylesheet
+
+DEPRECATION WARNING: @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
+
+For details, see https://sass-lang.com/d/moz-document.
+
+   ,
+22 | / @-moz-document regexp("https:.*") {
+23 | |   a {type: regexp}
+24 | \ }
+   '
+    input.scss 22:1  root stylesheet

--- a/spec/css/moz_document/multi_function.hrx
+++ b/spec/css/moz_document/multi_function.hrx
@@ -17,10 +17,10 @@
 }
 
 <===> warning
-DEPRECATION WARNING on line 1, column 1 of input.scss: 
-@-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
+DEPRECATION WARNING: @-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.
 
 For details, see https://sass-lang.com/d/moz-document.
+
   ,
 1 | / @-moz-document url(http://www.w3.org/),
 2 | |                url-prefix(http://www.w3.org/Style/),
@@ -29,3 +29,4 @@ For details, see https://sass-lang.com/d/moz-document.
 5 | |   a {b: c}
 6 | \ }
   '
+    input.scss 1:1  root stylesheet

--- a/spec/css/plain/error/statement/style_rule.hrx
+++ b/spec/css/plain/error/statement/style_rule.hrx
@@ -133,14 +133,15 @@ a {@import "plain"}
 > b {c: d}
 
 <===> leading_combinator/through_import/error
-DEPRECATION WARNING on line 1, column 12 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | a {@import "plain"}
   |            ^^^^^^^
   '
+    input.scss 1:12  root stylesheet
 
 Error: Top-level leading combinators aren't allowed in plain CSS.
   ,

--- a/spec/css/plain/functions.hrx
+++ b/spec/css/plain/functions.hrx
@@ -12,14 +12,15 @@ c {
 }
 
 <===> defined_elsewhere/warning
-DEPRECATION WARNING on line 3, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 3 | @import "plain";
   |         ^^^^^^^
   '
+    input.scss 3:9  root stylesheet
 
 <===>
 ================================================================================

--- a/spec/css/plain/import/css_before_index.hrx
+++ b/spec/css/plain/import/css_before_index.hrx
@@ -13,11 +13,12 @@ other {
 }
 
 <===> warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import 'other';
   |         ^^^^^^^
   '
+    input.scss 1:9  root stylesheet

--- a/spec/css/plain/import/in_css.hrx
+++ b/spec/css/plain/import/in_css.hrx
@@ -8,11 +8,12 @@
 @import "whatever";
 
 <===> warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "plain";
   |         ^^^^^^^
   '
+    input.scss 1:9  root stylesheet

--- a/spec/css/plain/import/partial_conflict.hrx
+++ b/spec/css/plain/import/partial_conflict.hrx
@@ -8,14 +8,15 @@ plain {partial: true}
 plain {partial: false}
 
 <===> error
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "plain";
   |         ^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 Error: It's not clear which file to import. Found:
   _plain.css

--- a/spec/css/plain/import/sass_takes_precedence.hrx
+++ b/spec/css/plain/import/sass_takes_precedence.hrx
@@ -14,11 +14,12 @@ other {
 }
 
 <===> warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 1:9  root stylesheet

--- a/spec/css/plain/import/scss_takes_precedence.hrx
+++ b/spec/css/plain/import/scss_takes_precedence.hrx
@@ -13,11 +13,12 @@ other {
 }
 
 <===> warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 1:9  root stylesheet

--- a/spec/css/plain/style_rule.hrx
+++ b/spec/css/plain/style_rule.hrx
@@ -240,14 +240,15 @@ a b {
 }
 
 <===> nesting/through_import/one_level/warning
-DEPRECATION WARNING on line 1, column 12 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | a {@import "plain"}
   |            ^^^^^^^
   '
+    input.scss 1:12  root stylesheet
 
 <===>
 ================================================================================
@@ -265,14 +266,15 @@ a b {
 }
 
 <===> nesting/through_import/two_levels/warning
-DEPRECATION WARNING on line 1, column 12 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | a {@import "plain"}
   |            ^^^^^^^
   '
+    input.scss 1:12  root stylesheet
 
 <===>
 ================================================================================
@@ -290,14 +292,15 @@ a & {
 }
 
 <===> nesting/through_import/top_level_parent/warning
-DEPRECATION WARNING on line 1, column 12 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | a {@import "plain"}
   |            ^^^^^^^
   '
+    input.scss 1:12  root stylesheet
 
 <===>
 ================================================================================

--- a/spec/css/selector/inline_comments.hrx
+++ b/spec/css/selector/inline_comments.hrx
@@ -25,12 +25,13 @@ b {
 }
 
 <===> silent/with_comma_in_comment/warning
-WARNING on line 4, column 1 of input.sass: 
-This selector doesn't have any properties and won't be rendered.
+WARNING: This selector doesn't have any properties and won't be rendered.
+
   ,
 4 | a // comment,
   | ^^^^^^^^^^^^^
   '
+    input.sass 4:1  root stylesheet
 
 <===>
 ================================================================================

--- a/spec/directives/at_root.hrx
+++ b/spec/directives/at_root.hrx
@@ -18,12 +18,13 @@
 <===> sass/empty/selector/output.css
 
 <===> sass/empty/selector/warning
-WARNING on line 1, column 10 of input.sass: 
-This selector doesn't have any properties and won't be rendered.
+WARNING: This selector doesn't have any properties and won't be rendered.
+
   ,
 1 | @at-root a
   |          ^
   '
+    input.sass 1:10  root stylesheet
 
 <===>
 ================================================================================
@@ -76,14 +77,15 @@ b {
 }
 
 <===> nested_import/with_no_use/warning
-DEPRECATION WARNING on line 2, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 |   @import "other";
   |           ^^^^^^^
   '
+    input.scss 2:11  root stylesheet
 
 <===>
 ================================================================================
@@ -107,14 +109,15 @@ b {
 }
 
 <===> nested_import/with_builtin_use/warning
-DEPRECATION WARNING on line 2, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 |   @import "other";
   |           ^^^^^^^
   '
+    input.scss 2:11  root stylesheet
 
 <===>
 ================================================================================

--- a/spec/directives/forward/css.hrx
+++ b/spec/directives/forward/css.hrx
@@ -108,11 +108,13 @@ in-input {
 }
 
 <===> forward_into_import/warning
-DEPRECATION WARNING on line 1, column 9 of _forwarded.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "imported";
   |         ^^^^^^^^^^
   '
+    _forwarded.scss 1:9  @forward
+    input.scss 1:1       root stylesheet

--- a/spec/directives/forward/error/load.hrx
+++ b/spec/directives/forward/error/load.hrx
@@ -73,14 +73,16 @@ Error: Module loop: this module is already being loaded.
 @import "input";
 
 <===> loop/forward_to_import/error
-DEPRECATION WARNING on line 1, column 9 of other.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "input";
   |         ^^^^^^^
   '
+    other.scss 1:9  @forward
+    input.scss 1:1  root stylesheet
 
 Error: This file is already being loaded.
   ,

--- a/spec/directives/forward/error/member/import_to_forward.hrx
+++ b/spec/directives/forward/error/member/import_to_forward.hrx
@@ -10,14 +10,15 @@ b {c: $d}
 $d: e;
 
 <===> nested/variable/error
-DEPRECATION WARNING on line 1, column 12 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | a {@import "midstream"}
   |            ^^^^^^^^^^^
   '
+    input.scss 1:12  root stylesheet
 
 Error: Undefined variable.
   ,
@@ -40,14 +41,15 @@ b {@include c}
 @mixin c {d: e}
 
 <===> nested/mixin/error
-DEPRECATION WARNING on line 1, column 12 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | a {@import "midstream"}
   |            ^^^^^^^^^^^
   '
+    input.scss 1:12  root stylesheet
 
 Error: Undefined mixin.
   ,
@@ -75,11 +77,12 @@ b {
 }
 
 <===> nested/function/warning
-DEPRECATION WARNING on line 1, column 12 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | a {@import "midstream"}
   |            ^^^^^^^^^^^
   '
+    input.scss 1:12  root stylesheet

--- a/spec/directives/forward/error/syntax.hrx
+++ b/spec/directives/forward/error/syntax.hrx
@@ -284,15 +284,6 @@ Error: @forward rules must be written before any other rules.
 @forward "b";
 
 <===> after/at_rule/import/error
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
-
-More info and automated migrator: https://sass-lang.com/d/import
-  ,
-1 | @import "a";
-  |         ^^^
-  '
-
 Error: @forward rules must be written before any other rules.
   ,
 2 | @forward "b";

--- a/spec/directives/forward/extend.hrx
+++ b/spec/directives/forward/extend.hrx
@@ -63,11 +63,14 @@ in-imported, in-input {
 }
 
 <===> forward_into_import/warning
-DEPRECATION WARNING on line 1, column 9 of _forwarded.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "imported";
   |         ^^^^^^^^^^
   '
+    _forwarded.scss 1:9  @forward
+    _midstream.scss 1:1  @use
+    input.scss 1:1       root stylesheet

--- a/spec/directives/forward/member/import/forward_to_import.hrx
+++ b/spec/directives/forward/member/import/forward_to_import.hrx
@@ -18,14 +18,17 @@ b {
 }
 
 <===> mixin/warning
-DEPRECATION WARNING on line 1, column 9 of _forwarded.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "imported";
   |         ^^^^^^^^^^
   '
+    _forwarded.scss 1:9  @forward
+    _used.scss 1:1       @use
+    input.scss 1:1       root stylesheet
 
 <===>
 ================================================================================
@@ -53,14 +56,17 @@ b {
 }
 
 <===> variable_assignment/warning
-DEPRECATION WARNING on line 1, column 9 of _forwarded.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "imported";
   |         ^^^^^^^^^^
   '
+    _forwarded.scss 1:9  @forward
+    _used.scss 1:1       @use
+    input.scss 1:1       root stylesheet
 
 <===>
 ================================================================================
@@ -84,14 +90,17 @@ a {
 }
 
 <===> variable_use/warning
-DEPRECATION WARNING on line 1, column 9 of _forwarded.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "imported";
   |         ^^^^^^^^^^
   '
+    _forwarded.scss 1:9  @forward
+    _used.scss 1:1       @use
+    input.scss 1:1       root stylesheet
 
 <===>
 ================================================================================
@@ -117,11 +126,14 @@ a {
 }
 
 <===> with/warning
-DEPRECATION WARNING on line 1, column 9 of _forwarded.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "imported";
   |         ^^^^^^^^^^
   '
+    _forwarded.scss 1:9  @forward
+    _used.scss 1:1       @use
+    input.scss 1:1       root stylesheet

--- a/spec/directives/forward/member/import/import_to_forward/nested.hrx
+++ b/spec/directives/forward/member/import/import_to_forward/nested.hrx
@@ -17,14 +17,15 @@ a {
 }
 
 <===> mixin/warning
-DEPRECATION WARNING on line 2, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 |   @import "midstream";
   |           ^^^^^^^^^^^
   '
+    input.scss 2:11  root stylesheet
 
 <===>
 ================================================================================
@@ -50,14 +51,15 @@ a {
 }
 
 <===> variable_assignment/warning
-DEPRECATION WARNING on line 2, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 |   @import "midstream";
   |           ^^^^^^^^^^^
   '
+    input.scss 2:11  root stylesheet
 
 <===>
 ================================================================================
@@ -80,11 +82,12 @@ a {
 }
 
 <===> variable_use/warning
-DEPRECATION WARNING on line 2, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 |   @import "midstream";
   |           ^^^^^^^^^^^
   '
+    input.scss 2:11  root stylesheet

--- a/spec/directives/forward/member/import/import_to_forward/override.hrx
+++ b/spec/directives/forward/member/import/import_to_forward/override.hrx
@@ -32,23 +32,25 @@ after-second {
 }
 
 <===> override/variable/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "midstream1";
   |         ^^^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
-DEPRECATION WARNING on line 4, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 4 | @import "midstream2";
   |         ^^^^^^^^^^^^
   '
+    input.scss 4:9  root stylesheet
 
 <===>
 ================================================================================
@@ -81,23 +83,25 @@ after-second {
 }
 
 <===> override/mixin/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "midstream1";
   |         ^^^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
-DEPRECATION WARNING on line 4, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 4 | @import "midstream2";
   |         ^^^^^^^^^^^^
   '
+    input.scss 4:9  root stylesheet
 
 <===>
 ================================================================================
@@ -130,20 +134,22 @@ after-second {
 }
 
 <===> override/function/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "midstream1";
   |         ^^^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
-DEPRECATION WARNING on line 4, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 4 | @import "midstream2";
   |         ^^^^^^^^^^^^
   '
+    input.scss 4:9  root stylesheet

--- a/spec/directives/forward/member/import/import_to_forward/top_level.hrx
+++ b/spec/directives/forward/member/import/import_to_forward/top_level.hrx
@@ -15,14 +15,15 @@ b {
 }
 
 <===> mixin/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "midstream";
   |         ^^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 <===>
 ================================================================================
@@ -47,14 +48,15 @@ b {
 }
 
 <===> variable_assignment/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "midstream";
   |         ^^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 <===>
 ================================================================================
@@ -75,14 +77,15 @@ a {
 }
 
 <===> variable_use/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "midstream";
   |         ^^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 <===>
 ================================================================================
@@ -107,23 +110,25 @@ b {
 }
 
 <===> post_facto/without_use/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "midstream";
   |         ^^^^^^^^^^^
   '
+    input.scss 2:9  root stylesheet
 
 <===>
 ================================================================================
@@ -150,20 +155,22 @@ b {
 }
 
 <===> post_facto/with_use/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "midstream";
   |         ^^^^^^^^^^^
   '
+    input.scss 2:9  root stylesheet

--- a/spec/directives/forward/member/import/import_to_forward/transitive.hrx
+++ b/spec/directives/forward/member/import/import_to_forward/transitive.hrx
@@ -18,23 +18,26 @@ a {
 }
 
 <===> transitive/variable/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "downstream";
   |         ^^^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
-DEPRECATION WARNING on line 1, column 9 of _downstream.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "midstream";
   |         ^^^^^^^^^^^
   '
+    _downstream.scss 1:9  @import
+    input.scss 1:9        root stylesheet
 
 <===>
 ================================================================================
@@ -58,23 +61,26 @@ a {
 }
 
 <===> transitive/mixin/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "downstream";
   |         ^^^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
-DEPRECATION WARNING on line 1, column 9 of _downstream.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "midstream";
   |         ^^^^^^^^^^^
   '
+    _downstream.scss 1:9  @import
+    input.scss 1:9        root stylesheet
 
 <===>
 ================================================================================
@@ -98,20 +104,23 @@ a {
 }
 
 <===> transitive/function/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "downstream";
   |         ^^^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
-DEPRECATION WARNING on line 1, column 9 of _downstream.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "midstream";
   |         ^^^^^^^^^^^
   '
+    _downstream.scss 1:9  @import
+    input.scss 1:9        root stylesheet

--- a/spec/directives/forward/member/import/import_to_forward/use_to.hrx
+++ b/spec/directives/forward/member/import/import_to_forward/use_to.hrx
@@ -18,14 +18,16 @@ b {
 }
 
 <===> mixin/warning
-DEPRECATION WARNING on line 1, column 9 of _used.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "imported";
   |         ^^^^^^^^^^
   '
+    _used.scss 1:9  @use
+    input.scss 1:1  root stylesheet
 
 <===>
 ================================================================================
@@ -53,14 +55,16 @@ b {
 }
 
 <===> variable_assignment/warning
-DEPRECATION WARNING on line 1, column 9 of _used.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "imported";
   |         ^^^^^^^^^^
   '
+    _used.scss 1:9  @use
+    input.scss 1:1  root stylesheet
 
 <===>
 ================================================================================
@@ -84,11 +88,13 @@ a {
 }
 
 <===> variable_use/warning
-DEPRECATION WARNING on line 1, column 9 of _used.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "imported";
   |         ^^^^^^^^^^
   '
+    _used.scss 1:9  @use
+    input.scss 1:1  root stylesheet

--- a/spec/directives/forward/member/import/import_to_forward/with.hrx
+++ b/spec/directives/forward/member/import/import_to_forward/with.hrx
@@ -17,14 +17,15 @@ a {
 }
 
 <===> default/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "midstream";
   |         ^^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 <===>
 ================================================================================
@@ -49,14 +50,15 @@ b {
 }
 
 <===> non_overridable/warning
-DEPRECATION WARNING on line 3, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 3 | @import "midstream";
   |         ^^^^^^^^^^^
   '
+    input.scss 3:9  root stylesheet
 
 <===>
 ================================================================================
@@ -81,11 +83,12 @@ b {
 }
 
 <===> overridden/warning
-DEPRECATION WARNING on line 3, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 3 | @import "midstream";
   |         ^^^^^^^^^^^
   '
+    input.scss 3:9  root stylesheet

--- a/spec/directives/forward/member/import/precedence.hrx
+++ b/spec/directives/forward/member/import/precedence.hrx
@@ -23,14 +23,15 @@ b {
 }
 
 <===> top_level/warning
-DEPRECATION WARNING on line 3, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 3 | @import "midstream";
   |         ^^^^^^^^^^^
   '
+    input.scss 3:9  root stylesheet
 
 <===>
 ================================================================================
@@ -55,11 +56,12 @@ b {
 }
 
 <===> nested/warning
-DEPRECATION WARNING on line 4, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 4 |   @import "midstream";
   |           ^^^^^^^^^^^
   '
+    input.scss 4:11  root stylesheet

--- a/spec/directives/forward/with/through_import.hrx
+++ b/spec/directives/forward/with/through_import.hrx
@@ -17,14 +17,17 @@ b {
 }
 
 <===> direct/warning
-DEPRECATION WARNING on line 1, column 9 of _midstream.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "upstream";
   |         ^^^^^^^^^^
   '
+    _midstream.scss 1:9   @forward
+    _downstream.scss 1:1  @use
+    input.scss 1:1        root stylesheet
 
 <===>
 ================================================================================
@@ -50,20 +53,27 @@ b {
 }
 
 <===> transitive/warning
-DEPRECATION WARNING on line 1, column 9 of _forwarded.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "imported_downstream";
   |         ^^^^^^^^^^^^^^^^^^^^^
   '
+    _forwarded.scss 1:9  @forward
+    _used.scss 1:1       @use
+    input.scss 1:1       root stylesheet
 
-DEPRECATION WARNING on line 1, column 9 of _imported_downstream.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "imported_upstream";
   |         ^^^^^^^^^^^^^^^^^^^
   '
+    _imported_downstream.scss 1:9  @import
+    _forwarded.scss 1:9            @forward
+    _used.scss 1:1                 @use
+    input.scss 1:1                 root stylesheet

--- a/spec/directives/function.hrx
+++ b/spec/directives/function.hrx
@@ -22,14 +22,15 @@ b {
 }
 
 <===> custom_ident_name/warning
-DEPRECATION WARNING on line 1, column 11 of input.scss: 
-Sass @function names beginning with -- are deprecated for forward-compatibility with plain CSS mixins.
+DEPRECATION WARNING: Sass @function names beginning with -- are deprecated for forward-compatibility with plain CSS mixins.
 
 For details, see https://sass-lang.com/d/css-function-mixin
+
   ,
 1 | @function --a() {@return 1}
   |           ^^^
   '
+    input.scss 1:11  root stylesheet
 
 <===>
 ================================================================================

--- a/spec/directives/import/configuration.hrx
+++ b/spec/directives/import/configuration.hrx
@@ -15,14 +15,15 @@ b {
 }
 
 <===> same_file/warning
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "midstream";
   |         ^^^^^^^^^^^
   '
+    input.scss 2:9  root stylesheet
 
 <===>
 ================================================================================
@@ -45,14 +46,15 @@ a b {
 }
 
 <===> nested/warning
-DEPRECATION WARNING on line 3, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 3 |   @import "midstream";
   |           ^^^^^^^^^^^
   '
+    input.scss 3:11  root stylesheet
 
 <===>
 ================================================================================
@@ -73,14 +75,15 @@ b {
 }
 
 <===> prefixed_as/warning
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "midstream";
   |         ^^^^^^^^^^^
   '
+    input.scss 2:9  root stylesheet
 
 <===>
 ================================================================================
@@ -104,23 +107,25 @@ b {
 }
 
 <===> separate_file/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "config";
   |         ^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "midstream";
   |         ^^^^^^^^^^^
   '
+    input.scss 2:9  root stylesheet
 
 <===>
 ================================================================================
@@ -142,14 +147,15 @@ b {
 }
 
 <===> unrelated_variable/warning
-DEPRECATION WARNING on line 3, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 3 | @import "midstream";
   |         ^^^^^^^^^^^
   '
+    input.scss 3:9  root stylesheet
 
 <===>
 ================================================================================
@@ -171,14 +177,15 @@ b {
 }
 
 <===> midstream_definition/with_config/warning
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "midstream";
   |         ^^^^^^^^^^^
   '
+    input.scss 2:9  root stylesheet
 
 <===>
 ================================================================================
@@ -199,14 +206,15 @@ b {
 }
 
 <===> midstream_definition/no_config/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "midstream";
   |         ^^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 <===>
 ================================================================================
@@ -232,23 +240,25 @@ b {
 }
 
 <===> import_twice/no_change/warning
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 2:9  root stylesheet
 
-DEPRECATION WARNING on line 3, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 3 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 3:9  root stylesheet
 
 <===>
 ================================================================================
@@ -275,23 +285,25 @@ b {
 }
 
 <===> import_twice/with_change/warning
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 2:9  root stylesheet
 
-DEPRECATION WARNING on line 4, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 4 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 4:9  root stylesheet
 
 <===>
 ================================================================================
@@ -325,23 +337,25 @@ d {
 }
 
 <===> import_twice/still_changes_in_same_file/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
-DEPRECATION WARNING on line 3, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 3 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 3:9  root stylesheet
 
 <===>
 ================================================================================
@@ -365,23 +379,26 @@ b {
 }
 
 <===> indirect/through_import/warning
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "midstream";
   |         ^^^^^^^^^^^
   '
+    input.scss 2:9  root stylesheet
 
-DEPRECATION WARNING on line 1, column 9 of _midstream.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "upstream";
   |         ^^^^^^^^^^
   '
+    _midstream.scss 1:9  @import
+    input.scss 2:9       root stylesheet
 
 <===>
 ================================================================================
@@ -408,11 +425,12 @@ b {
 }
 
 <===> indirect/through_forward/warning
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "midstream";
   |         ^^^^^^^^^^^
   '
+    input.scss 2:9  root stylesheet

--- a/spec/directives/import/css.hrx
+++ b/spec/directives/import/css.hrx
@@ -25,20 +25,22 @@ a {
 }
 
 <===> css_import_after_style_rule/warning
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "rule";
   |         ^^^^^^
   '
+    input.scss 2:9  root stylesheet
 
-DEPRECATION WARNING on line 3, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 3 | @import "import";
   |         ^^^^^^^^
   '
+    input.scss 3:9  root stylesheet

--- a/spec/directives/import/error/conflict.hrx
+++ b/spec/directives/import/error/conflict.hrx
@@ -10,14 +10,15 @@ a {partial: true}
 a {partial: false}
 
 <===> partial/error
-DEPRECATION WARNING on line 3, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 3 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 3:9  root stylesheet
 
 Error: It's not clear which file to import. Found:
   _other.scss
@@ -43,14 +44,15 @@ a
 a {syntax: scss}
 
 <===> extension/error
-DEPRECATION WARNING on line 3, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 3 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 3:9  root stylesheet
 
 Error: It's not clear which file to import. Found:
   other.sass
@@ -85,14 +87,15 @@ a
 a {syntax: scss; partial: true}
 
 <===> all/error
-DEPRECATION WARNING on line 3, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 3 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 3:9  root stylesheet
 
 Error: It's not clear which file to import. Found:
   _other.sass
@@ -119,14 +122,15 @@ a {partial: true}
 a {partial: false}
 
 <===> index/error
-DEPRECATION WARNING on line 3, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 3 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 3:9  root stylesheet
 
 Error: It's not clear which file to import. Found:
   other/_index.scss
@@ -152,14 +156,15 @@ a
   syntax: sass
 
 <===> import_only/no_extension/error
-DEPRECATION WARNING on line 3, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 3 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 3:9  root stylesheet
 
 Error: It's not clear which file to import. Found:
   other.import.sass
@@ -184,14 +189,15 @@ a {partial: false}
 a {partial: true}
 
 <===> import_only/with_extension/error
-DEPRECATION WARNING on line 3, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 3 | @import "other.scss";
   |         ^^^^^^^^^^^^
   '
+    input.scss 3:9  root stylesheet
 
 Error: It's not clear which file to import. Found:
   _other.import.scss

--- a/spec/directives/import/error/member.hrx
+++ b/spec/directives/import/error/member.hrx
@@ -7,14 +7,15 @@ b {c: $d}
 $d: e;
 
 <===> inaccessible/nested/variable/error
-DEPRECATION WARNING on line 1, column 12 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | a {@import "other"}
   |            ^^^^^^^
   '
+    input.scss 1:12  root stylesheet
 
 Error: Undefined variable.
   ,
@@ -34,14 +35,15 @@ b {@include c}
 @mixin c() {d: e};
 
 <===> inaccessible/nested/mixin/error
-DEPRECATION WARNING on line 1, column 12 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | a {@import "other"}
   |            ^^^^^^^
   '
+    input.scss 1:12  root stylesheet
 
 Error: Undefined mixin.
   ,
@@ -66,11 +68,12 @@ b {
 }
 
 <===> inaccessible/nested/function/warning
-DEPRECATION WARNING on line 1, column 12 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | a {@import "other"}
   |            ^^^^^^^
   '
+    input.scss 1:12  root stylesheet

--- a/spec/directives/import/error/not_found.hrx
+++ b/spec/directives/import/error/not_found.hrx
@@ -5,14 +5,15 @@
 a {b: c}
 
 <===> no_extension/error
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 Error: Can't find stylesheet to import.
   ,
@@ -32,14 +33,15 @@ Error: Can't find stylesheet to import.
 a {b: c}
 
 <===> directory_dot_import/error
-DEPRECATION WARNING on line 3, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 3 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 3:9  root stylesheet
 
 Error: Can't find stylesheet to import.
   ,
@@ -63,23 +65,26 @@ a {b: ""}
 @import "sibling"
 
 <===> parent_relative/error
-DEPRECATION WARNING on line 4, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 4 | @import "dir/child"
   |         ^^^^^^^^^^^
   '
+    input.scss 4:9  root stylesheet
 
-DEPRECATION WARNING on line 1, column 9 of dir/child.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "sibling"
   |         ^^^^^^^^^
   '
+    dir/child.scss 1:9  @import
+    input.scss 4:9      root stylesheet
 
 Error: Can't find stylesheet to import.
   ,

--- a/spec/directives/import/escaped.hrx
+++ b/spec/directives/import/escaped.hrx
@@ -10,11 +10,12 @@ a {
 }
 
 <===> warning
-DEPRECATION WARNING on line 1, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @impor\74 "other"
   |           ^^^^^^^
   '
+    input.scss 1:11  root stylesheet

--- a/spec/directives/import/implicit_dependencies.hrx
+++ b/spec/directives/import/implicit_dependencies.hrx
@@ -16,23 +16,25 @@ a {
 }
 
 <===> no_forward/no_use/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "first";
   |         ^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "second";
   |         ^^^^^^^^
   '
+    input.scss 2:9  root stylesheet
 
 <===>
 ================================================================================
@@ -56,23 +58,25 @@ a {
 }
 
 <===> no_forward/use_in_first/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "first";
   |         ^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "second";
   |         ^^^^^^^^
   '
+    input.scss 2:9  root stylesheet
 
 <===>
 ================================================================================
@@ -96,23 +100,25 @@ a {
 }
 
 <===> no_forward/use_in_second/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "first";
   |         ^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "second";
   |         ^^^^^^^^
   '
+    input.scss 2:9  root stylesheet
 
 <===>
 ================================================================================
@@ -138,23 +144,25 @@ a {
 }
 
 <===> no_forward/use_in_both/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "first";
   |         ^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "second";
   |         ^^^^^^^^
   '
+    input.scss 2:9  root stylesheet
 
 <===>
 ================================================================================
@@ -179,23 +187,25 @@ a {
 }
 
 <===> forwarded_first/no_use/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "first";
   |         ^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "second";
   |         ^^^^^^^^
   '
+    input.scss 2:9  root stylesheet
 
 <===>
 ================================================================================
@@ -222,23 +232,25 @@ a {
 }
 
 <===> forwarded_first/use_in_first/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "first";
   |         ^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "second";
   |         ^^^^^^^^
   '
+    input.scss 2:9  root stylesheet
 
 <===>
 ================================================================================
@@ -265,23 +277,25 @@ a {
 }
 
 <===> forwarded_first/use_in_second/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "first";
   |         ^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "second";
   |         ^^^^^^^^
   '
+    input.scss 2:9  root stylesheet
 
 <===>
 ================================================================================
@@ -310,20 +324,22 @@ a {
 }
 
 <===> forwarded_first/use_in_both/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "first";
   |         ^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "second";
   |         ^^^^^^^^
   '
+    input.scss 2:9  root stylesheet

--- a/spec/directives/import/load.hrx
+++ b/spec/directives/import/load.hrx
@@ -17,14 +17,15 @@ a {
 }
 
 <===> explicit_extension/sass/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "other.sass"
   |         ^^^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 <===>
 ================================================================================
@@ -47,14 +48,15 @@ a {
 }
 
 <===> explicit_extension/scss/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "other.scss"
   |         ^^^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 <===>
 ================================================================================
@@ -73,14 +75,15 @@ a {
 }
 
 <===> precedence/scss_before_css/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 <===>
 ================================================================================
@@ -100,14 +103,15 @@ a {
 }
 
 <===> precedence/sass_before_css/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 <===>
 ================================================================================
@@ -126,14 +130,15 @@ a {
 }
 
 <===> precedence/normal_before_index/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "dir";
   |         ^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 <===>
 ================================================================================
@@ -155,14 +160,15 @@ a {
 }
 
 <===> precedence/import_only/implicit_extension/warning
-DEPRECATION WARNING on line 3, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 3 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 3:9  root stylesheet
 
 <===>
 ================================================================================
@@ -181,14 +187,15 @@ a {
 }
 
 <===> precedence/import_only/explicit_extension/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 <===>
 ================================================================================
@@ -208,14 +215,15 @@ a {
 }
 
 <===> precedence/import_only/partial_before_normal/warning
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 2:9  root stylesheet
 
 <===>
 ================================================================================
@@ -235,14 +243,15 @@ a {
 }
 
 <===> precedence/import_only/normal_before_partial/warning
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 2:9  root stylesheet
 
 <===>
 ================================================================================
@@ -262,14 +271,15 @@ a {
 }
 
 <===> precedence/import_only/before_index/warning
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 2:9  root stylesheet
 
 <===>
 ================================================================================
@@ -289,14 +299,15 @@ a {
 }
 
 <===> precedence/import_only/index/warning
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 2:9  root stylesheet
 
 <===>
 ================================================================================
@@ -316,14 +327,15 @@ a {
 }
 
 <===> precedence/import_only/index_after_normal/warning
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 2:9  root stylesheet
 
 <===>
 ================================================================================
@@ -341,14 +353,15 @@ More info and automated migrator: https://sass-lang.com/d/import
 }
 
 <===> index/scss/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "dir";
   |         ^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 <===>
 ================================================================================
@@ -365,14 +378,15 @@ More info and automated migrator: https://sass-lang.com/d/import
 }
 
 <===> index/sass/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "dir";
   |         ^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 <===>
 ================================================================================
@@ -390,14 +404,15 @@ More info and automated migrator: https://sass-lang.com/d/import
 }
 
 <===> index/partial/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "dir";
   |         ^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 <===>
 ================================================================================
@@ -415,14 +430,15 @@ More info and automated migrator: https://sass-lang.com/d/import
 }
 
 <===> index/dir_dot_foo/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "dir.foo";
   |         ^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 <===>
 ================================================================================
@@ -435,14 +451,15 @@ More info and automated migrator: https://sass-lang.com/d/import
 }
 
 <===> index/dir_dot_scss/error
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "dir.scss";
   |         ^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 Error: Can't find stylesheet to import.
   ,

--- a/spec/directives/import/nested.hrx
+++ b/spec/directives/import/nested.hrx
@@ -20,14 +20,15 @@ x {
 }
 
 <===> scope/function/warning
-DEPRECATION WARNING on line 8, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 8 |   @import 'other';
   |           ^^^^^^^
   '
+    input.scss 8:11  root stylesheet
 
 <===>
 ================================================================================
@@ -51,14 +52,15 @@ More info and automated migrator: https://sass-lang.com/d/import
 }
 
 <===> scope/mixin/warning
-DEPRECATION WARNING on line 8, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 8 |   @import 'other';
   |           ^^^^^^^
   '
+    input.scss 8:11  root stylesheet
 
 <===>
 ================================================================================
@@ -81,14 +83,15 @@ x {
 }
 
 <===> scope/variable/warning
-DEPRECATION WARNING on line 5, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 5 |   @import 'other';
   |           ^^^^^^^
   '
+    input.scss 5:11  root stylesheet
 
 <===>
 ================================================================================
@@ -110,14 +113,15 @@ a {@import "other"}
 }
 
 <===> at_rule/keyframes/warning
-DEPRECATION WARNING on line 1, column 12 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | a {@import "other"}
   |            ^^^^^^^
   '
+    input.scss 1:12  root stylesheet
 
 <===>
 ================================================================================
@@ -133,14 +137,15 @@ a {
 }
 
 <===> at_rule/childless/warning
-DEPRECATION WARNING on line 1, column 12 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | a {@import "other"}
   |            ^^^^^^^
   '
+    input.scss 1:12  root stylesheet
 
 <===>
 ================================================================================
@@ -158,14 +163,15 @@ a {@import "other"}
 }
 
 <===> at_rule/declaration_child/warning
-DEPRECATION WARNING on line 1, column 12 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | a {@import "other"}
   |            ^^^^^^^
   '
+    input.scss 1:12  root stylesheet
 
 <===>
 ================================================================================
@@ -185,14 +191,15 @@ a {@import "other"}
 }
 
 <===> at_rule/rule_child/warning
-DEPRECATION WARNING on line 1, column 12 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | a {@import "other"}
   |            ^^^^^^^
   '
+    input.scss 1:12  root stylesheet
 
 <===>
 ================================================================================
@@ -214,38 +221,44 @@ More info and automated migrator: https://sass-lang.com/d/import
 /* Y */
 
 <===> with_comment/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import 'b';
   |         ^^^
   '
+    input.scss 1:9  root stylesheet
 
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import 'c';
   |         ^^^
   '
+    input.scss 2:9  root stylesheet
 
-DEPRECATION WARNING on line 1, column 9 of _b.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import 'a'
   |         ^^^
   '
+    _b.scss 1:9     @import
+    input.scss 1:9  root stylesheet
 
-DEPRECATION WARNING on line 1, column 9 of _c.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import 'a'
   |         ^^^
   '
+    _c.scss 1:9     @import
+    input.scss 2:9  root stylesheet

--- a/spec/directives/mixin.hrx
+++ b/spec/directives/mixin.hrx
@@ -8,14 +8,15 @@ d {
 }
 
 <===> custom_ident_name/warning
-DEPRECATION WARNING on line 1, column 8 of input.scss: 
-Sass @mixin names beginning with -- are deprecated for forward-compatibility with plain CSS mixins.
+DEPRECATION WARNING: Sass @mixin names beginning with -- are deprecated for forward-compatibility with plain CSS mixins.
 
 For details, see https://sass-lang.com/d/css-function-mixin
+
   ,
 1 | @mixin --a {b: c}
   |        ^^^
   '
+    input.scss 1:8  root stylesheet
 
 <===>
 ================================================================================

--- a/spec/directives/use/css/import.hrx
+++ b/spec/directives/use/css/import.hrx
@@ -25,14 +25,16 @@ in-input {
 }
 
 <===> use_into_import/warning
-DEPRECATION WARNING on line 1, column 9 of _used.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "imported";
   |         ^^^^^^^^^^
   '
+    _used.scss 1:9  @use
+    input.scss 1:1  root stylesheet
 
 <===>
 ================================================================================
@@ -72,14 +74,16 @@ in-input {
 }
 
 <===> use_into_import_into_use/warning
-DEPRECATION WARNING on line 1, column 9 of _used-downstream.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "imported";
   |         ^^^^^^^^^^
   '
+    _used-downstream.scss 1:9  @use
+    input.scss 1:1             root stylesheet
 
 <===>
 ================================================================================
@@ -107,14 +111,15 @@ a {
 }
 
 <===> use_and_import_same/warning
-DEPRECATION WARNING on line 5, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 5 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 5:9  root stylesheet
 
 _other.scss:3 DEBUG: evaluating other
 _other.scss:3 DEBUG: evaluating other
@@ -147,14 +152,15 @@ a {
 }
 
 <===> use_module_used_by_import/warning
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "imported";
   |         ^^^^^^^^^^
   '
+    input.scss 2:9  root stylesheet
 
 _shared.scss:3 DEBUG: evaluating shared
 
@@ -187,14 +193,15 @@ in-input {
 }
 
 <===> import_into_use/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "imported";
   |         ^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 <===>
 ================================================================================
@@ -223,14 +230,15 @@ outer in-imported {
 }
 
 <===> nested_import_into_use/warning
-DEPRECATION WARNING on line 1, column 16 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | outer {@import "imported"}
   |                ^^^^^^^^^^
   '
+    input.scss 1:16  root stylesheet
 
 <===>
 ================================================================================
@@ -270,23 +278,27 @@ in-input {
 }
 
 <===> import_into_use_into_import/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "imported-downstream";
   |         ^^^^^^^^^^^^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
-DEPRECATION WARNING on line 1, column 9 of _used.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "imported-upstream";
   |         ^^^^^^^^^^^^^^^^^^^
   '
+    _used.scss 1:9                 @use
+    _imported-downstream.scss 1:1  @import
+    input.scss 1:9                 root stylesheet
 
 <===>
 ================================================================================
@@ -314,23 +326,26 @@ a {
 }
 
 <===> import_module_imported_by_use/warning
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "shared";
   |         ^^^^^^^^
   '
+    input.scss 2:9  root stylesheet
 
-DEPRECATION WARNING on line 1, column 9 of _used.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "shared";
   |         ^^^^^^^^
   '
+    _used.scss 1:9  @use
+    input.scss 1:1  root stylesheet
 
 _shared.scss:3 DEBUG: evaluating shared
 _shared.scss:3 DEBUG: evaluating shared

--- a/spec/directives/use/css/order/use_and_import.hrx
+++ b/spec/directives/use/css/order/use_and_import.hrx
@@ -92,14 +92,16 @@ a {
 }
 
 <===> use_into_import/css_import_above_rule/warning
-DEPRECATION WARNING on line 1, column 9 of _used.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "imported";
   |         ^^^^^^^^^^
   '
+    _used.scss 1:9  @use
+    input.scss 1:1  root stylesheet
 
 <===>
 ================================================================================
@@ -133,14 +135,16 @@ a {
 }
 
 <===> use_into_import/css_import_below_rule/warning
-DEPRECATION WARNING on line 1, column 9 of _used.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "imported";
   |         ^^^^^^^^^^
   '
+    _used.scss 1:9  @use
+    input.scss 1:1  root stylesheet
 
 <===>
 ================================================================================
@@ -163,14 +167,16 @@ More info and automated migrator: https://sass-lang.com/d/import
 @import "input.css";
 
 <===> use_into_import/sass_import_below_css_import/warning
-DEPRECATION WARNING on line 3, column 9 of _used.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 3 | @import "imported";
   |         ^^^^^^^^^^
   '
+    _used.scss 3:9  @use
+    input.scss 1:1  root stylesheet
 
 <===>
 ================================================================================
@@ -204,14 +210,15 @@ a {
 }
 
 <===> import_into_use/css_import_above_rule/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "imported";
   |         ^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 <===>
 ================================================================================
@@ -245,14 +252,15 @@ a {
 }
 
 <===> import_into_use/css_import_below_rule/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "imported";
   |         ^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 <===>
 ================================================================================
@@ -275,14 +283,15 @@ More info and automated migrator: https://sass-lang.com/d/import
 @import "imported.css";
 
 <===> import_into_use/sass_import_below_css_import/warning
-DEPRECATION WARNING on line 3, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 3 | @import "imported";
   |         ^^^^^^^^^^
   '
+    input.scss 3:9  root stylesheet
 
 <===>
 ================================================================================

--- a/spec/directives/use/error/load.hrx
+++ b/spec/directives/use/error/load.hrx
@@ -206,14 +206,16 @@ Error: Module loop: this module is already being loaded.
 @import "input";
 
 <===> loop/use_to_import/error
-DEPRECATION WARNING on line 1, column 9 of other.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "input";
   |         ^^^^^^^
   '
+    other.scss 1:9  @use
+    input.scss 1:1  root stylesheet
 
 Error: This file is already being loaded.
   ,
@@ -232,14 +234,15 @@ Error: This file is already being loaded.
 @use "input";
 
 <===> loop/import_to_use/error
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "other";
   |         ^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 Error: Module loop: this module is already being loaded.
   ,

--- a/spec/directives/use/error/member/inaccessible.hrx
+++ b/spec/directives/use/error/member/inaccessible.hrx
@@ -72,14 +72,15 @@ a {b: $upstream};
 $upstream: value;
 
 <===> transitive_from_import/variable/error
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "midstream";
   |         ^^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 Error: Undefined variable.
   ,
@@ -109,14 +110,15 @@ a {
 }
 
 <===> transitive_from_import/function/warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "midstream";
   |         ^^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 <===>
 ================================================================================
@@ -132,14 +134,15 @@ More info and automated migrator: https://sass-lang.com/d/import
 @mixin upstream {a {b: c}}
 
 <===> transitive_from_import/mixin/error
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "midstream";
   |         ^^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 Error: Undefined mixin.
   ,

--- a/spec/directives/use/error/syntax/after.hrx
+++ b/spec/directives/use/error/syntax/after.hrx
@@ -31,15 +31,6 @@ Error: @use rules must be written before any other rules.
 @use "other2";
 
 <===> at_rule/import/error
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
-
-More info and automated migrator: https://sass-lang.com/d/import
-  ,
-1 | @import "other1";
-  |         ^^^^^^^^
-  '
-
 Error: @use rules must be written before any other rules.
   ,
 2 | @use "other2";

--- a/spec/directives/use/extend/scope.hrx
+++ b/spec/directives/use/extend/scope.hrx
@@ -121,14 +121,15 @@ shared, in-imported {
 }
 
 <===> use_into_use_and_import_into_use/warning
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "imported";
   |         ^^^^^^^^^^
   '
+    input.scss 2:9  root stylesheet
 
 <===>
 ================================================================================
@@ -162,23 +163,26 @@ shared, in-imported {
 }
 
 <===> use_into_use_and_import_into_import/warning
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "imported";
   |         ^^^^^^^^^^
   '
+    input.scss 2:9  root stylesheet
 
-DEPRECATION WARNING on line 1, column 9 of _imported.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "shared";
   |         ^^^^^^^^
   '
+    _imported.scss 1:9  @import
+    input.scss 2:9      root stylesheet
 
 <===>
 ================================================================================
@@ -212,14 +216,16 @@ shared, in-importer {
 }
 
 <===> use_into_use_and_use_into_import/warning
-DEPRECATION WARNING on line 1, column 9 of _importer.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "shared";
   |         ^^^^^^^^
   '
+    _importer.scss 1:9  @use
+    input.scss 2:1      root stylesheet
 
 <===>
 ================================================================================
@@ -256,14 +262,16 @@ shared, in-used {
 }
 
 <===> use_into_use_and_use_into_import_into_use/warning
-DEPRECATION WARNING on line 1, column 9 of _importer.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "imported";
   |         ^^^^^^^^^^
   '
+    _importer.scss 1:9  @use
+    input.scss 1:1      root stylesheet
 
 <===>
 ================================================================================
@@ -312,23 +320,25 @@ in-shared, right-extendee, left-extendee {
 }
 
 <===> use_and_import_into_diamond_extend/warning
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "downstream";
   |         ^^^^^^^^^^^^
   '
+    input.scss 2:9  root stylesheet
 
-DEPRECATION WARNING on line 3, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 3 | @import "imported";
   |         ^^^^^^^^^^
   '
+    input.scss 3:9  root stylesheet
 
 <===>
 ================================================================================
@@ -365,11 +375,12 @@ More info and automated migrator: https://sass-lang.com/d/import
 }
 
 <===> isolated_through_import/warning
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "imported";
   |         ^^^^^^^^^^
   '
+    input.scss 2:9  root stylesheet

--- a/spec/directives/use/member/nested_global_variable.hrx
+++ b/spec/directives/use/member/nested_global_variable.hrx
@@ -48,11 +48,13 @@ a {
 }
 
 <===> through_import/warning
-DEPRECATION WARNING on line 1, column 9 of used.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "imported";
   |         ^^^^^^^^^^
   '
+    used.scss 1:9   @use
+    input.scss 2:1  root stylesheet

--- a/spec/directives/use/member/use_to_import.hrx
+++ b/spec/directives/use/member/use_to_import.hrx
@@ -15,14 +15,16 @@ a {
 }
 
 <===> variable_use/warning
-DEPRECATION WARNING on line 1, column 9 of midstream.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "upstream";
   |         ^^^^^^^^^^
   '
+    midstream.scss 1:9  @use
+    input.scss 1:1      root stylesheet
 
 <===>
 ================================================================================
@@ -47,14 +49,16 @@ a {
 }
 
 <===> variable_assignment/warning
-DEPRECATION WARNING on line 1, column 9 of midstream.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "upstream";
   |         ^^^^^^^^^^
   '
+    midstream.scss 1:9  @use
+    input.scss 1:1      root stylesheet
 
 <===>
 ================================================================================
@@ -75,14 +79,16 @@ a {
 }
 
 <===> function/warning
-DEPRECATION WARNING on line 1, column 9 of midstream.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "upstream";
   |         ^^^^^^^^^^
   '
+    midstream.scss 1:9  @use
+    input.scss 1:1      root stylesheet
 
 <===>
 ================================================================================
@@ -103,11 +109,13 @@ a {
 }
 
 <===> mixin/warning
-DEPRECATION WARNING on line 1, column 9 of midstream.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "upstream";
   |         ^^^^^^^^^^
   '
+    midstream.scss 1:9  @use
+    input.scss 1:1      root stylesheet

--- a/spec/directives/use/with/through_import.hrx
+++ b/spec/directives/use/with/through_import.hrx
@@ -14,14 +14,16 @@ b {
 }
 
 <===> direct/warning
-DEPRECATION WARNING on line 1, column 9 of _used.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "imported";
   |         ^^^^^^^^^^
   '
+    _used.scss 1:9  @use
+    input.scss 1:1  root stylesheet
 
 <===>
 ================================================================================
@@ -44,20 +46,25 @@ b {
 }
 
 <===> transitive/warning
-DEPRECATION WARNING on line 1, column 9 of _used.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "midstream";
   |         ^^^^^^^^^^^
   '
+    _used.scss 1:9  @use
+    input.scss 1:1  root stylesheet
 
-DEPRECATION WARNING on line 1, column 9 of _midstream.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "upstream";
   |         ^^^^^^^^^^
   '
+    _midstream.scss 1:9  @import
+    _used.scss 1:9       @use
+    input.scss 1:1       root stylesheet

--- a/spec/libsass-closed-issues/issue_1060.hrx
+++ b/spec/libsass-closed-issues/issue_1060.hrx
@@ -24,11 +24,12 @@ foo {
 }
 
 <===> warning
-DEPRECATION WARNING on line 4, column 5 of input.scss: 
-@elseif is deprecated and will not be supported in future Sass versions.
+DEPRECATION WARNING: @elseif is deprecated and will not be supported in future Sass versions.
 
 Recommendation: @else if
+
   ,
 4 |   } @elseif true {
   |     ^^^^^^^
   '
+    input.scss 4:5  root stylesheet

--- a/spec/libsass-closed-issues/issue_1081.hrx
+++ b/spec/libsass-closed-issues/issue_1081.hrx
@@ -39,14 +39,15 @@ after import-after {
 }
 
 <===> warning
-DEPRECATION WARNING on line 10, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
    ,
 10 |   @import "import";
    |           ^^^^^^^^
    '
+    input.scss 10:11  root stylesheet
 
 DEPRECATION WARNING: As of Dart Sass 2.0.0, !global assignments won't be able to declare new variables.
 

--- a/spec/libsass-closed-issues/issue_1103.hrx
+++ b/spec/libsass-closed-issues/issue_1103.hrx
@@ -62,20 +62,22 @@ baz {
 }
 
 <===> warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "import";
   |         ^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
-DEPRECATION WARNING on line 9, column 13 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 9 |     @import "import";
   |             ^^^^^^^^
   '
+    input.scss 9:13  root stylesheet

--- a/spec/libsass-closed-issues/issue_1578.hrx
+++ b/spec/libsass-closed-issues/issue_1578.hrx
@@ -10,9 +10,10 @@ foo {
 }
 
 <===> warning
-WARNING on line 4, column 5 of input.sass: 
-This selector doesn't have any properties and won't be rendered.
+WARNING: This selector doesn't have any properties and won't be rendered.
+
   ,
 4 |     baz:bam
   |     ^^^^^^^
   '
+    input.sass 4:5  root stylesheet

--- a/spec/libsass-closed-issues/issue_1648.hrx
+++ b/spec/libsass-closed-issues/issue_1648.hrx
@@ -23,11 +23,12 @@ $x: 3px;
 /* comment 5 */
 
 <===> warning
-DEPRECATION WARNING on line 7, column 1 of input.scss: 
-@elseif is deprecated and will not be supported in future Sass versions.
+DEPRECATION WARNING: @elseif is deprecated and will not be supported in future Sass versions.
 
 Recommendation: @else if
+
   ,
 7 | @elseif/* pre 2 */$x == 2px/* post 2 */{
   | ^^^^^^^
   '
+    input.scss 7:1  root stylesheet

--- a/spec/libsass-closed-issues/issue_1739/basic.hrx
+++ b/spec/libsass-closed-issues/issue_1739/basic.hrx
@@ -70,8 +70,7 @@ mod {
 }
 
 <===> warning
-DEPRECATION WARNING on line 11, column 8 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     2 + 3
 
@@ -84,7 +83,9 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
    ,
 11 |   baz: 2  +3;
    |        ^^^^^
    '
+    input.scss 11:8  root stylesheet

--- a/spec/libsass-closed-issues/issue_1739/interpolate/both.hrx
+++ b/spec/libsass-closed-issues/issue_1739/interpolate/both.hrx
@@ -34,8 +34,7 @@ mod {
   baz: #{1  %  2}  %  #{1  %  2};
 }
 <===> error
-DEPRECATION WARNING on line 11, column 10 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     1 + 2
 
@@ -48,13 +47,14 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
    ,
 11 |   baz: #{1  +2}  +#{1  +2};
    |          ^^^^^
    '
+    input.scss 11:10  root stylesheet
 
-DEPRECATION WARNING on line 11, column 21 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     1 + 2
 
@@ -67,13 +67,14 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
    ,
 11 |   baz: #{1  +2}  +#{1  +2};
    |                     ^^^^^
    '
+    input.scss 11:21  root stylesheet
 
-DEPRECATION WARNING on line 11, column 8 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     #{1 + 2} + #{1 + 2}
 
@@ -86,10 +87,12 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
    ,
 11 |   baz: #{1  +2}  +#{1  +2};
    |        ^^^^^^^^^^^^^^^^^^^
    '
+    input.scss 11:8  root stylesheet
 
 Error: Undefined operation "2 * 2".
    ,

--- a/spec/libsass-closed-issues/issue_1739/interpolate/left.hrx
+++ b/spec/libsass-closed-issues/issue_1739/interpolate/left.hrx
@@ -34,8 +34,7 @@ mod {
   baz: #{1  %  2}  %  3;
 }
 <===> error
-DEPRECATION WARNING on line 11, column 10 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     1 + 2
 
@@ -48,13 +47,14 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
    ,
 11 |   baz: #{1  +2}  +3;
    |          ^^^^^
    '
+    input.scss 11:10  root stylesheet
 
-DEPRECATION WARNING on line 11, column 8 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     #{1 + 2} + 3
 
@@ -67,10 +67,12 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
    ,
 11 |   baz: #{1  +2}  +3;
    |        ^^^^^^^^^^^^
    '
+    input.scss 11:8  root stylesheet
 
 Error: Undefined operation "2 * 3".
    ,

--- a/spec/libsass-closed-issues/issue_1739/interpolate/right.hrx
+++ b/spec/libsass-closed-issues/issue_1739/interpolate/right.hrx
@@ -34,8 +34,7 @@ mod {
   baz: 3 %  #{1  %  2};
 }
 <===> error
-DEPRECATION WARNING on line 11, column 14 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     1 + 2
 
@@ -48,13 +47,14 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
    ,
 11 |   baz: 3  +#{1  +2};
    |              ^^^^^
    '
+    input.scss 11:14  root stylesheet
 
-DEPRECATION WARNING on line 11, column 8 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     3 + #{1 + 2}
 
@@ -67,10 +67,12 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
    ,
 11 |   baz: 3  +#{1  +2};
    |        ^^^^^^^^^^^^
    '
+    input.scss 11:8  root stylesheet
 
 Error: Undefined operation "3 * 2".
    ,

--- a/spec/libsass-closed-issues/issue_1766.hrx
+++ b/spec/libsass-closed-issues/issue_1766.hrx
@@ -18,20 +18,22 @@ foo { bar: baz }
 }
 
 <===> warning
-DEPRECATION WARNING on line 1, column 22 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @media all { @import "foo.scss" }
   |                      ^^^^^^^^^^
   '
+    input.scss 1:22  root stylesheet
 
-DEPRECATION WARNING on line 2, column 22 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @media all { @import "foo.scss"; }
   |                      ^^^^^^^^^^
   '
+    input.scss 2:22  root stylesheet

--- a/spec/libsass-closed-issues/issue_1801/import-cycle.hrx
+++ b/spec/libsass-closed-issues/issue_1801/import-cycle.hrx
@@ -8,32 +8,38 @@
 @import 'alpha';
 
 <===> error
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import 'alpha';
   |         ^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
-DEPRECATION WARNING on line 1, column 9 of _alpha.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import 'beta';
   |         ^^^^^^
   '
+    _alpha.scss 1:9  @import
+    input.scss 1:9   root stylesheet
 
-DEPRECATION WARNING on line 1, column 9 of _beta.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import 'alpha';
   |         ^^^^^^^
   '
+    _beta.scss 1:9   @import
+    _alpha.scss 1:9  @import
+    input.scss 1:9   root stylesheet
 
 Error: This file is already being loaded.
   ,--> _beta.scss

--- a/spec/libsass-closed-issues/issue_2106/test.hrx
+++ b/spec/libsass-closed-issues/issue_2106/test.hrx
@@ -2,14 +2,15 @@
 @import "../does-not-exist";
 
 <===> error
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "../does-not-exist";
   |         ^^^^^^^^^^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 Error: Can't find stylesheet to import.
   ,

--- a/spec/libsass-closed-issues/issue_2233.hrx
+++ b/spec/libsass-closed-issues/issue_2233.hrx
@@ -14,11 +14,12 @@ a { b: c; }
 }
 
 <===> warning
-DEPRECATION WARNING on line 2, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 |   @import "foo"
   |           ^^^^^
   '
+    input.scss 2:11  root stylesheet

--- a/spec/libsass-closed-issues/issue_2295/basic.hrx
+++ b/spec/libsass-closed-issues/issue_2295/basic.hrx
@@ -12,11 +12,12 @@
 }
 
 <===> warning
-DEPRECATION WARNING on line 2, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 |   @import 'include.scss';
   |           ^^^^^^^^^^^^^^
   '
+    input.scss 2:11  root stylesheet

--- a/spec/libsass-closed-issues/issue_2295/original.hrx
+++ b/spec/libsass-closed-issues/issue_2295/original.hrx
@@ -28,11 +28,12 @@ $include-foo: true !default;
 }
 
 <===> warning
-DEPRECATION WARNING on line 7, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 7 |   @import 'input-bug';
   |           ^^^^^^^^^^^
   '
+    input.scss 7:11  root stylesheet

--- a/spec/libsass-closed-issues/issue_2303.hrx
+++ b/spec/libsass-closed-issues/issue_2303.hrx
@@ -21,11 +21,12 @@
 }
 
 <===> warning
-DEPRECATION WARNING on line 2, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 |   @import 'module';
   |           ^^^^^^^^
   '
+    input.scss 2:11  root stylesheet

--- a/spec/libsass-closed-issues/issue_2304.hrx
+++ b/spec/libsass-closed-issues/issue_2304.hrx
@@ -9,14 +9,15 @@
   background: red;
 }
 <===> error
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "module";
   |         ^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 Error: Top-level selectors may not contain the parent selector "&".
   ,

--- a/spec/libsass-closed-issues/issue_279.hrx
+++ b/spec/libsass-closed-issues/issue_279.hrx
@@ -18,11 +18,12 @@
 }
 
 <===> warning
-DEPRECATION WARNING on line 2, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 |   @import "foo.scss";
   |           ^^^^^^^^^^
   '
+    input.scss 2:11  root stylesheet

--- a/spec/libsass-closed-issues/issue_759.hrx
+++ b/spec/libsass-closed-issues/issue_759.hrx
@@ -23,45 +23,113 @@ foo {
 }
 
 <===> warning
-DEPRECATION WARNING on line 3, column 19 of input.scss: 
-!default should only be written once for each variable.
+DEPRECATION WARNING: !default should only be written once for each variable.
 This will be an error in Dart Sass 2.0.0.
+
   ,
 3 | $c: 30px !default !default !default !global !global !global;
   |                   ^^^^^^^^
   '
+    input.scss 3:19  root stylesheet
 
-DEPRECATION WARNING on line 3, column 28 of input.scss: 
-!default should only be written once for each variable.
+DEPRECATION WARNING: !default should only be written once for each variable.
 This will be an error in Dart Sass 2.0.0.
+
   ,
 3 | $c: 30px !default !default !default !global !global !global;
   |                            ^^^^^^^^
   '
+    input.scss 3:28  root stylesheet
 
-DEPRECATION WARNING on line 3, column 45 of input.scss: 
-!global should only be written once for each variable.
+DEPRECATION WARNING: !global should only be written once for each variable.
 This will be an error in Dart Sass 2.0.0.
+
   ,
 3 | $c: 30px !default !default !default !global !global !global;
   |                                             ^^^^^^^
   '
+    input.scss 3:45  root stylesheet
 
-DEPRECATION WARNING on line 3, column 53 of input.scss: 
-!global should only be written once for each variable.
+DEPRECATION WARNING: !global should only be written once for each variable.
 This will be an error in Dart Sass 2.0.0.
+
   ,
 3 | $c: 30px !default !default !default !global !global !global;
   |                                                     ^^^^^^^
   '
+    input.scss 3:53  root stylesheet
 
-DEPRECATION WARNING on line 4, column 18 of input.scss: 
-!global should only be written once for each variable.
+DEPRECATION WARNING: !global should only be written once for each variable.
 This will be an error in Dart Sass 2.0.0.
+
   ,
 4 | $d: 40px !global !global !global !default !default !default;
   |                  ^^^^^^^
   '
+    input.scss 4:18  root stylesheet
+
+DEPRECATION WARNING: !global should only be written once for each variable.
+This will be an error in Dart Sass 2.0.0.
+
+  ,
+4 | $d: 40px !global !global !global !default !default !default;
+  |                          ^^^^^^^
+  '
+    input.scss 4:26  root stylesheet
+
+DEPRECATION WARNING: !default should only be written once for each variable.
+This will be an error in Dart Sass 2.0.0.
+
+  ,
+4 | $d: 40px !global !global !global !default !default !default;
+  |                                           ^^^^^^^^
+  '
+    input.scss 4:43  root stylesheet
+
+DEPRECATION WARNING: !default should only be written once for each variable.
+This will be an error in Dart Sass 2.0.0.
+
+  ,
+4 | $d: 40px !global !global !global !default !default !default;
+  |                                                    ^^^^^^^^
+  '
+    input.scss 4:52  root stylesheet
+
+DEPRECATION WARNING: !global should only be written once for each variable.
+This will be an error in Dart Sass 2.0.0.
+
+  ,
+5 | $e: 50px !global !default !global !default !global !default;
+  |                           ^^^^^^^
+  '
+    input.scss 5:27  root stylesheet
+
+DEPRECATION WARNING: !default should only be written once for each variable.
+This will be an error in Dart Sass 2.0.0.
+
+  ,
+5 | $e: 50px !global !default !global !default !global !default;
+  |                                   ^^^^^^^^
+  '
+    input.scss 5:35  root stylesheet
+
+DEPRECATION WARNING: !global should only be written once for each variable.
+This will be an error in Dart Sass 2.0.0.
+
+  ,
+5 | $e: 50px !global !default !global !default !global !default;
+  |                                            ^^^^^^^
+  '
+    input.scss 5:44  root stylesheet
+
+DEPRECATION WARNING: !default should only be written once for each variable.
+This will be an error in Dart Sass 2.0.0.
+
+  ,
+5 | $e: 50px !global !default !global !default !global !default;
+  |                                                    ^^^^^^^^
+  '
+    input.scss 5:52  root stylesheet
 
 DEPRECATION WARNING: As of Dart Sass 2.0.0, !global assignments won't be able to declare new variables.
 

--- a/spec/libsass-closed-issues/issue_893.hrx
+++ b/spec/libsass-closed-issues/issue_893.hrx
@@ -10,8 +10,7 @@ $gutter: 20px;
 }
 
 <===> warning
-DEPRECATION WARNING on line 4, column 11 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     0 - $gutter
 
@@ -24,7 +23,9 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
   ,
 4 |   margin: 0 -$gutter;
   |           ^^^^^^^^^^
   '
+    input.scss 4:11  root stylesheet

--- a/spec/libsass-todo-issues/issue_1763.hrx
+++ b/spec/libsass-todo-issues/issue_1763.hrx
@@ -17,11 +17,12 @@ foo {
 }
 
 <===> warning
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "first.scss", "second.scss" (max-width: 400px);
   |         ^^^^^^^^^^^^
   '
+    input.scss 2:9  root stylesheet

--- a/spec/libsass-todo-issues/issue_1801/simple-import-loop.hrx
+++ b/spec/libsass-todo-issues/issue_1801/simple-import-loop.hrx
@@ -5,23 +5,26 @@
 @import 'susy';
 
 <===> error
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import 'susy';
   |         ^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
-DEPRECATION WARNING on line 1, column 9 of _susy.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import 'susy';
   |         ^^^^^^
   '
+    _susy.scss 1:9  @import
+    input.scss 1:9  root stylesheet
 
 Error: This file is already being loaded.
   ,--> _susy.scss

--- a/spec/libsass-todo-issues/issue_2295/error/basic.hrx
+++ b/spec/libsass-todo-issues/issue_2295/error/basic.hrx
@@ -6,14 +6,15 @@
 display: none;
 
 <===> error
-DEPRECATION WARNING on line 2, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 |   @import 'include.scss';
   |           ^^^^^^^^^^^^^^
   '
+    input.scss 2:11  root stylesheet
 
 Error: expected "{".
   ,

--- a/spec/libsass-todo-issues/issue_2295/error/wrapped.hrx
+++ b/spec/libsass-todo-issues/issue_2295/error/wrapped.hrx
@@ -7,14 +7,15 @@
   display: none;
 }
 <===> error
-DEPRECATION WARNING on line 2, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 |   @import 'include.scss';
   |           ^^^^^^^^^^^^^^
   '
+    input.scss 2:11  root stylesheet
 
 Error: expected "{".
   ,

--- a/spec/libsass/base-level-parent/imported/at-root-alone-itpl.hrx
+++ b/spec/libsass/base-level-parent/imported/at-root-alone-itpl.hrx
@@ -10,14 +10,15 @@
 }
 
 <===> error
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "include.scss";
   |         ^^^^^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 Error: expected selector.
   ,

--- a/spec/libsass/base-level-parent/imported/at-root-alone.hrx
+++ b/spec/libsass/base-level-parent/imported/at-root-alone.hrx
@@ -9,14 +9,15 @@
   }
 }
 <===> error
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "include.scss";
   |         ^^^^^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 Error: Top-level selectors may not contain the parent selector "&".
   ,

--- a/spec/libsass/base-level-parent/imported/at-root-postfix-itpl.hrx
+++ b/spec/libsass/base-level-parent/imported/at-root-postfix-itpl.hrx
@@ -15,11 +15,12 @@ post foo {
 }
 
 <===> warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "include.scss";
   |         ^^^^^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet

--- a/spec/libsass/base-level-parent/imported/at-root-postfix.hrx
+++ b/spec/libsass/base-level-parent/imported/at-root-postfix.hrx
@@ -9,14 +9,15 @@
   }
 }
 <===> error
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "include.scss";
   |         ^^^^^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 Error: Top-level selectors may not contain the parent selector "&".
   ,

--- a/spec/libsass/base-level-parent/imported/at-root-prefix-itpl.hrx
+++ b/spec/libsass/base-level-parent/imported/at-root-prefix-itpl.hrx
@@ -15,11 +15,12 @@ pre foo {
 }
 
 <===> warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "include.scss";
   |         ^^^^^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet

--- a/spec/libsass/base-level-parent/imported/at-root-prefix.hrx
+++ b/spec/libsass/base-level-parent/imported/at-root-prefix.hrx
@@ -9,14 +9,15 @@
   }
 }
 <===> error
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "include.scss";
   |         ^^^^^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 Error: "&" may only used at the beginning of a compound selector.
   ,

--- a/spec/libsass/base-level-parent/imported/basic-alone-itpl.hrx
+++ b/spec/libsass/base-level-parent/imported/basic-alone-itpl.hrx
@@ -8,14 +8,15 @@
 }
 
 <===> error
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "include.scss";
   |         ^^^^^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 Error: expected selector.
   ,

--- a/spec/libsass/base-level-parent/imported/basic-alone.hrx
+++ b/spec/libsass/base-level-parent/imported/basic-alone.hrx
@@ -8,14 +8,15 @@
 }
 
 <===> error
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "include.scss";
   |         ^^^^^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 Error: Top-level selectors may not contain the parent selector "&".
   ,

--- a/spec/libsass/base-level-parent/imported/basic-postfix-itpl.hrx
+++ b/spec/libsass/base-level-parent/imported/basic-postfix-itpl.hrx
@@ -13,11 +13,12 @@ post foo {
 }
 
 <===> warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "include.scss";
   |         ^^^^^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet

--- a/spec/libsass/base-level-parent/imported/basic-postfix.hrx
+++ b/spec/libsass/base-level-parent/imported/basic-postfix.hrx
@@ -7,14 +7,15 @@
   }
 }
 <===> error
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "include.scss";
   |         ^^^^^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 Error: Top-level selectors may not contain the parent selector "&".
   ,

--- a/spec/libsass/base-level-parent/imported/basic-prefix-itpl.hrx
+++ b/spec/libsass/base-level-parent/imported/basic-prefix-itpl.hrx
@@ -13,11 +13,12 @@ pre foo {
 }
 
 <===> warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "include.scss";
   |         ^^^^^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet

--- a/spec/libsass/base-level-parent/imported/basic-prefix.hrx
+++ b/spec/libsass/base-level-parent/imported/basic-prefix.hrx
@@ -7,14 +7,15 @@ pre& {
   }
 }
 <===> error
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "include.scss";
   |         ^^^^^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
 Error: "&" may only used at the beginning of a compound selector.
   ,

--- a/spec/libsass/bourbon.hrx
+++ b/spec/libsass/bourbon.hrx
@@ -1932,50 +1932,565 @@ div {
 }
 
 <===> warning
-DEPRECATION WARNING on line 2, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "lib/_bourbon.scss";
   |         ^^^^^^^^^^^^^^^^^^^
   '
+    input.scss 2:9  root stylesheet
 
-DEPRECATION WARNING on line 2, column 9 of lib/_bourbon.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 2 | @import "helpers/deprecated-webkit-gradient";
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   '
+    lib/_bourbon.scss 2:9  @import
+    input.scss 2:9         root stylesheet
 
-DEPRECATION WARNING on line 3, column 9 of lib/_bourbon.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 3 | @import "helpers/gradient-positions-parser";
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   '
+    lib/_bourbon.scss 3:9  @import
+    input.scss 2:9         root stylesheet
 
-DEPRECATION WARNING on line 4, column 9 of lib/_bourbon.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 4 | @import "helpers/linear-positions-parser";
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   '
+    lib/_bourbon.scss 4:9  @import
+    input.scss 2:9         root stylesheet
 
-DEPRECATION WARNING on line 5, column 9 of lib/_bourbon.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 5 | @import "helpers/radial-arg-parser";
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   '
+    lib/_bourbon.scss 5:9  @import
+    input.scss 2:9         root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+  ,
+6 | @import "helpers/radial-positions-parser";
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+    lib/_bourbon.scss 6:9  @import
+    input.scss 2:9         root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+  ,
+7 | @import "helpers/render-gradients";
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+    lib/_bourbon.scss 7:9  @import
+    input.scss 2:9         root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+  ,
+8 | @import "helpers/shape-size-stripper";
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+    lib/_bourbon.scss 8:9  @import
+    input.scss 2:9         root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+11 | @import "functions/compact";
+   |         ^^^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 11:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+12 | @import "functions/flex-grid";
+   |         ^^^^^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 12:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+13 | @import "functions/grid-width";
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 13:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+14 | @import "functions/linear-gradient";
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 14:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+15 | @import "functions/modular-scale";
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 15:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+16 | @import "functions/px-to-em";
+   |         ^^^^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 16:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+17 | @import "functions/radial-gradient";
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 17:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+18 | @import "functions/tint-shade";
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 18:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+19 | @import "functions/transition-property-name";
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 19:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+22 | @import "css3/animation";
+   |         ^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 22:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+23 | @import "css3/appearance";
+   |         ^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 23:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+24 | @import "css3/backface-visibility";
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 24:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+25 | @import "css3/background";
+   |         ^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 25:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+26 | @import "css3/background-image";
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 26:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+27 | @import "css3/border-image";
+   |         ^^^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 27:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+28 | @import "css3/border-radius";
+   |         ^^^^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 28:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+29 | @import "css3/box-sizing";
+   |         ^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 29:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+30 | @import "css3/columns";
+   |         ^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 30:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+31 | @import "css3/flex-box";
+   |         ^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 31:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+32 | @import "css3/font-face";
+   |         ^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 32:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+33 | @import "css3/hidpi-media-query";
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 33:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+34 | @import "css3/image-rendering";
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 34:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+35 | @import "css3/inline-block";
+   |         ^^^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 35:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+36 | @import "css3/keyframes";
+   |         ^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 36:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+37 | @import "css3/linear-gradient";
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 37:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+38 | @import "css3/perspective";
+   |         ^^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 38:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+39 | @import "css3/radial-gradient";
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 39:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+40 | @import "css3/transform";
+   |         ^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 40:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+41 | @import "css3/transition";
+   |         ^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 41:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+42 | @import "css3/user-select";
+   |         ^^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 42:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+43 | @import "css3/placeholder";
+   |         ^^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 43:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+46 | @import "addons/button";
+   |         ^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 46:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+47 | @import "addons/clearfix";
+   |         ^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 47:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+48 | @import "addons/font-family";
+   |         ^^^^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 48:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+49 | @import "addons/hide-text";
+   |         ^^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 49:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+50 | @import "addons/html5-input-types";
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 50:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+51 | @import "addons/position";
+   |         ^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 51:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+52 | @import "addons/prefixer";
+   |         ^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 52:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+53 | @import "addons/retina-image";
+   |         ^^^^^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 53:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+54 | @import "addons/size";
+   |         ^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 54:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+55 | @import "addons/timing-functions";
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 55:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+56 | @import "addons/triangle";
+   |         ^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 56:9  @import
+    input.scss 2:9          root stylesheet
+
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+   ,
+59 | @import "bourbon-deprecated-upcoming";
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   '
+    lib/_bourbon.scss 59:9  @import
+    input.scss 2:9          root stylesheet
 
 DEPRECATION WARNING: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
 Use string.unquote instead.

--- a/spec/non_conformant/basic/14_imports.hrx
+++ b/spec/non_conformant/basic/14_imports.hrx
@@ -58,38 +58,43 @@ foo blux {
 }
 
 <===> warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "a.scss";
   |         ^^^^^^^^
   '
+    input.scss 1:9  root stylesheet
 
-DEPRECATION WARNING on line 7, column 13 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 7 |     @import "../14_imports/b.scss";
   |             ^^^^^^^^^^^^^^^^^^^^^^
   '
+    input.scss 7:13  root stylesheet
 
-DEPRECATION WARNING on line 10, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
    ,
 10 |   @import "sub/c.scss";
    |           ^^^^^^^^^^^^
    '
+    input.scss 10:11  root stylesheet
 
-DEPRECATION WARNING on line 4, column 11 of b.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 4 |   @import "d.scss";
   |           ^^^^^^^^
   '
+    b.scss 4:11      @import
+    input.scss 7:13  root stylesheet

--- a/spec/non_conformant/errors/import/file/control-else.hrx
+++ b/spec/non_conformant/errors/import/file/control-else.hrx
@@ -7,15 +7,6 @@
 <===> _include.scss
 
 <===> error
-DEPRECATION WARNING on line 3, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
-
-More info and automated migrator: https://sass-lang.com/d/import
-  ,
-3 |   @import '_include';
-  |           ^^^^^^^^^^
-  '
-
 Error: This at-rule is not allowed here.
   ,
 3 |   @import '_include';

--- a/spec/non_conformant/errors/import/file/control-if.hrx
+++ b/spec/non_conformant/errors/import/file/control-if.hrx
@@ -6,15 +6,6 @@
 <===> _include.scss
 
 <===> error
-DEPRECATION WARNING on line 2, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
-
-More info and automated migrator: https://sass-lang.com/d/import
-  ,
-2 |   @import '_include';
-  |           ^^^^^^^^^^
-  '
-
 Error: This at-rule is not allowed here.
   ,
 2 |   @import '_include';

--- a/spec/non_conformant/errors/import/file/loop/each.hrx
+++ b/spec/non_conformant/errors/import/file/loop/each.hrx
@@ -6,15 +6,6 @@
 <===> _include.scss
 
 <===> error
-DEPRECATION WARNING on line 2, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
-
-More info and automated migrator: https://sass-lang.com/d/import
-  ,
-2 |   @import '_include';
-  |           ^^^^^^^^^^
-  '
-
 Error: This at-rule is not allowed here.
   ,
 2 |   @import '_include';

--- a/spec/non_conformant/errors/import/file/loop/for.hrx
+++ b/spec/non_conformant/errors/import/file/loop/for.hrx
@@ -6,15 +6,6 @@
 <===> _include.scss
 
 <===> error
-DEPRECATION WARNING on line 2, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
-
-More info and automated migrator: https://sass-lang.com/d/import
-  ,
-2 |   @import '_include';
-  |           ^^^^^^^^^^
-  '
-
 Error: This at-rule is not allowed here.
   ,
 2 |   @import '_include';

--- a/spec/non_conformant/errors/import/file/loop/while.hrx
+++ b/spec/non_conformant/errors/import/file/loop/while.hrx
@@ -8,15 +8,6 @@ $count: 0;
 <===> _include.scss
 
 <===> error
-DEPRECATION WARNING on line 3, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
-
-More info and automated migrator: https://sass-lang.com/d/import
-  ,
-3 |   @import '_include';
-  |           ^^^^^^^^^^
-  '
-
 Error: This at-rule is not allowed here.
   ,
 3 |   @import '_include';

--- a/spec/non_conformant/errors/import/file/mixin/control-else/inside.hrx
+++ b/spec/non_conformant/errors/import/file/mixin/control-else/inside.hrx
@@ -12,15 +12,6 @@ foo {
 <===> _include.scss
 
 <===> error
-DEPRECATION WARNING on line 4, column 13 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
-
-More info and automated migrator: https://sass-lang.com/d/import
-  ,
-4 |     @import '_include';
-  |             ^^^^^^^^^^
-  '
-
 Error: This at-rule is not allowed here.
   ,
 4 |     @import '_include';

--- a/spec/non_conformant/errors/import/file/mixin/control-else/outside.hrx
+++ b/spec/non_conformant/errors/import/file/mixin/control-else/outside.hrx
@@ -11,15 +11,6 @@
 <===> _include.scss
 
 <===> error
-DEPRECATION WARNING on line 2, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
-
-More info and automated migrator: https://sass-lang.com/d/import
-  ,
-2 |   @import '_include';
-  |           ^^^^^^^^^^
-  '
-
 Error: This at-rule is not allowed here.
   ,
 2 |   @import '_include';

--- a/spec/non_conformant/errors/import/file/mixin/control-if/inside.hrx
+++ b/spec/non_conformant/errors/import/file/mixin/control-if/inside.hrx
@@ -11,15 +11,6 @@ foo {
 <===> _include.scss
 
 <===> error
-DEPRECATION WARNING on line 3, column 13 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
-
-More info and automated migrator: https://sass-lang.com/d/import
-  ,
-3 |     @import '_include';
-  |             ^^^^^^^^^^
-  '
-
 Error: This at-rule is not allowed here.
   ,
 3 |     @import '_include';

--- a/spec/non_conformant/errors/import/file/mixin/control-if/outside.hrx
+++ b/spec/non_conformant/errors/import/file/mixin/control-if/outside.hrx
@@ -9,15 +9,6 @@
 <===> _include.scss
 
 <===> error
-DEPRECATION WARNING on line 2, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
-
-More info and automated migrator: https://sass-lang.com/d/import
-  ,
-2 |   @import '_include';
-  |           ^^^^^^^^^^
-  '
-
 Error: This at-rule is not allowed here.
   ,
 2 |   @import '_include';

--- a/spec/non_conformant/errors/import/miss/control-else.hrx
+++ b/spec/non_conformant/errors/import/miss/control-else.hrx
@@ -5,15 +5,6 @@
 }
 
 <===> error
-DEPRECATION WARNING on line 3, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
-
-More info and automated migrator: https://sass-lang.com/d/import
-  ,
-3 |   @import '_include';
-  |           ^^^^^^^^^^
-  '
-
 Error: This at-rule is not allowed here.
   ,
 3 |   @import '_include';

--- a/spec/non_conformant/errors/import/miss/control-if.hrx
+++ b/spec/non_conformant/errors/import/miss/control-if.hrx
@@ -4,15 +4,6 @@
 }
 
 <===> error
-DEPRECATION WARNING on line 2, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
-
-More info and automated migrator: https://sass-lang.com/d/import
-  ,
-2 |   @import '_include';
-  |           ^^^^^^^^^^
-  '
-
 Error: This at-rule is not allowed here.
   ,
 2 |   @import '_include';

--- a/spec/non_conformant/errors/import/miss/loop/each.hrx
+++ b/spec/non_conformant/errors/import/miss/loop/each.hrx
@@ -4,15 +4,6 @@
 }
 
 <===> error
-DEPRECATION WARNING on line 2, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
-
-More info and automated migrator: https://sass-lang.com/d/import
-  ,
-2 |   @import '_include';
-  |           ^^^^^^^^^^
-  '
-
 Error: This at-rule is not allowed here.
   ,
 2 |   @import '_include';

--- a/spec/non_conformant/errors/import/miss/loop/for.hrx
+++ b/spec/non_conformant/errors/import/miss/loop/for.hrx
@@ -4,15 +4,6 @@
 }
 
 <===> error
-DEPRECATION WARNING on line 2, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
-
-More info and automated migrator: https://sass-lang.com/d/import
-  ,
-2 |   @import '_include';
-  |           ^^^^^^^^^^
-  '
-
 Error: This at-rule is not allowed here.
   ,
 2 |   @import '_include';

--- a/spec/non_conformant/errors/import/miss/loop/while.hrx
+++ b/spec/non_conformant/errors/import/miss/loop/while.hrx
@@ -6,15 +6,6 @@ $count: 0;
 }
 
 <===> error
-DEPRECATION WARNING on line 3, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
-
-More info and automated migrator: https://sass-lang.com/d/import
-  ,
-3 |   @import '_include';
-  |           ^^^^^^^^^^
-  '
-
 Error: This at-rule is not allowed here.
   ,
 3 |   @import '_include';

--- a/spec/non_conformant/errors/import/miss/mixin/control-else/inside.hrx
+++ b/spec/non_conformant/errors/import/miss/mixin/control-else/inside.hrx
@@ -10,15 +10,6 @@ foo {
   @include do_import();
 }
 <===> error
-DEPRECATION WARNING on line 4, column 13 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
-
-More info and automated migrator: https://sass-lang.com/d/import
-  ,
-4 |     @import '_include';
-  |             ^^^^^^^^^^
-  '
-
 Error: This at-rule is not allowed here.
   ,
 4 |     @import '_include';

--- a/spec/non_conformant/errors/import/miss/mixin/control-else/outside.hrx
+++ b/spec/non_conformant/errors/import/miss/mixin/control-else/outside.hrx
@@ -9,15 +9,6 @@
 }
 
 <===> error
-DEPRECATION WARNING on line 2, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
-
-More info and automated migrator: https://sass-lang.com/d/import
-  ,
-2 |   @import '_include';
-  |           ^^^^^^^^^^
-  '
-
 Error: This at-rule is not allowed here.
   ,
 2 |   @import '_include';

--- a/spec/non_conformant/errors/import/miss/mixin/control-if/inside.hrx
+++ b/spec/non_conformant/errors/import/miss/mixin/control-if/inside.hrx
@@ -9,15 +9,6 @@ foo {
   @include do_import();
 }
 <===> error
-DEPRECATION WARNING on line 3, column 13 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
-
-More info and automated migrator: https://sass-lang.com/d/import
-  ,
-3 |     @import '_include';
-  |             ^^^^^^^^^^
-  '
-
 Error: This at-rule is not allowed here.
   ,
 3 |     @import '_include';

--- a/spec/non_conformant/errors/import/miss/mixin/control-if/outside.hrx
+++ b/spec/non_conformant/errors/import/miss/mixin/control-if/outside.hrx
@@ -7,15 +7,6 @@
   @include do_import();
 }
 <===> error
-DEPRECATION WARNING on line 2, column 11 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
-
-More info and automated migrator: https://sass-lang.com/d/import
-  ,
-2 |   @import '_include';
-  |           ^^^^^^^^^^
-  '
-
 Error: This at-rule is not allowed here.
   ,
 2 |   @import '_include';

--- a/spec/non_conformant/parser/and_and.hrx
+++ b/spec/non_conformant/parser/and_and.hrx
@@ -9,9 +9,10 @@
 }
 
 <===> warning
-WARNING on line 2, column 15 of input.scss: 
-In Sass, "&&" means two copies of the parent selector. You probably want to use "and" instead.
+WARNING: In Sass, "&&" means two copies of the parent selector. You probably want to use "and" instead.
+
   ,
 2 |   value: true && false;
   |               ^^
   '
+    input.scss 2:15  root stylesheet

--- a/spec/non_conformant/parser/operations/addition/dimensions/pairs.hrx
+++ b/spec/non_conformant/parser/operations/addition/dimensions/pairs.hrx
@@ -175,8 +175,7 @@ foo {
 }
 
 <===> warning
-DEPRECATION WARNING on line 3, column 11 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     10 + 10
 
@@ -189,13 +188,14 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
   ,
 3 |   test-2: 10 +10;
   |           ^^^^^^
   '
+    input.scss 3:11  root stylesheet
 
-DEPRECATION WARNING on line 7, column 11 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     10 + 10px
 
@@ -208,13 +208,14 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
   ,
 7 |   test-6: 10 +10px;
   |           ^^^^^^^^
   '
+    input.scss 7:11  root stylesheet
 
-DEPRECATION WARNING on line 11, column 12 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     10 + #{10}px
 
@@ -227,13 +228,14 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
    ,
 11 |   test-10: 10 +#{10}px;
    |            ^^^^^^^^^^^
    '
+    input.scss 11:12  root stylesheet
 
-DEPRECATION WARNING on line 15, column 12 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     10 + 1
 
@@ -246,13 +248,14 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
    ,
 15 |   test-14: 10 +1#{0}px;
    |            ^^^^^
    '
+    input.scss 15:12  root stylesheet
 
-DEPRECATION WARNING on line 19, column 12 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     10 + 10
 
@@ -265,7 +268,329 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
    ,
 19 |   test-18: 10 +10#{px};
    |            ^^^^^^
    '
+    input.scss 19:12  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    10 + 10
+
+but you may have intended it to mean:
+
+    10 (+10)
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+23 |   test-22: 10 +10#{p}x;
+   |            ^^^^^^
+   '
+    input.scss 23:12  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    10px + 10px
+
+but you may have intended it to mean:
+
+    10px (+10px)
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+27 |   test-26: 10px +10px;
+   |            ^^^^^^^^^^
+   '
+    input.scss 27:12  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    10px + #{10}px
+
+but you may have intended it to mean:
+
+    10px (+#{10}px)
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+31 |   test-30: 10px +#{10}px;
+   |            ^^^^^^^^^^^^^
+   '
+    input.scss 31:12  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    10px + 1
+
+but you may have intended it to mean:
+
+    10px (+1)
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+35 |   test-34: 10px +1#{0}px;
+   |            ^^^^^^^
+   '
+    input.scss 35:12  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    10px + 10
+
+but you may have intended it to mean:
+
+    10px (+10)
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+39 |   test-38: 10px +10#{px};
+   |            ^^^^^^^^
+   '
+    input.scss 39:12  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    10px + 10
+
+but you may have intended it to mean:
+
+    10px (+10)
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+43 |   test-42: 10px +10#{p}x;
+   |            ^^^^^^^^
+   '
+    input.scss 43:12  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    #{10}px + #{10}px
+
+but you may have intended it to mean:
+
+    #{10}px (+#{10}px)
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+47 |   test-46: #{10}px +#{10}px;
+   |            ^^^^^^^^^^^^^^^^
+   '
+    input.scss 47:12  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    #{10}px + 1
+
+but you may have intended it to mean:
+
+    #{10}px (+1)
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+51 |   test-50: #{10}px +1#{0}px;
+   |            ^^^^^^^^^^
+   '
+    input.scss 51:12  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    #{10}px + 10
+
+but you may have intended it to mean:
+
+    #{10}px (+10)
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+55 |   test-54: #{10}px +10#{px};
+   |            ^^^^^^^^^^^
+   '
+    input.scss 55:12  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    #{10}px + 10
+
+but you may have intended it to mean:
+
+    #{10}px (+10)
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+59 |   test-58: #{10}px +10#{p}x;
+   |            ^^^^^^^^^^^
+   '
+    input.scss 59:12  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    #{0}px + 1
+
+but you may have intended it to mean:
+
+    #{0}px (+1)
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+63 |   test-62: 1#{0}px +1#{0}px;
+   |             ^^^^^^^^^
+   '
+    input.scss 63:13  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    #{0}px + 10
+
+but you may have intended it to mean:
+
+    #{0}px (+10)
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+67 |   test-66: 1#{0}px +10#{px};
+   |             ^^^^^^^^^^
+   '
+    input.scss 67:13  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    #{0}px + 10
+
+but you may have intended it to mean:
+
+    #{0}px (+10)
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+71 |   test-70: 1#{0}px +10#{p}x;
+   |             ^^^^^^^^^^
+   '
+    input.scss 71:13  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    #{px} + 10
+
+but you may have intended it to mean:
+
+    #{px} (+10)
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+75 |   test-74: 10#{px} +10#{px};
+   |              ^^^^^^^^^
+   '
+    input.scss 75:14  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    #{px} + 10
+
+but you may have intended it to mean:
+
+    #{px} (+10)
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+79 |   test-78: 10#{px} +10#{p}x;
+   |              ^^^^^^^^^
+   '
+    input.scss 79:14  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    #{p}x + 10
+
+but you may have intended it to mean:
+
+    #{p}x (+10)
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+83 |   test-82: 10#{p}x +10#{p}x;
+   |              ^^^^^^^^^
+   '
+    input.scss 83:14  root stylesheet

--- a/spec/non_conformant/parser/operations/addition/numbers/pairs.hrx
+++ b/spec/non_conformant/parser/operations/addition/numbers/pairs.hrx
@@ -87,8 +87,7 @@ foo {
 }
 
 <===> warning
-DEPRECATION WARNING on line 3, column 11 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     10 + 10
 
@@ -101,13 +100,14 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
   ,
 3 |   test-2: 10 +10;
   |           ^^^^^^
   '
+    input.scss 3:11  root stylesheet
 
-DEPRECATION WARNING on line 7, column 11 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     10 + #{10}
 
@@ -120,13 +120,14 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
   ,
 7 |   test-6: 10 +#{10};
   |           ^^^^^^^^^
   '
+    input.scss 7:11  root stylesheet
 
-DEPRECATION WARNING on line 11, column 12 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     10 + 1
 
@@ -139,13 +140,14 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
    ,
 11 |   test-10: 10 +1#{0};
    |            ^^^^^
    '
+    input.scss 11:12  root stylesheet
 
-DEPRECATION WARNING on line 15, column 12 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     10 + #{1}0
 
@@ -158,13 +160,14 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
    ,
 15 |   test-14: 10 +#{1}0;
    |            ^^^^^^^^^
    '
+    input.scss 15:12  root stylesheet
 
-DEPRECATION WARNING on line 19, column 12 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     #{10} + #{10}
 
@@ -177,7 +180,109 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
    ,
 19 |   test-18: #{10} +#{10};
    |            ^^^^^^^^^^^^
    '
+    input.scss 19:12  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    #{10} + 1
+
+but you may have intended it to mean:
+
+    #{10} (+1)
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+23 |   test-22: #{10} +1#{0};
+   |            ^^^^^^^^
+   '
+    input.scss 23:12  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    #{10} + #{1}0
+
+but you may have intended it to mean:
+
+    #{10} (+#{1}0)
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+27 |   test-26: #{10} +#{1}0;
+   |            ^^^^^^^^^^^^
+   '
+    input.scss 27:12  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    #{0} + 1
+
+but you may have intended it to mean:
+
+    #{0} (+1)
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+31 |   test-30: 1#{0} +1#{0};
+   |             ^^^^^^^
+   '
+    input.scss 31:13  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    #{0} + #{1}0
+
+but you may have intended it to mean:
+
+    #{0} (+#{1}0)
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+35 |   test-34: 1#{0} +#{1}0;
+   |             ^^^^^^^^^^^
+   '
+    input.scss 35:13  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    #{1}0 + #{1}0
+
+but you may have intended it to mean:
+
+    #{1}0 (+#{1}0)
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+39 |   test-38: #{1}0 +#{1}0;
+   |            ^^^^^^^^^^^^
+   '
+    input.scss 39:12  root stylesheet

--- a/spec/non_conformant/parser/operations/addition/strings/pairs.hrx
+++ b/spec/non_conformant/parser/operations/addition/strings/pairs.hrx
@@ -127,8 +127,7 @@ foo {
 }
 
 <===> warning
-DEPRECATION WARNING on line 3, column 11 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     literal + literal
 
@@ -141,13 +140,14 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
   ,
 3 |   test-2: literal +literal;
   |           ^^^^^^^^^^^^^^^^
   '
+    input.scss 3:11  root stylesheet
 
-DEPRECATION WARNING on line 7, column 11 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     literal + "quoted"
 
@@ -160,13 +160,14 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
   ,
 7 |   test-6: literal +"quoted";
   |           ^^^^^^^^^^^^^^^^^
   '
+    input.scss 7:11  root stylesheet
 
-DEPRECATION WARNING on line 11, column 12 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     literal + #{interpolant}
 
@@ -179,13 +180,14 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
    ,
 11 |   test-10: literal +#{interpolant};
    |            ^^^^^^^^^^^^^^^^^^^^^^^
    '
+    input.scss 11:12  root stylesheet
 
-DEPRECATION WARNING on line 15, column 12 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     literal + lschema_#{ritlp}
 
@@ -198,13 +200,14 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
    ,
 15 |   test-14: literal +lschema_#{ritlp};
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
    '
+    input.scss 15:12  root stylesheet
 
-DEPRECATION WARNING on line 19, column 12 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     literal + #{litlp}_rschema
 
@@ -217,7 +220,209 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
    ,
 19 |   test-18: literal +#{litlp}_rschema;
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
    '
+    input.scss 19:12  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    "quoted" + "quoted"
+
+but you may have intended it to mean:
+
+    "quoted" (+"quoted")
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+23 |   test-22: "quoted" +"quoted";
+   |            ^^^^^^^^^^^^^^^^^^
+   '
+    input.scss 23:12  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    "quoted" + #{interpolant}
+
+but you may have intended it to mean:
+
+    "quoted" (+#{interpolant})
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+27 |   test-26: "quoted" +#{interpolant};
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^
+   '
+    input.scss 27:12  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    "quoted" + lschema_#{ritlp}
+
+but you may have intended it to mean:
+
+    "quoted" (+lschema_#{ritlp})
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+31 |   test-30: "quoted" +lschema_#{ritlp};
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   '
+    input.scss 31:12  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    "quoted" + #{litlp}_rschema
+
+but you may have intended it to mean:
+
+    "quoted" (+#{litlp}_rschema)
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+35 |   test-34: "quoted" +#{litlp}_rschema;
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   '
+    input.scss 35:12  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    #{interpolant} + #{interpolant}
+
+but you may have intended it to mean:
+
+    #{interpolant} (+#{interpolant})
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+39 |   test-38: #{interpolant} +#{interpolant};
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   '
+    input.scss 39:12  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    #{interpolant} + lschema_#{ritlp}
+
+but you may have intended it to mean:
+
+    #{interpolant} (+lschema_#{ritlp})
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+43 |   test-42: #{interpolant} +lschema_#{ritlp};
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   '
+    input.scss 43:12  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    #{interpolant} + #{litlp}_rschema
+
+but you may have intended it to mean:
+
+    #{interpolant} (+#{litlp}_rschema)
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+47 |   test-46: #{interpolant} +#{litlp}_rschema;
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   '
+    input.scss 47:12  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    lschema_#{ritlp} + lschema_#{ritlp}
+
+but you may have intended it to mean:
+
+    lschema_#{ritlp} (+lschema_#{ritlp})
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+51 |   test-50: lschema_#{ritlp} +lschema_#{ritlp};
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   '
+    input.scss 51:12  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    lschema_#{ritlp} + #{litlp}_rschema
+
+but you may have intended it to mean:
+
+    lschema_#{ritlp} (+#{litlp}_rschema)
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+55 |   test-54: lschema_#{ritlp} +#{litlp}_rschema;
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   '
+    input.scss 55:12  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    #{litlp}_rschema + #{litlp}_rschema
+
+but you may have intended it to mean:
+
+    #{litlp}_rschema (+#{litlp}_rschema)
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+59 |   test-58: #{litlp}_rschema +#{litlp}_rschema;
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   '
+    input.scss 59:12  root stylesheet

--- a/spec/non_conformant/parser/operations/subtract/strings/pairs.hrx
+++ b/spec/non_conformant/parser/operations/subtract/strings/pairs.hrx
@@ -127,8 +127,7 @@ foo {
 }
 
 <===> warning
-DEPRECATION WARNING on line 7, column 11 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     literal - "quoted"
 
@@ -141,13 +140,14 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
   ,
 7 |   test-6: literal -"quoted";
   |           ^^^^^^^^^^^^^^^^^
   '
+    input.scss 7:11  root stylesheet
 
-DEPRECATION WARNING on line 23, column 12 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     "quoted" - "quoted"
 
@@ -160,7 +160,9 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
    ,
 23 |   test-22: "quoted" -"quoted";
    |            ^^^^^^^^^^^^^^^^^^
    '
+    input.scss 23:12  root stylesheet

--- a/spec/non_conformant/sass/import/unquoted.hrx
+++ b/spec/non_conformant/sass/import/unquoted.hrx
@@ -17,20 +17,22 @@ d {
 }
 
 <===> warning
-DEPRECATION WARNING on line 1, column 9 of input.sass: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import unquoted, sub/unquoted
   |         ^^^^^^^^
   '
+    input.sass 1:9  root stylesheet
 
-DEPRECATION WARNING on line 1, column 19 of input.sass: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import unquoted, sub/unquoted
   |                   ^^^^^^^^^^^^
   '
+    input.sass 1:19  root stylesheet

--- a/spec/non_conformant/sass/imported.hrx
+++ b/spec/non_conformant/sass/imported.hrx
@@ -16,11 +16,12 @@ div li {
 }
 
 <===> warning
-DEPRECATION WARNING on line 1, column 9 of input.scss: 
-Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+DEPRECATION WARNING: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
 
 More info and automated migrator: https://sass-lang.com/d/import
+
   ,
 1 | @import "imported.sass";
   |         ^^^^^^^^^^^^^^^
   '
+    input.scss 1:9  root stylesheet

--- a/spec/non_conformant/scss/interpolation-operators-precedence.hrx
+++ b/spec/non_conformant/scss/interpolation-operators-precedence.hrx
@@ -49,8 +49,7 @@
 }
 
 <===> error
-DEPRECATION WARNING on line 4, column 9 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     #{a} + 5%
 
@@ -63,13 +62,14 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
   ,
 4 |   a03: (#{a}  +5.0% + 2);
   |         ^^^^^^^^^^^
   '
+    input.scss 4:9  root stylesheet
 
-DEPRECATION WARNING on line 8, column 9 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     5 + 2% + #{a}
 
@@ -82,13 +82,14 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
   ,
 8 |   b03: (5 + 2.0%  +#{a});
   |         ^^^^^^^^^^^^^^^
   '
+    input.scss 8:9  root stylesheet
 
-DEPRECATION WARNING on line 10, column 9 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     #{a} + 5%
 
@@ -101,13 +102,14 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
    ,
 10 |   c01: (#{a} +5.0% + 2);
    |         ^^^^^^^^^^
    '
+    input.scss 10:9  root stylesheet
 
-DEPRECATION WARNING on line 14, column 9 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     #{a} + 5%
 
@@ -120,13 +122,14 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
    ,
 14 |   c05: (#{a} +5.0% - 2);
    |         ^^^^^^^^^^
    '
+    input.scss 14:9  root stylesheet
 
-DEPRECATION WARNING on line 18, column 9 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     #{a} + 5% / 2
 
@@ -139,10 +142,112 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
    ,
 18 |   c09: (#{a} +5.0% / 2);
    |         ^^^^^^^^^^^^^^
    '
+    input.scss 18:9  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    #{a} + 5% * 2
+
+but you may have intended it to mean:
+
+    #{a} (+5% * 2)
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+22 |   c13: (#{a} +5.0% * 2);
+   |         ^^^^^^^^^^^^^^
+   '
+    input.scss 22:9  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    5 + 2% + #{a}
+
+but you may have intended it to mean:
+
+    5 + 2% (+#{a})
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+26 |   d01: (5 + 2.0% +#{a});
+   |         ^^^^^^^^^^^^^^
+   '
+    input.scss 26:9  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    5 - 2% + #{a}
+
+but you may have intended it to mean:
+
+    5 - 2% (+#{a})
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+30 |   d05: (5 - 2.0% +#{a});
+   |         ^^^^^^^^^^^^^^
+   '
+    input.scss 30:9  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    5% / 2 + #{a}
+
+but you may have intended it to mean:
+
+    5% / 2 (+#{a})
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+34 |   d09: (5% / 2.0 +#{a});
+   |         ^^^^^^^^^^^^^^
+   '
+    input.scss 34:9  root stylesheet
+
+DEPRECATION WARNING: This operation is parsed as:
+
+    5 * 2% + #{a}
+
+but you may have intended it to mean:
+
+    5 * 2% (+#{a})
+
+Add a space after + to clarify that it's meant to be a binary operation, or wrap
+it in parentheses to make it a unary operation. This will be an error in future
+versions of Sass.
+
+More info and automated migrator: https://sass-lang.com/d/strict-unary
+
+   ,
+38 |   d13: (5 * 2.0% +#{a});
+   |         ^^^^^^^^^^^^^^
+   '
+    input.scss 38:9  root stylesheet
 
 Error: Undefined operation "a * 5%".
    ,

--- a/spec/operators/minus.hrx
+++ b/spec/operators/minus.hrx
@@ -27,8 +27,7 @@ a {
 }
 
 <===> syntax/whitespace/left/space/warning
-DEPRECATION WARNING on line 1, column 7 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     c - (d)
 
@@ -41,10 +40,12 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
   ,
 1 | a {b: c -(d)}
   |       ^^^^^^
   '
+    input.scss 1:7  root stylesheet
 
 <===>
 ================================================================================
@@ -57,8 +58,7 @@ a {
 }
 
 <===> syntax/whitespace/left/tab/warning
-DEPRECATION WARNING on line 1, column 7 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     c - (d)
 
@@ -71,10 +71,12 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
   ,
 1 | a {b: c    -(d)}
   |       ^^^^^^^^^
   '
+    input.scss 1:7  root stylesheet
 
 <===>
 ================================================================================
@@ -88,8 +90,7 @@ a {
 }
 
 <===> syntax/whitespace/left/newline/warning
-DEPRECATION WARNING on line 1, column 7 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     c - (d)
 
@@ -102,12 +103,14 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
   ,
 1 |   a {b: c
   | ,-------^
 2 | | -(d)}
   | '----^
   '
+    input.scss 1:7  root stylesheet
 
 <===>
 ================================================================================

--- a/spec/operators/plus.hrx
+++ b/spec/operators/plus.hrx
@@ -27,8 +27,7 @@ a {
 }
 
 <===> syntax/whitespace/left/space/warning
-DEPRECATION WARNING on line 1, column 7 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     c + d
 
@@ -41,10 +40,12 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
   ,
 1 | a {b: c +d}
   |       ^^^^
   '
+    input.scss 1:7  root stylesheet
 
 <===>
 ================================================================================
@@ -57,8 +58,7 @@ a {
 }
 
 <===> syntax/whitespace/left/tab/warning
-DEPRECATION WARNING on line 1, column 7 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     c + d
 
@@ -71,10 +71,12 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
   ,
 1 | a {b: c    +d}
   |       ^^^^^^^
   '
+    input.scss 1:7  root stylesheet
 
 <===>
 ================================================================================
@@ -88,8 +90,7 @@ a {
 }
 
 <===> syntax/whitespace/left/newline/warning
-DEPRECATION WARNING on line 1, column 7 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     c + d
 
@@ -102,12 +103,14 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
   ,
 1 |   a {b: c
   | ,-------^
 2 | | +d}
   | '--^
   '
+    input.scss 1:7  root stylesheet
 
 <===>
 ================================================================================

--- a/spec/values/calculation/calc/error/syntax.hrx
+++ b/spec/values/calculation/calc/error/syntax.hrx
@@ -147,8 +147,7 @@ Error: "+" and "-" must be surrounded by whitespace in calculations.
 a {b: calc(1 +1)}
 
 <===> no_whitespace/plus/after/error
-DEPRECATION WARNING on line 1, column 12 of input.scss: 
-This operation is parsed as:
+DEPRECATION WARNING: This operation is parsed as:
 
     1 + 1
 
@@ -161,10 +160,12 @@ it in parentheses to make it a unary operation. This will be an error in future
 versions of Sass.
 
 More info and automated migrator: https://sass-lang.com/d/strict-unary
+
   ,
 1 | a {b: calc(1 +1)}
   |            ^^^^
   '
+    input.scss 1:12  root stylesheet
 
 Error: "+" and "-" must be surrounded by whitespace in calculations.
   ,

--- a/spec/variables.hrx
+++ b/spec/variables.hrx
@@ -29,13 +29,14 @@ c {
 }
 
 <===> double_flag/default/warning
-DEPRECATION WARNING on line 1, column 16 of input.scss: 
-!default should only be written once for each variable.
+DEPRECATION WARNING: !default should only be written once for each variable.
 This will be an error in Dart Sass 2.0.0.
+
   ,
 1 | $a: b !default !default;
   |                ^^^^^^^^
   '
+    input.scss 1:16  root stylesheet
 
 <===>
 ================================================================================
@@ -52,13 +53,14 @@ c {
 }
 
 <===> double_flag/global/warning
-DEPRECATION WARNING on line 3, column 17 of input.scss: 
-!global should only be written once for each variable.
+DEPRECATION WARNING: !global should only be written once for each variable.
 This will be an error in Dart Sass 2.0.0.
+
   ,
 3 |   $a: d !global !global;
   |                 ^^^^^^^
   '
+    input.scss 3:17  root stylesheet
 
 <===>
 ================================================================================


### PR DESCRIPTION
This is mostly just minor formatting changes, now that parse-time warnings include traces

[skip dart-sass]