### PR TITLE
Fix test for increasing number precision in inspect mode

### DIFF
--- a/spec/values/numbers/units/multiple/division_cancels_compatible.hrx
+++ b/spec/values/numbers/units/multiple/division_cancels_compatible.hrx
@@ -1,37 +1,37 @@
 <===> input.scss
 @use "sass:meta";
-$number: 1px * 1rad / 1ms / 1Hz;
+$number: 96px * 1rad / 1ms / 1Hz;
 a {
   b: meta.inspect($number / 1in);
 }
 
 <===> output.css
 a {
-  b: calc(0.0104166667rad / 1ms / 1Hz);
+  b: calc(1rad / 1ms / 1Hz);
 }
 
 <===> warning
 DEPRECATION WARNING [slash-div]: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.
 
-Recommendation: math.div(1px * 1rad, 1ms) or calc(1px * 1rad / 1ms)
+Recommendation: math.div(96px * 1rad, 1ms) or calc(96px * 1rad / 1ms)
 
 More info and automated migrator: https://sass-lang.com/d/slash-div
 
   ,
-2 | $number: 1px * 1rad / 1ms / 1Hz;
-  |          ^^^^^^^^^^^^^^^^
+2 | $number: 96px * 1rad / 1ms / 1Hz;
+  |          ^^^^^^^^^^^^^^^^^
   '
     input.scss 2:10  root stylesheet
 
 DEPRECATION WARNING [slash-div]: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.
 
-Recommendation: math.div(math.div(1px * 1rad, 1ms), 1Hz) or calc(1px * 1rad / 1ms / 1Hz)
+Recommendation: math.div(math.div(96px * 1rad, 1ms), 1Hz) or calc(96px * 1rad / 1ms / 1Hz)
 
 More info and automated migrator: https://sass-lang.com/d/slash-div
 
   ,
-2 | $number: 1px * 1rad / 1ms / 1Hz;
-  |          ^^^^^^^^^^^^^^^^^^^^^^
+2 | $number: 96px * 1rad / 1ms / 1Hz;
+  |          ^^^^^^^^^^^^^^^^^^^^^^^
   '
     input.scss 2:10  root stylesheet
 


### PR DESCRIPTION
I think the output format of `meta.inspect` shouldn't really be part of the spec, and this is purely being abused because there is no other good way to test this, as the output here is not a valid css.

This PR fixes the test failure in https://github.com/sass/dart-sass/pull/2615 by producing an integer output which is independent of inspect mode or not.