### PR TITLE
Run language tests on Windows and MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,13 +45,22 @@ jobs:
       - run: npm run lint-spec
 
   dart_sass_language:
-    name: "Language | Dart Sass | Dart ${{ matrix.dart_channel }}"
+    name: "Language | Dart Sass | Dart ${{ matrix.dart_channel }} | ${{ matrix.os }}"
     runs-on: ubuntu-latest
     if: "github.event_name != 'pull_request' || !contains(github.event.pull_request.body, 'skip dart-sass')"
 
     strategy:
       matrix:
-        dart_channel: [stable, dev]
+        # We expect language test results not to vary from OS to OS. In most
+        # cases, this is trivial, but for operations on very high-precision
+        # floating-point numbers there are cases where float rounding can differ
+        # (see sass/sass-spec#2156). To ensure we don't include these in our
+        # test cases, we test against Windows and MacOS as well.
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        dart_channel: [stable]
+        include:
+        - os: ubuntu-latest
+          dart_channel: dev
 
     steps:
       - uses: actions/checkout@v3

--- a/spec/core_functions/color/to_space/oklch/prophoto_rgb.hrx
+++ b/spec/core_functions/color/to_space/oklch/prophoto_rgb.hrx
@@ -66,11 +66,11 @@ a {
 ================================================================================
 <===> out_of_range/far/input.scss
 @use "sass:color";
-a {b: color.to-space(oklch(10% 999999 0deg), prophoto-rgb)}
+a {b: color.to-space(oklch(10% 999998 0deg), prophoto-rgb)}
 
 <===> out_of_range/far/output.css
 a {
-  b: color(prophoto-rgb 2922139901.256741 -1810418671.4016082 -574654054.8066751);
+  b: color(prophoto-rgb 2922135031.0215025 -1810415654.0357418 -574653097.0493711);
 }
 
 <===>


### PR DESCRIPTION
This also fixes a case where slight differences in float rounding cause tests to fail on one OS in particular.

Closes #2156