### PR TITLE
New deprecation test for case insensitive function names

### DIFF
--- a/spec/directives/function/name.hrx
+++ b/spec/directives/function/name.hrx
@@ -209,3 +209,25 @@ Error: This name is reserved for the plain-CSS function.
   |           ^^^^
   '
   input.scss 1:11  root stylesheet
+
+<===>
+================================================================================
+<===> case-insensitive-reserved-function-name/EXPRESSION/input.scss
+@function EXPRESSION() {@return 1}
+a {b: EXPRESSION()}
+
+<===> case-insensitive-reserved-function-name/EXPRESSION/output.css
+a {
+  b: expression();
+}
+
+<===>
+================================================================================
+<===> case-insensitive-reserved-function-name/URL/input.scss
+@function URL() {@return 1}
+a {b: URL()}
+
+<===> case-insensitive-reserved-function-name/URL/output.css
+a {
+  b: url();
+}

--- a/spec/directives/function/name.hrx
+++ b/spec/directives/function/name.hrx
@@ -221,6 +221,17 @@ a {
   b: expression();
 }
 
+<===> case-insensitive-reserved-function-name/EXPRESSION/warning-dart-sass
+DEPRECATION WARNING [case-insensitive-function-names]: Function names that only differ by case from reserved names are deprecated and will be disallowed in a future release.
+
+  ,
+1 | @function EXPRESSION() {@return 1}
+  |           ^^^
+  '
+    input.scss 1:11  root stylesheet
+
+
+
 <===>
 ================================================================================
 <===> case-insensitive-reserved-function-name/URL/input.scss
@@ -231,3 +242,14 @@ a {b: URL()}
 a {
   b: url();
 }
+
+<===> case-insensitive-reserved-function-name/URL/warning-dart-sass
+DEPRECATION WARNING [case-insensitive-function-names]: Function names that only differ by case from reserved names are deprecated and will be disallowed in a future release.
+
+  ,
+1 | @function URL() {@return 1}
+  |           ^^^
+  '
+    input.scss 1:11  root stylesheet
+
+


### PR DESCRIPTION
In this repo I added deprecation test for case-insensitive function names in spec/directives/function/name.hrx.
