### PR TITLE
Fix `ts-node` wrapper on windows

### DIFF
--- a/ts-node-wrapper.mjs
+++ b/ts-node-wrapper.mjs
@@ -10,8 +10,7 @@
 import {execFileSync} from 'node:child_process';
 
 try {
-  execFileSync('node', ['--no-experimental-strip-types', '-e', ''], {
-    shell: process.platform === 'win32',
+  execFileSync(process.execPath, ['--no-experimental-strip-types', '-e', 'undefined'], {
     stdio: 'ignore',
   });
 


### PR DESCRIPTION
@nex3 Here is the fix for the wrapper. The issue turns out to be the `shell: true` is stripping the last empty argument which is actually necessary...