### PR TITLE
Fix deprecation warnings for vendor-prefixed `expression()`

### DIFF
--- a/spec/css/functions/special/prefixed/lowercase.hrx
+++ b/spec/css/functions/special/prefixed/lowercase.hrx
@@ -138,7 +138,7 @@ a {
 }
 
 <===> expression/punctuation/warning
-DEPRECATION WARNING [function-name]: Vendor-prefixed expression() functions will no longer have special parsing in a future release of Dart Sass. Once that happens, this argument will be parsed as SassScript. To preserve current behavior:
+DEPRECATION WARNING [function-name]: Vendor-prefixed expression() functions will no longer have special parsing in a future release of Dart Sass. Once that happens, this argument will no longer be valid syntax. To preserve current behavior:
 
 -c-expression(#{"@#$%^&*({[]})_-+=|\\\\:\"\"''<>,.?/"})
 
@@ -161,7 +161,7 @@ a {
 }
 
 <===> expression/script_like/warning
-DEPRECATION WARNING [function-name]: Vendor-prefixed expression() functions will no longer have special parsing in a future release of Dart Sass. Once that happens, this argument will no longer be valid syntax. To preserve current behavior:
+DEPRECATION WARNING [function-name]: Vendor-prefixed expression() functions will no longer have special parsing in a future release of Dart Sass. Once that happens, this argument will be parsed as SassScript. To preserve current behavior:
 
 -c-expression(#{"$d"})
 

--- a/spec/css/functions/special/prefixed/uppercase.hrx
+++ b/spec/css/functions/special/prefixed/uppercase.hrx
@@ -138,7 +138,7 @@ a {
 }
 
 <===> expression/punctuation/warning
-DEPRECATION WARNING [function-name]: Vendor-prefixed expression() functions will no longer have special parsing in a future release of Dart Sass. Once that happens, this argument will be parsed as SassScript. To preserve current behavior:
+DEPRECATION WARNING [function-name]: Vendor-prefixed expression() functions will no longer have special parsing in a future release of Dart Sass. Once that happens, this argument will no longer be valid syntax. To preserve current behavior:
 
 -c-expression(#{"@#$%^&*({[]})_-+=|\\\\:\"\"''<>,.?/"})
 
@@ -161,7 +161,7 @@ a {
 }
 
 <===> expression/script_like/warning
-DEPRECATION WARNING [function-name]: Vendor-prefixed expression() functions will no longer have special parsing in a future release of Dart Sass. Once that happens, this argument will no longer be valid syntax. To preserve current behavior:
+DEPRECATION WARNING [function-name]: Vendor-prefixed expression() functions will no longer have special parsing in a future release of Dart Sass. Once that happens, this argument will be parsed as SassScript. To preserve current behavior:
 
 -c-expression(#{"$d"})
 

--- a/spec/directives/function/name.hrx
+++ b/spec/directives/function/name.hrx
@@ -112,19 +112,6 @@ b {
   c: -a-expression();
 }
 
-<===> special/expression/prefix/warning
-DEPRECATION WARNING [function-name]: Vendor-prefixed expression() functions will no longer have special parsing in a future release of Dart Sass. Once that happens, this argument will be parsed as SassScript. To preserve current behavior:
-
--a-expression(#{""})
-
-More info: https://sass-lang.com/d/function-name
-
-  ,
-3 |   c: -a-expression();
-  |      ^^^^^^^^^^^^^^^
-  '
-    input.scss 3:6  root stylesheet
-
 <===>
 ================================================================================
 <===> special/url/uppercase/input.scss


### PR DESCRIPTION
[skip dart-sass]