### PR TITLE
Test `@extend` without a selector

### DIFF
--- a/spec/directives/extend/error.hrx
+++ b/spec/directives/extend/error.hrx
@@ -34,3 +34,16 @@ See https://sass-lang.com/d/extend-compound for details.
   |           ^^^^^^^
   '
   input.scss 5:11  root stylesheet
+
+<===>
+================================================================================
+<===> no_selector/input.scss
+a {@extend}
+
+<===> no_selector/error
+Error: expected selector.
+  ,
+1 | a {@extend}
+  |           ^
+  '
+  input.scss 1:11  root stylesheet


### PR DESCRIPTION
See sass/dart-sass#2497

[skip dart-sass]