### PR TITLE
Add tests for CSS `round()` with one argument

### DIFF
--- a/spec/values/calculation/abs.hrx
+++ b/spec/values/calculation/abs.hrx
@@ -64,6 +64,17 @@ a {
   b: 2px;
 }
 
+<===> preserves_single_unit/warning
+DEPRECATION WARNING: In future versions of Sass, abs() will be interpreted as the CSS abs() calculation. This doesn't allow unitless numbers to be mixed with numbers with units. If you want to use the Sass function, call math.abs() instead.
+
+See https://sass-lang.com/d/import
+
+  ,
+1 | a {b: abs(1 + 1px)}
+  |           ^^^^^^^
+  '
+    input.scss 1:11  root stylesheet
+
 <===>
 ================================================================================
 <===> sass_script/input.scss

--- a/spec/values/calculation/max.hrx
+++ b/spec/values/calculation/max.hrx
@@ -211,6 +211,17 @@ a {
   b: 3.4px;
 }
 
+<===> simplified/operation/unitless_and_real/warning
+DEPRECATION WARNING: In future versions of Sass, max() will be interpreted as the CSS max() calculation. This doesn't allow unitless numbers to be mixed with numbers with units. If you want to use the Sass function, call math.max() instead.
+
+See https://sass-lang.com/d/import
+
+  ,
+1 | a {b: max(1px, 2.5 + 0.9px)}
+  |                ^^^^^^^^^^^
+  '
+    input.scss 1:16  root stylesheet
+
 <===>
 ================================================================================
 <===> preserved/math/first/input.scss
@@ -292,6 +303,17 @@ a {
   b: max(1%, 3.4px);
 }
 
+<===> preserved/operation/unitless_and_real/plus/warning
+DEPRECATION WARNING: In future versions of Sass, max() will be interpreted as the CSS max() calculation. This doesn't allow unitless numbers to be mixed with numbers with units. If you want to use the Sass function, call math.max() instead.
+
+See https://sass-lang.com/d/import
+
+  ,
+1 | a {b: max(1%, 2.5 + 0.9px)}
+  |               ^^^^^^^^^^^
+  '
+    input.scss 1:15  root stylesheet
+
 <===>
 ================================================================================
 <===> preserved/operation/unitless_and_real/minus/input.scss
@@ -302,6 +324,17 @@ a {
   b: max(1%, 1.6px);
 }
 
+<===> preserved/operation/unitless_and_real/minus/warning
+DEPRECATION WARNING: In future versions of Sass, max() will be interpreted as the CSS max() calculation. This doesn't allow unitless numbers to be mixed with numbers with units. If you want to use the Sass function, call math.max() instead.
+
+See https://sass-lang.com/d/import
+
+  ,
+1 | a {b: max(1%, 2.5 - 0.9px)}
+  |               ^^^^^^^^^^^
+  '
+    input.scss 1:15  root stylesheet
+
 <===>
 ================================================================================
 <===> preserved/operation/unitless_and_real/in_calc/input.scss
@@ -311,6 +344,17 @@ a {b: calc(max(1%, 2.5 + 0.9px))}
 a {
   b: max(1%, 3.4px);
 }
+
+<===> preserved/operation/unitless_and_real/in_calc/warning
+DEPRECATION WARNING: In future versions of Sass, max() will be interpreted as the CSS max() calculation. This doesn't allow unitless numbers to be mixed with numbers with units. If you want to use the Sass function, call math.max() instead.
+
+See https://sass-lang.com/d/import
+
+  ,
+1 | a {b: calc(max(1%, 2.5 + 0.9px))}
+  |                    ^^^^^^^^^^^
+  '
+    input.scss 1:20  root stylesheet
 
 <===>
 ================================================================================

--- a/spec/values/calculation/min.hrx
+++ b/spec/values/calculation/min.hrx
@@ -211,6 +211,17 @@ a {
   b: 1px;
 }
 
+<===> simplified/operation/unitless_and_real/warning
+DEPRECATION WARNING: In future versions of Sass, min() will be interpreted as the CSS min() calculation. This doesn't allow unitless numbers to be mixed with numbers with units. If you want to use the Sass function, call math.min() instead.
+
+See https://sass-lang.com/d/import
+
+  ,
+1 | a {b: min(1px, 2.5 + 0.9px)}
+  |                ^^^^^^^^^^^
+  '
+    input.scss 1:16  root stylesheet
+
 <===>
 ================================================================================
 <===> preserved/math/first/input.scss
@@ -292,6 +303,17 @@ a {
   b: min(1%, 3.4px);
 }
 
