### PR TITLE
Add sass-spec tests for deprecated case-insensitive function names

### DIFF
--- a/spec/directives/function/name.hrx
+++ b/spec/directives/function/name.hrx
@@ -176,3 +176,36 @@ Error: This name is reserved for the plain-CSS function.
   |           ^^^^
   '
   input.scss 1:11  root stylesheet
+
+
+<===>
+================================================================================
+<===> warning/special/url/case_insensitive/input.scss
+@function URL() {@return 1}
+
+<===> warning/special/url/case_insensitive/output.css
+
+<===> warning/special/url/case_insensitive/warning
+DEPRECATION WARNING [case-insensitive-function]: Function names that differ from reserved names only by case are deprecated.
+
+  ,
+1 | @function URL() {@return 1}
+  |           ^^^^^
+  '
+    input.scss 1:11  root stylesheet
+
+<===>
+================================================================================
+<===> warning/special/expression/case_insensitive/input.scss
+@function EXPRESSION() {@return 1}
+
+<===> warning/special/expression/case_insensitive/output.css
+
+<===> warning/special/expression/case_insensitive/warning
+DEPRECATION WARNING [case-insensitive-function]: Function names that differ from reserved names only by case are deprecated.
+
+  ,
+1 | @function EXPRESSION() {@return 1}
+  |           ^^^^^^^^^^^^
+  '
+    input.scss 1:11  root stylesheet


### PR DESCRIPTION
Tests for case-insensitive function name deprecation:

- Dart Sass emits warning: https://github.com/sass/dart-sass/pull/2716
- Deprecation entry: https://github.com/sass/sass/pull/4175
- Marked [skip dart-sass] so it only runs in Dart Sass, because only Dart Sass emits this deprecation warning.