### PR TITLE
Update tests to forbid passing strings to `meta.call()`

### DIFF
--- a/js-api-spec/deprecations.test.ts
+++ b/js-api-spec/deprecations.test.ts
@@ -35,22 +35,23 @@ describe('a warning', () => {
     });
   });
 
-  it('is emitted with different deprecation type silenced', done => {
-    compileString('@import "other"', {
-      importers: [emptyStylesheetImporter],
-      logger: {
-        warn(
-          message: string,
-          {
-            deprecationType,
-          }: {deprecation: boolean; deprecationType?: Deprecation}
-        ) {
-          expect(deprecationType).toEqual(deprecations['import']);
-          done();
-        },
-      },
-      silenceDeprecations: ['call-string'],
-    });
+  // Excluding this test until we add post-2.0.0 deprecations.
+  xit('is emitted with different deprecation type silenced', done => {
+    // compileString('@import "other"', {
+    //   importers: [emptyStylesheetImporter],
+    //   logger: {
+    //     warn(
+    //       message: string,
+    //       {
+    //         deprecationType,
+    //       }: {deprecation: boolean; deprecationType?: Deprecation}
+    //     ) {
+    //       expect(deprecationType).toEqual(deprecations['import']);
+    //       done();
+    //     },
+    //   },
+    //   silenceDeprecations: ['call-string'],
+    // });
   });
 
   it('is not emitted when deprecation silenced', () => {

--- a/spec/core_functions/meta/call.hrx
+++ b/spec/core_functions/meta/call.hrx
@@ -69,51 +69,6 @@ a {
 
 <===>
 ================================================================================
-<===> string/local/input.scss
-@use "sass:meta";
-@function a($arg) {@return $arg + 1}
-a {b: meta.call("a", 1)}
-
-<===> string/local/output.css
-a {
-  b: 2;
-}
-
-<===> string/local/warning
-DEPRECATION WARNING [call-string]: Passing a string to call() is deprecated and will be illegal in Dart Sass 2.0.0.
-
-Recommendation: call(get-function("a"))
-
-  ,
-3 | a {b: meta.call("a", 1)}
-  |       ^^^^^^^^^^^^^^^^^
-  '
-    input.scss 3:7  root stylesheet
-
-<===>
-================================================================================
-<===> string/built_in/input.scss
-@use "sass:meta";
-a {b: meta.call("rgb", 1, 2, 3)}
-
-<===> string/built_in/output.css
-a {
-  b: rgb(1, 2, 3);
-}
-
-<===> string/built_in/warning
-DEPRECATION WARNING [call-string]: Passing a string to call() is deprecated and will be illegal in Dart Sass 2.0.0.
-
-Recommendation: call(get-function("rgb"))
-
-  ,
-2 | a {b: meta.call("rgb", 1, 2, 3)}
-  |       ^^^^^^^^^^^^^^^^^^^^^^^^^
-  '
-    input.scss 2:7  root stylesheet
-
-<===>
-================================================================================
 <===> named/input.scss
 @use "sass:meta";
 a {b: meta.call($function: meta.get-function("rgb"), $red: 1, $green: 2, $blue: 3)}
@@ -166,6 +121,37 @@ Error: $channels: The rgb color space has 3 channels but 1 has 1.
   ,
 2 | a {b: meta.call(meta.get-function("rgb"), 1)}
   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  '
+  input.scss 2:7  root stylesheet
+
+<===>
+================================================================================
+<===> error/string/local/input.scss
+@use "sass:meta";
+@function a($arg) {@return $arg + 1}
+a {b: meta.call("a", 1)}
+
+<===> error/string/local/error
+Error: $function: "a" is not a function reference.
+Call meta.get-function() to get a reference for a function name.
+  ,
+3 | a {b: meta.call("a", 1)}
+  |       ^^^^^^^^^^^^^^^^^
+  '
+  input.scss 3:7  root stylesheet
+
+<===>
+================================================================================
+<===> error/string/built_in/input.scss
+@use "sass:meta";
+a {b: meta.call("rgb", 1, 2, 3)}
+
+<===> error/string/built_in/error
+Error: $function: "rgb" is not a function reference.
+Call meta.get-function() to get a reference for a function name.
+  ,
+2 | a {b: meta.call("rgb", 1, 2, 3)}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^
   '
   input.scss 2:7  root stylesheet
 

--- a/spec/libsass-closed-issues/issue_1075.hrx
+++ b/spec/libsass-closed-issues/issue_1075.hrx
@@ -7,17 +7,8 @@ foo {
 }
 
 <===> error
-DEPRECATION WARNING [call-string]: Passing a string to call() is deprecated and will be illegal in Dart Sass 2.0.0.
-
-Recommendation: call(get-function("lighten"))
-
-  ,
-5 |   bar: meta.call($name, $args...);
-  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  '
-    input.scss 5:8  root stylesheet
-
-Error: Plain CSS functions don't support keyword arguments.
+Error: $function: "lighten" is not a function reference.
+Call meta.get-function() to get a reference for a function name.
   ,
 5 |   bar: meta.call($name, $args...);
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/spec/libsass-closed-issues/issue_1133/normal.hrx
+++ b/spec/libsass-closed-issues/issue_1133/normal.hrx
@@ -18,24 +18,11 @@ b {
     }
 }
 
-<===> output.css
-a {
-  this: is;
-  my: map;
-}
-
-b {
-  this: is;
-  my: map;
-}
-
-<===> warning
-DEPRECATION WARNING [call-string]: Passing a string to call() is deprecated and will be illegal in Dart Sass 2.0.0.
-
-Recommendation: call(get-function("foo"))
-
+<===> error
+Error: $function: "foo" is not a function reference.
+Call meta.get-function() to get a reference for a function name.
    ,
 14 |     $map: meta.call("foo", (this: is, my: map));
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    '
-    input.scss 14:11  root stylesheet
+  input.scss 14:11  root stylesheet

--- a/spec/libsass-closed-issues/issue_1133/vararg.hrx
+++ b/spec/libsass-closed-issues/issue_1133/vararg.hrx
@@ -18,24 +18,11 @@ b {
   }
 }
 
-<===> output.css
-a {
-  this: is;
-  my: map;
-}
-
-b {
-  this: is;
-  my: map;
-}
-
-<===> warning
-DEPRECATION WARNING [call-string]: Passing a string to call() is deprecated and will be illegal in Dart Sass 2.0.0.
-
-Recommendation: call(get-function("foo"))
-
+<===> error
+Error: $function: "foo" is not a function reference.
+Call meta.get-function() to get a reference for a function name.
    ,
 14 |   $map: meta.call("foo", (this: is, my: map)...);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    '
-    input.scss 14:9  root stylesheet
+  input.scss 14:9  root stylesheet

--- a/spec/libsass-closed-issues/issue_1266/max.hrx
+++ b/spec/libsass-closed-issues/issue_1266/max.hrx
@@ -6,28 +6,8 @@ foo {
 }
 
 <===> error
-DEPRECATION WARNING [call-string]: Passing a string to call() is deprecated and will be illegal in Dart Sass 2.0.0.
-
-Recommendation: call(get-function(max))
-
-  ,
-4 |   bar: meta.call(max, $foo...);
-  |        ^^^^^^^^^^^^^^^^^^^^^^^
-  '
-    input.scss 4:8  root stylesheet
-
-DEPRECATION WARNING [global-builtin]: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
-Use math.max instead.
-
-More info and automated migrator: https://sass-lang.com/d/import
-
-  ,
-4 |   bar: meta.call(max, $foo...);
-  |        ^^^^^^^^^^^^^^^^^^^^^^^
-  '
-    input.scss 4:8  root stylesheet
-
-Error: blah is not a number.
+Error: $function: max is not a function reference.
+Call meta.get-function() to get a reference for a function name.
   ,
 4 |   bar: meta.call(max, $foo...);
   |        ^^^^^^^^^^^^^^^^^^^^^^^

--- a/spec/libsass-closed-issues/issue_1266/min.hrx
+++ b/spec/libsass-closed-issues/issue_1266/min.hrx
@@ -6,28 +6,8 @@ foo {
 }
 
 <===> error
-DEPRECATION WARNING [call-string]: Passing a string to call() is deprecated and will be illegal in Dart Sass 2.0.0.
-
-Recommendation: call(get-function(min))
-
-  ,
-4 |   bar: meta.call(min, $foo...);
-  |        ^^^^^^^^^^^^^^^^^^^^^^^
-  '
-    input.scss 4:8  root stylesheet
-
-DEPRECATION WARNING [global-builtin]: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
-Use math.min instead.
-
-More info and automated migrator: https://sass-lang.com/d/import
-
-  ,
-4 |   bar: meta.call(min, $foo...);
-  |        ^^^^^^^^^^^^^^^^^^^^^^^
-  '
-    input.scss 4:8  root stylesheet
-
-Error: blah is not a number.
+Error: $function: min is not a function reference.
+Call meta.get-function() to get a reference for a function name.
   ,
 4 |   bar: meta.call(min, $foo...);
   |        ^^^^^^^^^^^^^^^^^^^^^^^

--- a/spec/libsass-closed-issues/issue_1305.hrx
+++ b/spec/libsass-closed-issues/issue_1305.hrx
@@ -4,29 +4,11 @@
     content: meta.call('unquote', 'foo', ()...);
 }
 
-<===> output.css
-.foo {
-  content: foo;
-}
-
-<===> warning
-DEPRECATION WARNING [call-string]: Passing a string to call() is deprecated and will be illegal in Dart Sass 2.0.0.
-
-Recommendation: call(get-function("unquote"))
-
+<===> error
+Error: $function: "unquote" is not a function reference.
+Call meta.get-function() to get a reference for a function name.
   ,
 3 |     content: meta.call('unquote', 'foo', ()...);
   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   '
-    input.scss 3:14  root stylesheet
-
-DEPRECATION WARNING [global-builtin]: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
-Use string.unquote instead.
-
-More info and automated migrator: https://sass-lang.com/d/import
-
-  ,
-3 |     content: meta.call('unquote', 'foo', ()...);
-  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  '
-    input.scss 3:14  root stylesheet
+  input.scss 3:14  root stylesheet

--- a/spec/libsass-closed-issues/issue_1417.hrx
+++ b/spec/libsass-closed-issues/issue_1417.hrx
@@ -13,22 +13,11 @@ foo {
   foo: meta.call(missing, 1px / 2px, 1px / math.round(1.5));
 }
 
-<===> output.css
-foo {
-  foo: 1px / 2px;
-  foo: 1px / 2;
-  foo: 1px / 2px 1px / 2;
-  foo: missing(1px / 2px, 1px / 2);
-  foo: missing(1px / 2px, 1px / 2);
-}
-
-<===> warning
-DEPRECATION WARNING [call-string]: Passing a string to call() is deprecated and will be illegal in Dart Sass 2.0.0.
-
-Recommendation: call(get-function(missing))
-
+<===> error
+Error: $function: missing is not a function reference.
+Call meta.get-function() to get a reference for a function name.
    ,
 12 |   foo: meta.call(missing, 1px / 2px, 1px / math.round(1.5));
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    '
-    input.scss 12:8  root stylesheet
+  input.scss 12:8  root stylesheet

--- a/spec/libsass-closed-issues/issue_1418/dynamic.hrx
+++ b/spec/libsass-closed-issues/issue_1418/dynamic.hrx
@@ -5,17 +5,8 @@ foo {
 }
 
 <===> error
-DEPRECATION WARNING [call-string]: Passing a string to call() is deprecated and will be illegal in Dart Sass 2.0.0.
-
-Recommendation: call(get-function(missing))
-
-  ,
-3 |     color: meta.call(missing, $a: b);
-  |            ^^^^^^^^^^^^^^^^^^^^^^^^^
-  '
-    input.scss 3:12  root stylesheet
-
-Error: Plain CSS functions don't support keyword arguments.
+Error: $function: missing is not a function reference.
+Call meta.get-function() to get a reference for a function name.
   ,
 3 |     color: meta.call(missing, $a: b);
   |            ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/spec/libsass-closed-issues/issue_1488.hrx
+++ b/spec/libsass-closed-issues/issue_1488.hrx
@@ -37,106 +37,11 @@ bar {
   bar: meta.call('bar_', one, two);
   bar: meta.call('bar_', one, two...);
 }
-<===> output.css
-foo {
-  foo: string;
-  foo: string;
-  bar: string::string;
-  bar: string::string;
-  foo: string;
-  foo: string;
-  bar: string::string;
-  bar: string::string;
-}
-
-bar {
-  foo: arglist;
-  foo: arglist;
-  bar: string::arglist;
-  bar: string::arglist;
-  foo: arglist;
-  foo: arglist;
-  bar: string::arglist;
-  bar: string::arglist;
-}
-
-<===> warning
-DEPRECATION WARNING [call-string]: Passing a string to call() is deprecated and will be illegal in Dart Sass 2.0.0.
-
-Recommendation: call(get-function("foo"))
-
+<===> error
+Error: $function: "foo" is not a function reference.
+Call meta.get-function() to get a reference for a function name.
    ,
 23 |   foo: meta.call('foo', one);
    |        ^^^^^^^^^^^^^^^^^^^^^
    '
-    input.scss 23:8  root stylesheet
-
-DEPRECATION WARNING [call-string]: Passing a string to call() is deprecated and will be illegal in Dart Sass 2.0.0.
-
-Recommendation: call(get-function("foo"))
-
-   ,
-24 |   foo: meta.call('foo', one...);
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^
-   '
-    input.scss 24:8  root stylesheet
-
-DEPRECATION WARNING [call-string]: Passing a string to call() is deprecated and will be illegal in Dart Sass 2.0.0.
-
-Recommendation: call(get-function("bar"))
-
-   ,
-25 |   bar: meta.call('bar', one, two);
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   '
-    input.scss 25:8  root stylesheet
-
-DEPRECATION WARNING [call-string]: Passing a string to call() is deprecated and will be illegal in Dart Sass 2.0.0.
-
-Recommendation: call(get-function("bar"))
-
-   ,
-26 |   bar: meta.call('bar', one, two...);
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   '
-    input.scss 26:8  root stylesheet
-
-DEPRECATION WARNING [call-string]: Passing a string to call() is deprecated and will be illegal in Dart Sass 2.0.0.
-
-Recommendation: call(get-function("foo_"))
-
-   ,
-34 |   foo: meta.call('foo_', one);
-   |        ^^^^^^^^^^^^^^^^^^^^^^
-   '
-    input.scss 34:8  root stylesheet
-
-DEPRECATION WARNING [call-string]: Passing a string to call() is deprecated and will be illegal in Dart Sass 2.0.0.
-
-Recommendation: call(get-function("foo_"))
-
-   ,
-35 |   foo: meta.call('foo_', one...);
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^
-   '
-    input.scss 35:8  root stylesheet
-
-DEPRECATION WARNING [call-string]: Passing a string to call() is deprecated and will be illegal in Dart Sass 2.0.0.
-
-Recommendation: call(get-function("bar_"))
-
-   ,
-36 |   bar: meta.call('bar_', one, two);
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   '
-    input.scss 36:8  root stylesheet
-
-DEPRECATION WARNING [call-string]: Passing a string to call() is deprecated and will be illegal in Dart Sass 2.0.0.
-
-Recommendation: call(get-function("bar_"))
-
-   ,
-37 |   bar: meta.call('bar_', one, two...);
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   '
-    input.scss 37:8  root stylesheet
+  input.scss 23:8  root stylesheet

--- a/spec/libsass-closed-issues/issue_1566.hrx
+++ b/spec/libsass-closed-issues/issue_1566.hrx
@@ -12,19 +12,12 @@ test {
   test: foo(1 2 3);
 }
 
-<===> output.css
-test {
-  test: list;
-}
-
-<===> warning
-DEPRECATION WARNING [call-string]: Passing a string to call() is deprecated and will be illegal in Dart Sass 2.0.0.
-
-Recommendation: call(get-function("bar"))
-
+<===> error
+Error: $function: "bar" is not a function reference.
+Call meta.get-function() to get a reference for a function name.
   ,
 3 |   @return meta.call('bar', $predicate);
   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   '
-    input.scss 3:11  foo()
-    input.scss 11:9  root stylesheet
+  input.scss 3:11  foo()
+  input.scss 11:9  root stylesheet

--- a/spec/libsass-closed-issues/issue_1579.hrx
+++ b/spec/libsass-closed-issues/issue_1579.hrx
@@ -12,19 +12,12 @@ test {
   test: bar(3, $c: true);
 }
 
-<===> output.css
-test {
-  test: true;
-}
-
-<===> warning
-DEPRECATION WARNING [call-string]: Passing a string to call() is deprecated and will be illegal in Dart Sass 2.0.0.
-
-Recommendation: call(get-function(foo))
-
+<===> error
+Error: $function: foo is not a function reference.
+Call meta.get-function() to get a reference for a function name.
   ,
 7 |   @return meta.call(foo, $args...);
   |           ^^^^^^^^^^^^^^^^^^^^^^^^
   '
-    input.scss 7:11  bar()
-    input.scss 11:9  root stylesheet
+  input.scss 7:11  bar()
+  input.scss 11:9  root stylesheet

--- a/spec/libsass-closed-issues/issue_1622.hrx
+++ b/spec/libsass-closed-issues/issue_1622.hrx
@@ -13,19 +13,12 @@ test {
   test: foo(1 2 3);
 }
 
-<===> output.css
-test {
-  test: 3;
-}
-
-<===> warning
-DEPRECATION WARNING [call-string]: Passing a string to call() is deprecated and will be illegal in Dart Sass 2.0.0.
-
-Recommendation: call(get-function(bar))
-
+<===> error
+Error: $function: bar is not a function reference.
+Call meta.get-function() to get a reference for a function name.
   ,
 4 |     @return meta.call(bar, $list);
   |             ^^^^^^^^^^^^^^^^^^^^^
   '
-    input.scss 4:13  foo()
-    input.scss 12:9  root stylesheet
+  input.scss 4:13  foo()
+  input.scss 12:9  root stylesheet

--- a/spec/libsass-closed-issues/issue_1634.hrx
+++ b/spec/libsass-closed-issues/issue_1634.hrx
@@ -14,19 +14,12 @@ $empty-list: ();
 test {
   test: foo($empty-list);
 }
-<===> output.css
-test {
-  test: 0;
-}
-
-<===> warning
-DEPRECATION WARNING [call-string]: Passing a string to call() is deprecated and will be illegal in Dart Sass 2.0.0.
-
-Recommendation: call(get-function(bar))
-
+<===> error
+Error: $function: bar is not a function reference.
+Call meta.get-function() to get a reference for a function name.
   ,
 6 |     @return meta.call(bar, $args...);
   |             ^^^^^^^^^^^^^^^^^^^^^^^^
   '
-    input.scss 6:13  foo()
-    input.scss 14:9  root stylesheet
+  input.scss 6:13  foo()
+  input.scss 14:9  root stylesheet

--- a/spec/libsass-closed-issues/issue_1645.hrx
+++ b/spec/libsass-closed-issues/issue_1645.hrx
@@ -19,19 +19,12 @@ test {
   test: bar($a);
 }
 
-<===> output.css
-test {
-  test: 0;
-}
-
-<===> warning
-DEPRECATION WARNING [call-string]: Passing a string to call() is deprecated and will be illegal in Dart Sass 2.0.0.
-
-Recommendation: call(get-function(foo))
-
+<===> error
+Error: $function: foo is not a function reference.
+Call meta.get-function() to get a reference for a function name.
   ,
 8 |   @return meta.call(foo, $args...);
   |           ^^^^^^^^^^^^^^^^^^^^^^^^
   '
-    input.scss 8:11  bar()
-    input.scss 18:9  root stylesheet
+  input.scss 8:11  bar()
+  input.scss 18:9  root stylesheet

--- a/spec/libsass-closed-issues/issue_2472.hrx
+++ b/spec/libsass-closed-issues/issue_2472.hrx
@@ -21,16 +21,7 @@ $arg: join((), 5%);
   function: dark(#102030, 5%);
   function2: dark2(#102030, 5%);
 }
-<===> output.css
-.single {
-  direct: darken(#102030, 5%);
-  arg: darken(#102030, 5%);
-  call: darken(#102030 5%);
-  function: darken(#102030, 5%);
-  function2: darken(#102030, 5%);
-}
-
-<===> warning
+<===> error
 DEPRECATION WARNING [global-builtin]: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
 Use list.join instead.
 
@@ -53,58 +44,10 @@ More info and automated migrator: https://sass-lang.com/d/import
    '
     input.scss 19:9  root stylesheet
 
-DEPRECATION WARNING [call-string]: Passing a string to call() is deprecated and will be illegal in Dart Sass 2.0.0.
-
-Recommendation: call(get-function("darken"))
-
+Error: $function: "darken" is not a function reference.
+Call meta.get-function() to get a reference for a function name.
    ,
 19 |   call: call('darken', #102030, $arg...);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    '
-    input.scss 19:9  root stylesheet
-
-DEPRECATION WARNING [global-builtin]: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
-Use meta.call instead.
-
-More info and automated migrator: https://sass-lang.com/d/import
-
-  ,
-5 |   @return call('darken', $color, $args...);
-  |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  '
-    input.scss 5:11   dark()
-    input.scss 20:13  root stylesheet
-
-DEPRECATION WARNING [call-string]: Passing a string to call() is deprecated and will be illegal in Dart Sass 2.0.0.
-
-Recommendation: call(get-function("darken"))
-
-  ,
-5 |   @return call('darken', $color, $args...);
-  |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  '
-    input.scss 5:11   dark()
-    input.scss 20:13  root stylesheet
-
-DEPRECATION WARNING [global-builtin]: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
-Use meta.call instead.
-
-More info and automated migrator: https://sass-lang.com/d/import
-
-   ,
-11 |   @return call('darken', $args...);
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^
-   '
-    input.scss 11:11  dark2()
-    input.scss 21:14  root stylesheet
-
-DEPRECATION WARNING [call-string]: Passing a string to call() is deprecated and will be illegal in Dart Sass 2.0.0.
-
-Recommendation: call(get-function("darken"))
-
-   ,
-11 |   @return call('darken', $args...);
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^
-   '
-    input.scss 11:11  dark2()
-    input.scss 21:14  root stylesheet
+  input.scss 19:9  root stylesheet


### PR DESCRIPTION
[skip dart-sass]

See https://github.com/sass/sass/pull/4213