+<===> preserved/operation/unitless_and_real/plus/warning
+DEPRECATION WARNING: In future versions of Sass, min() will be interpreted as the CSS min() calculation. This doesn't allow unitless numbers to be mixed with numbers with units. If you want to use the Sass function, call math.min() instead.
+
+See https://sass-lang.com/d/import
+
+  ,
+1 | a {b: min(1%, 2.5 + 0.9px)}
+  |               ^^^^^^^^^^^
+  '
+    input.scss 1:15  root stylesheet
+
 <===>
 ================================================================================
 <===> preserved/operation/unitless_and_real/minus/input.scss
@@ -302,6 +324,17 @@ a {
   b: min(1%, 1.6px);
 }
 
+<===> preserved/operation/unitless_and_real/minus/warning
+DEPRECATION WARNING: In future versions of Sass, min() will be interpreted as the CSS min() calculation. This doesn't allow unitless numbers to be mixed with numbers with units. If you want to use the Sass function, call math.min() instead.
+
+See https://sass-lang.com/d/import
+
+  ,
+1 | a {b: min(1%, 2.5 - 0.9px)}
+  |               ^^^^^^^^^^^
+  '
+    input.scss 1:15  root stylesheet
+
 <===>
 ================================================================================
 <===> preserved/operation/unitless_and_real/in_calc/input.scss
@@ -311,6 +344,17 @@ a {b: calc(min(1%, 2.5 + 0.9px))}
 a {
   b: min(1%, 3.4px);
 }
+
+<===> preserved/operation/unitless_and_real/in_calc/warning
+DEPRECATION WARNING: In future versions of Sass, min() will be interpreted as the CSS min() calculation. This doesn't allow unitless numbers to be mixed with numbers with units. If you want to use the Sass function, call math.min() instead.
+
+See https://sass-lang.com/d/import
+
+  ,
+1 | a {b: calc(min(1%, 2.5 + 0.9px))}
+  |                    ^^^^^^^^^^^
+  '
+    input.scss 1:20  root stylesheet
 
 <===>
 ================================================================================

--- a/spec/values/calculation/round/error.hrx
+++ b/spec/values/calculation/round/error.hrx
@@ -54,19 +54,6 @@ Error: $number: var(--c) is not a number.
 
 <===>
 ================================================================================
-<===> one_argument/unsimplifiable/input.scss
-a {b: round(1px + 2px - var(--c))}
-
-<===> one_argument/unsimplifiable/error
-Error: Single argument 3px - var(--c) expected to be simplifiable.
-  ,
-1 | a {b: round(1px + 2px - var(--c))}
-  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  '
-  input.scss 1:7  root stylesheet
-
-<===>
-================================================================================
 <===> one_argument/type/input.scss
 a {b: round("0")}
 

--- a/spec/values/calculation/round/one_argument.hrx
+++ b/spec/values/calculation/round/one_argument.hrx
@@ -42,6 +42,17 @@ a {
   b: -2px;
 }
 
+<===> preserves_units/warning
+DEPRECATION WARNING: In future versions of Sass, round() will be interpreted as a CSS round() calculation. This requires an explicit modulus when rounding numbers with units. If you want to use the Sass function, call math.round() instead.
+
+See https://sass-lang.com/d/import
+
+  ,
+1 | a {b: round(-7px / 4em) * 1em}
+  |       ^^^^^^^^^^^^^^^^^
+  '
+    input.scss 1:7  root stylesheet
+
 <===>
 ================================================================================
 <===> preserves_single_unit/input.scss
@@ -51,6 +62,27 @@ a {b: round(1 + 1px)}
 a {
   b: 2px;
 }
+
+<===> preserves_single_unit/warning
+DEPRECATION WARNING: In future versions of Sass, round() will be interpreted as the CSS round() calculation. This doesn't allow unitless numbers to be mixed with numbers with units. If you want to use the Sass function, call math.round() instead.
+
+See https://sass-lang.com/d/import
+
+  ,
+1 | a {b: round(1 + 1px)}
+  |             ^^^^^^^
+  '
+    input.scss 1:13  root stylesheet
+
+DEPRECATION WARNING: In future versions of Sass, round() will be interpreted as a CSS round() calculation. This requires an explicit modulus when rounding numbers with units. If you want to use the Sass function, call math.round() instead.
+
+See https://sass-lang.com/d/import
+
+  ,
+1 | a {b: round(1 + 1px)}
+  |       ^^^^^^^^^^^^^^
+  '
+    input.scss 1:7  root stylesheet
 
 <===>
 ================================================================================
@@ -127,4 +159,14 @@ a {b: round(1.1)}
 <===> overridden/output.css
 a {
   b: 1.1;
+}
+
+<===>
+================================================================================
+<===> unsimplifiable/input.scss
+a {b: round(1px + 2px - var(--c))}
+
+<===> unsimplifiable/output.css
+a {
+  b: round(3px - var(--c));
 }


### PR DESCRIPTION
This also updates tests expect global function warnings when
calculations are falling back on global Sass functions.

See sass/sass#3803
Closes #2036

[skip dart-sass]