### PR TITLE
Fix tests for top-level nesting selectors in loaded plain CSS

### DIFF
--- a/spec/css/plain/style_rule.hrx
+++ b/spec/css/plain/style_rule.hrx
@@ -220,9 +220,11 @@ a {@include meta.load-css("plain")}
 & {b {c: d}}
 
 <===> nesting/through_load_css/top_level_parent/output.css
-a & {
-  b {
-    c: d;
+a {
+  & {
+    b {
+      c: d;
+    }
   }
 }
 
@@ -285,9 +287,11 @@ a {@import "plain"}
 & {b {c: d}}
 
 <===> nesting/through_import/top_level_parent/output.css
-a & {
-  b {
-    c: d;
+a {
+  & {
+    b {
+      c: d;
+    }
   }
 }
 


### PR DESCRIPTION
See sass/sass#4055
See sass/sass#4060

[skip dart-sass]