### PR TITLE
Update specs to cover analogous sets of missing channels

### DIFF
--- a/spec/core_functions/color/invert/modern.hrx
+++ b/spec/core_functions/color/invert/modern.hrx
@@ -110,7 +110,7 @@ a {
 ================================================================================
 <===> space/missing_converted/input.scss
 @use "sass:color";
-a {b: color.invert(color(rec2020 none none none), $space: lab)}
+a {b: color.invert(color(rec2020 none 0 0), $space: lab)}
 
 <===> space/missing_converted/output.css
 a {

--- a/spec/core_functions/color/mix/missing.hrx
+++ b/spec/core_functions/color/mix/missing.hrx
@@ -82,40 +82,106 @@ a {
 
 <===>
 ================================================================================
-<===> explicit/analogous/legacy/color1/input.scss
+<===> explicit/analogous/legacy/color1/single/input.scss
 @use "sass:color";
 a {b: color.mix(rgb(none 100 200), rgb(200 100 0), $method: rec2020)}
 
-<===> explicit/analogous/legacy/color1/output.css
+<===> explicit/analogous/legacy/color1/single/output.css
 a {
   b: rgb(78.3685527456%, 36.0116672853%, 45.3323453854%);
 }
 
 <===>
 ================================================================================
-<===> explicit/analogous/legacy/color2/input.scss
+<===> explicit/analogous/legacy/color1/set/input.scss
+@use "sass:color";
+a {b: color.mix(hsl(none none 50%), lab(80% 10% 20%), $method: oklch)}
+
+<===> explicit/analogous/legacy/color1/set/output.css
+a {
+  b: hsl(27.6264349345, 39.5108871342%, 61.2332568327%);
+}
+
+<===>
+================================================================================
+<===> explicit/analogous/legacy/color1/all/input.scss
+@use "sass:color";
+a {b: color.mix(rgb(none none none), rgb(200 100 0), $method: rec2020)}
+
+<===> explicit/analogous/legacy/color1/all/output.css
+a {
+  b: #c86400;
+}
+
+<===>
+================================================================================
+<===> explicit/analogous/legacy/color2/single/input.scss
 @use "sass:color";
 a {b: color.mix(rgb(0 100 200), rgb(200 none 0), $method: rec2020)}
 
-<===> explicit/analogous/legacy/color2/output.css
+<===> explicit/analogous/legacy/color2/single/output.css
 a {
   b: rgb(50.1551278959%, 37.5727310145%, 42.8027026523%);
 }
 
 <===>
 ================================================================================
-<===> explicit/analogous/legacy/both/input.scss
+<===> explicit/analogous/legacy/color2/set/input.scss
+@use "sass:color";
+a {b: color.mix(hsl(120deg 10% 20%), lab(50% none none), $method: oklch)}
+
+<===> explicit/analogous/legacy/color2/set/output.css
+a {
+  b: hsl(119.669130857, 6.6488786052%, 32.4911149973%);
+}
+
+<===>
+================================================================================
+<===> explicit/analogous/legacy/color2/all/input.scss
+@use "sass:color";
+a {b: color.mix(rgb(200 100 0), rgb(none none none), $method: rec2020)}
+
+<===> explicit/analogous/legacy/color2/all/output.css
+a {
+  b: #c86400;
+}
+
+<===>
+================================================================================
+<===> explicit/analogous/legacy/both/single/input.scss
 @use "sass:color";
 a {b: color.mix(rgb(0 none 200), rgb(200 none 0), $method: rec2020)}
 
-<===> explicit/analogous/legacy/both/output.css
+<===> explicit/analogous/legacy/both/single/output.css
 a {
   b: rgb(50.0525424686%, 0%, 44.1197051136%);
 }
 
 <===>
 ================================================================================
-<===> explicit/analogous/modern/color1/input.scss
+<===> explicit/analogous/legacy/both/set/input.scss
+@use "sass:color";
+a {b: color.mix(hsl(none none 50%), lab(80% none none), $method: rec2020)}
+
+<===> explicit/analogous/legacy/both/set/output.css
+a {
+  b: hsl(0, 0%, 63.8879192621%);
+}
+
+<===>
+================================================================================
+<===> explicit/analogous/legacy/both/all/input.scss
+@use "sass:color";
+a {b: color.mix(rgb(none none none), rgb(none none none), $method: rec2020)}
+
+<===> explicit/analogous/legacy/both/all/output.css
+a {
+  b: black;
+}
+
+<===>
+================================================================================
+<===> explicit/analogous/modern/color1/single/input.scss
 @use "sass:color";
 a {
   b: color.mix(
@@ -125,14 +191,48 @@ a {
   );
 }
 
-<===> explicit/analogous/modern/color1/output.css
+<===> explicit/analogous/modern/color1/single/output.css
 a {
   b: color(srgb 0.1485286314 0.1448485586 0.2496395015);
 }
 
 <===>
 ================================================================================
-<===> explicit/analogous/modern/color2/input.scss
+<===> explicit/analogous/modern/color1/set/input.scss
+@use "sass:color";
+a {
+  b: color.mix(
+    lch(50% none none),
+    lab(80% 10% 20%),
+    $method: oklch
+  );
+}
+
+<===> explicit/analogous/modern/color1/set/output.css
+a {
+  b: lch(64.9034695294% 28.3412220859 63.2701468478deg);
+}
+
+<===>
+================================================================================
+<===> explicit/analogous/modern/color1/all/input.scss
+@use "sass:color";
+a {
+  b: color.mix(
+    color(srgb none none none),
+    color(srgb 0.1 0.2 0.3),
+    $method: rec2020
+  );
+}
+
+<===> explicit/analogous/modern/color1/all/output.css
+a {
+  b: color(srgb 0.1 0.2 0.3);
+}
+
+<===>
+================================================================================
+<===> explicit/analogous/modern/color2/single/input.scss
 @use "sass:color";
 a {
   b: color.mix(
@@ -142,14 +242,48 @@ a {
   );
 }
 
-<===> explicit/analogous/modern/color2/output.css
+<===> explicit/analogous/modern/color2/single/output.css
 a {
   b: color(srgb -0.0044280937 0.2034278916 0.2453243175);
 }
 
 <===>
 ================================================================================
-<===> explicit/analogous/modern/both/input.scss
+<===> explicit/analogous/modern/color2/set/input.scss
+@use "sass:color";
+a {
+  b: color.mix(
+    lab(80% 10% 20%),
+    lch(50% none none),
+    $method: oklch
+  );
+}
+
+<===> explicit/analogous/modern/color2/set/output.css
+a {
+  b: lab(64.9034695294% 12.7474400269 25.3125984854);
+}
+
+<===>
+================================================================================
+<===> explicit/analogous/modern/color2/all/input.scss
+@use "sass:color";
+a {
+  b: color.mix(
+    color(srgb 0.1 0.2 0.3),
+    color(srgb none none none),
+    $method: rec2020
+  );
+}
+
+<===> explicit/analogous/modern/color2/all/output.css
+a {
+  b: color(srgb 0.1 0.2 0.3);
+}
+
+<===>
+================================================================================
+<===> explicit/analogous/modern/both/single/input.scss
 @use "sass:color";
 a {
   b: color.mix(
@@ -159,9 +293,43 @@ a {
   );
 }
 
-<===> explicit/analogous/modern/both/output.css
+<===> explicit/analogous/modern/both/single/output.css
 a {
   b: color(srgb 0.210063151 0.2012856032 none);
+}
+
+<===>
+================================================================================
+<===> explicit/analogous/modern/both/set/input.scss
+@use "sass:color";
+a {
+  b: color.mix(
+    lab(20% none none),
+    lch(50% none none),
+    $method: oklch
+  );
+}
+
+<===> explicit/analogous/modern/both/set/output.css
+a {
+  b: lab(35% none none);
+}
+
+<===>
+================================================================================
+<===> explicit/analogous/modern/both/all/input.scss
+@use "sass:color";
+a {
+  b: color.mix(
+    color(srgb none none none),
+    color(srgb none none none),
+    $method: rec2020
+  );
+}
+
+<===> explicit/analogous/modern/both/all/output.css
+a {
+  b: color(srgb none none none);
 }
 
 <===>

--- a/spec/core_functions/color/to_space/a98_rgb/hsl.hrx
+++ b/spec/core_functions/color/to_space/a98_rgb/hsl.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(a98-rgb 0.1 0.2 none), hsl)}
 a {
   b: hsl(125.1711076789, 146.5566174361%, 7.5605855126%);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(a98-rgb none none none), hsl)}
+
+<===> missing/all/output.css
+a {
+  b: hsl(0, 0%, 0%);
+}

--- a/spec/core_functions/color/to_space/a98_rgb/hwb.hrx
+++ b/spec/core_functions/color/to_space/a98_rgb/hwb.hrx
@@ -147,3 +147,14 @@ a {b: color.to-space(color(a98-rgb 0.1 0.2 none), hwb)}
 a {
   b: hsl(125.1711076789, 146.5566174361%, 7.5605855126%);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(a98-rgb none none none), hwb)}
+
+<===> missing/all/output.css
+a {
+  b: red;
+}

--- a/spec/core_functions/color/to_space/a98_rgb/lab.hrx
+++ b/spec/core_functions/color/to_space/a98_rgb/lab.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(a98-rgb 0.1 0.2 none), lab)}
 a {
   b: lab(15.5541953165% -27.655552781 23.2496799552);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(a98-rgb none none none), lab)}
+
+<===> missing/all/output.css
+a {
+  b: lab(none none none);
+}

--- a/spec/core_functions/color/to_space/a98_rgb/lch.hrx
+++ b/spec/core_functions/color/to_space/a98_rgb/lch.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(a98-rgb 0.1 0.2 none), lch)}
 a {
   b: lch(15.5541953165% 36.1300043959 139.9466505913deg);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(a98-rgb none none none), lch)}
+
+<===> missing/all/output.css
+a {
+  b: lch(none none none);
+}

--- a/spec/core_functions/color/to_space/a98_rgb/oklab.hrx
+++ b/spec/core_functions/color/to_space/a98_rgb/oklab.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(a98-rgb 0.1 0.2 none), oklab)}
 a {
   b: oklab(26.2341471549% -0.0807607264 0.0595439714);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(a98-rgb none none none), oklab)}
+
+<===> missing/all/output.css
+a {
+  b: oklab(none none none);
+}

--- a/spec/core_functions/color/to_space/a98_rgb/oklch.hrx
+++ b/spec/core_functions/color/to_space/a98_rgb/oklch.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(a98-rgb 0.1 0.2 none), oklch)}
 a {
   b: oklch(26.2341471549% 0.100338325 143.5990675722deg);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(a98-rgb none none none), oklch)}
+
+<===> missing/all/output.css
+a {
+  b: oklch(none none none);
+}

--- a/spec/core_functions/color/to_space/display_p3/hsl.hrx
+++ b/spec/core_functions/color/to_space/display_p3/hsl.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(display-p3 0.1 0.2 none), hsl)}
 a {
   b: hsl(96.0435532608, 143.3480015017%, 8.3456369204%);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(display-p3 none none none), hsl)}
+
+<===> missing/all/output.css
+a {
+  b: hsl(0, 0%, 0%);
+}

--- a/spec/core_functions/color/to_space/display_p3/hwb.hrx
+++ b/spec/core_functions/color/to_space/display_p3/hwb.hrx
@@ -147,3 +147,14 @@ a {b: color.to-space(color(display-p3 0.1 0.2 none), hwb)}
 a {
   b: hsl(96.0435532608, 143.3480015017%, 8.3456369204%);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(display-p3 none none none), hwb)}
+
+<===> missing/all/output.css
+a {
+  b: red;
+}

--- a/spec/core_functions/color/to_space/display_p3/lab.hrx
+++ b/spec/core_functions/color/to_space/display_p3/lab.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(display-p3 0.1 0.2 none), lab)}
 a {
   b: lab(18.0687084518% -22.5066779572 28.5560007052);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(display-p3 none none none), lab)}
+
+<===> missing/all/output.css
+a {
+  b: lab(none none none);
+}

--- a/spec/core_functions/color/to_space/display_p3/lch.hrx
+++ b/spec/core_functions/color/to_space/display_p3/lch.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(display-p3 0.1 0.2 none), lch)}
 a {
   b: lch(18.0687084518% 36.3592591914 128.2437408357deg);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(display-p3 none none none), lch)}
+
+<===> missing/all/output.css
+a {
+  b: lch(none none none);
+}

--- a/spec/core_functions/color/to_space/display_p3/oklab.hrx
+++ b/spec/core_functions/color/to_space/display_p3/oklab.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(display-p3 0.1 0.2 none), oklab)}
 a {
   b: oklab(28.5078225669% -0.0706258683 0.0690953537);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(display-p3 none none none), oklab)}
+
+<===> missing/all/output.css
+a {
+  b: oklab(none none none);
+}

--- a/spec/core_functions/color/to_space/display_p3/oklch.hrx
+++ b/spec/core_functions/color/to_space/display_p3/oklch.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(display-p3 0.1 0.2 none), oklch)}
 a {
   b: oklch(28.5078225669% 0.0988037508 135.6275962604deg);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(display-p3 none none none), oklch)}
+
+<===> missing/all/output.css
+a {
+  b: oklch(none none none);
+}

--- a/spec/core_functions/color/to_space/display_p3_linear/hsl.hrx
+++ b/spec/core_functions/color/to_space/display_p3_linear/hsl.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(display-p3-linear 0.1 0.2 none), hsl)}
 a {
   b: hsl(77.1972503288, 181.3073182011%, 17.3912222966%);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(display-p3-linear none none none), hsl)}
+
+<===> missing/all/output.css
+a {
+  b: hsl(0, 0%, 0%);
+}

--- a/spec/core_functions/color/to_space/display_p3_linear/hwb.hrx
+++ b/spec/core_functions/color/to_space/display_p3_linear/hwb.hrx
@@ -147,3 +147,14 @@ a {b: color.to-space(color(display-p3-linear 0.1 0.2 none), hwb)}
 a {
   b: hsl(77.1972503288, 181.3073182011%, 17.3912222966%);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(display-p3-linear none none none), hwb)}
+
+<===> missing/all/output.css
+a {
+  b: red;
+}

--- a/spec/core_functions/color/to_space/display_p3_linear/lab.hrx
+++ b/spec/core_functions/color/to_space/display_p3_linear/lab.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(display-p3-linear 0.1 0.2 none), lab)}
 a {
   b: lab(47.3091665403% -30.4535652285 66.0309604136);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(display-p3-linear none none none), lab)}
+
+<===> missing/all/output.css
+a {
+  b: lab(none none none);
+}

--- a/spec/core_functions/color/to_space/display_p3_linear/lch.hrx
+++ b/spec/core_functions/color/to_space/display_p3_linear/lch.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(display-p3-linear 0.1 0.2 none), lch)}
 a {
   b: lch(47.3091665403% 72.7152485265 114.7592133291deg);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(display-p3-linear none none none), lch)}
+
+<===> missing/all/output.css
+a {
+  b: lch(none none none);
+}

--- a/spec/core_functions/color/to_space/display_p3_linear/oklab.hrx
+++ b/spec/core_functions/color/to_space/display_p3_linear/oklab.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(display-p3-linear 0.1 0.2 none), oklab)}
 a {
   b: oklab(53.2843793949% -0.1024723411 0.1284163638);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(display-p3-linear none none none), oklab)}
+
+<===> missing/all/output.css
+a {
+  b: oklab(none none none);
+}

--- a/spec/core_functions/color/to_space/display_p3_linear/oklch.hrx
+++ b/spec/core_functions/color/to_space/display_p3_linear/oklch.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(display-p3-linear 0.1 0.2 none), oklch)}
 a {
   b: oklch(53.2843793949% 0.1642904233 128.5887993605deg);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(display-p3-linear none none none), oklch)}
+
+<===> missing/all/output.css
+a {
+  b: oklch(none none none);
+}

--- a/spec/core_functions/color/to_space/hsl/a98_rgb.hrx
+++ b/spec/core_functions/color/to_space/hsl/a98_rgb.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(hsl(10deg 20% none), a98-rgb)}
 a {
   b: color(a98-rgb 0 0 0);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(10deg none none), a98-rgb)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(a98-rgb 0 0 0);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(none none 50%), a98-rgb)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(a98-rgb 0.4961036984 0.4961036984 0.4961036984);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(none none none), a98-rgb)}
+
+<===> missing/all/output.css
+a {
+  b: color(a98-rgb none none none);
+}

--- a/spec/core_functions/color/to_space/hsl/display_p3.hrx
+++ b/spec/core_functions/color/to_space/hsl/display_p3.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(hsl(10deg 20% none), display-p3)}
 a {
   b: color(display-p3 0 0 0);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(10deg none none), display-p3)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(display-p3 0 0 0);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(none none 50%), display-p3)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(display-p3 0.5 0.5 0.5);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(none none none), display-p3)}
+
+<===> missing/all/output.css
+a {
+  b: color(display-p3 none none none);
+}

--- a/spec/core_functions/color/to_space/hsl/display_p3_linear.hrx
+++ b/spec/core_functions/color/to_space/hsl/display_p3_linear.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(hsl(10deg 20% none), display-p3-linear)}
 a {
   b: color(display-p3-linear 0 0 0);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(10deg none none), display-p3-linear)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(display-p3-linear 0 0 0);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(none none 50%), display-p3-linear)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(display-p3-linear 0.2140411405 0.2140411405 0.2140411405);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(none none none), display-p3-linear)}
+
+<===> missing/all/output.css
+a {
+  b: color(display-p3-linear none none none);
+}

--- a/spec/core_functions/color/to_space/hsl/hsl.hrx
+++ b/spec/core_functions/color/to_space/hsl/hsl.hrx
@@ -50,3 +50,36 @@ a {b: color.to-space(hsl(10deg 20% none), hsl)}
 a {
   b: hsl(10deg 20% none);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(10deg none none), hsl)}
+
+<===> missing/non_hue/output.css
+a {
+  b: hsl(10deg none none);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(none none 50%), hsl)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: hsl(none none 50%);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(none none none), hsl)}
+
+<===> missing/all/output.css
+a {
+  b: hsl(none none none);
+}

--- a/spec/core_functions/color/to_space/hsl/hwb.hrx
+++ b/spec/core_functions/color/to_space/hsl/hwb.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(hsl(10deg 20% none), hwb)}
 a {
   b: black;
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(10deg none none), hwb)}
+
+<===> missing/non_hue/output.css
+a {
+  b: red;
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(none none 50%), hwb)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: hsl(0, 0%, 50%);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(none none none), hwb)}
+
+<===> missing/all/output.css
+a {
+  b: red;
+}

--- a/spec/core_functions/color/to_space/hsl/lab.hrx
+++ b/spec/core_functions/color/to_space/hsl/lab.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(hsl(10deg 20% none), lab)}
 a {
   b: lab(none 0 0);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(10deg none none), lab)}
+
+<===> missing/non_hue/output.css
+a {
+  b: lab(none 0 0);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(none none 50%), lab)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: lab(53.3889647411% none none);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(none none none), lab)}
+
+<===> missing/all/output.css
+a {
+  b: lab(none none none);
+}

--- a/spec/core_functions/color/to_space/hsl/lch.hrx
+++ b/spec/core_functions/color/to_space/hsl/lch.hrx
@@ -136,7 +136,8 @@ a {
 // through sRGB, which discards hue information if there aren't also saturation
 // and lightness values. (This matches the behavior of `color-mix` in Chrome.)
 //
-// See disucssion of this behavior in https://github.com/w3c/csswg-drafts/issues/10210#issuecomment-5052906087.
+// See discussion of this behavior in 
+// https://github.com/w3c/csswg-drafts/issues/10210#issuecomment-5052906087.
 @use "sass:color";
 a {b: color.to-space(hsl(10deg none none), lch)}
 

--- a/spec/core_functions/color/to_space/hsl/lch.hrx
+++ b/spec/core_functions/color/to_space/hsl/lch.hrx
@@ -127,3 +127,42 @@ a {b: color.to-space(hsl(10deg 20% none), lch)}
 a {
   b: lch(none 0 none);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+// This seems unintuitive, in that one would expect the HSL hue to translate
+// into an LCH hue. However, CSS specifies the HSL -> LCH conversion as going
+// through sRGB, which discards hue information if there aren't also saturation
+// and lightness values. (This matches the behavior of `color-mix` in Chrome.)
+//
+// See disucssion of this behavior in https://github.com/w3c/csswg-drafts/issues/10210#issuecomment-5052906087.
+@use "sass:color";
+a {b: color.to-space(hsl(10deg none none), lch)}
+
+<===> missing/non_hue/output.css
+a {
+  b: lch(none none none);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(none none 50%), lch)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: lch(53.3889647411% none none);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(none none none), lch)}
+
+<===> missing/all/output.css
+a {
+  b: lch(none none none);
+}

--- a/spec/core_functions/color/to_space/hsl/oklab.hrx
+++ b/spec/core_functions/color/to_space/hsl/oklab.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(hsl(10deg 20% none), oklab)}
 a {
   b: oklab(none 0 0);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(10deg none none), oklab)}
+
+<===> missing/non_hue/output.css
+a {
+  b: oklab(none 0 0);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(none none 50%), oklab)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: oklab(59.8180730527% none none);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(none none none), oklab)}
+
+<===> missing/all/output.css
+a {
+  b: oklab(none none none);
+}

--- a/spec/core_functions/color/to_space/hsl/oklch.hrx
+++ b/spec/core_functions/color/to_space/hsl/oklch.hrx
@@ -127,3 +127,37 @@ a {b: color.to-space(hsl(10deg 20% none), oklch)}
 a {
   b: oklch(none 0 none);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+// See comment in missing/non_hue/input.scss in lch.hrx.
+@use "sass:color";
+a {b: color.to-space(hsl(10deg none none), oklch)}
+
+<===> missing/non_hue/output.css
+a {
+  b: oklch(none none none);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(none none 50%), oklch)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: oklch(59.8180730527% none none);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(none none none), oklch)}
+
+<===> missing/all/output.css
+a {
+  b: oklch(none none none);
+}

--- a/spec/core_functions/color/to_space/hsl/prophoto_rgb.hrx
+++ b/spec/core_functions/color/to_space/hsl/prophoto_rgb.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(hsl(10deg 20% none), prophoto-rgb)}
 a {
   b: color(prophoto-rgb 0 0 0);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(10deg none none), prophoto-rgb)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(prophoto-rgb 0 0 0);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(none none 50%), prophoto-rgb)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(prophoto-rgb 0.4246723949 0.4246723949 0.4246723949);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(none none none), prophoto-rgb)}
+
+<===> missing/all/output.css
+a {
+  b: color(prophoto-rgb none none none);
+}

--- a/spec/core_functions/color/to_space/hsl/rec2020.hrx
+++ b/spec/core_functions/color/to_space/hsl/rec2020.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(hsl(10deg 20% none), rec2020)}
 a {
   b: color(rec2020 0 0 0);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(10deg none none), rec2020)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(rec2020 0 0 0);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(none none 50%), rec2020)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(rec2020 0.5260663507 0.5260663507 0.5260663507);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(none none none), rec2020)}
+
+<===> missing/all/output.css
+a {
+  b: color(rec2020 none none none);
+}

--- a/spec/core_functions/color/to_space/hsl/rgb.hrx
+++ b/spec/core_functions/color/to_space/hsl/rgb.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(hsl(10deg 20% none), rgb)}
 a {
   b: black;
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(10deg none none), rgb)}
+
+<===> missing/non_hue/output.css
+a {
+  b: black;
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(none none 50%), rgb)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: rgb(50%, 50%, 50%);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(none none none), rgb)}
+
+<===> missing/all/output.css
+a {
+  b: black;
+}

--- a/spec/core_functions/color/to_space/hsl/srgb.hrx
+++ b/spec/core_functions/color/to_space/hsl/srgb.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(hsl(10deg 20% none), srgb)}
 a {
   b: color(srgb 0 0 0);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(10deg none none), sRGB)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(srgb 0 0 0);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(none none 50%), sRGB)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(srgb 0.5 0.5 0.5);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(none none none), sRGB)}
+
+<===> missing/all/output.css
+a {
+  b: color(srgb none none none);
+}

--- a/spec/core_functions/color/to_space/hsl/srgb_linear.hrx
+++ b/spec/core_functions/color/to_space/hsl/srgb_linear.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(hsl(10deg 20% none), srgb-linear)}
 a {
   b: color(srgb-linear 0 0 0);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(10deg none none), srgb-linear)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(srgb-linear 0 0 0);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(none none 50%), srgb-linear)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(srgb-linear 0.2140411405 0.2140411405 0.2140411405);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(none none none), srgb-linear)}
+
+<===> missing/all/output.css
+a {
+  b: color(srgb-linear none none none);
+}

--- a/spec/core_functions/color/to_space/hsl/xyz.hrx
+++ b/spec/core_functions/color/to_space/hsl/xyz.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(hsl(10deg 20% none), xyz)}
 a {
   b: color(xyz 0 0 0);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(10deg none none), xyz)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(xyz 0 0 0);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(none none 50%), xyz)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(xyz 0.2034366706 0.2140411405 0.233103163);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(none none none), xyz)}
+
+<===> missing/all/output.css
+a {
+  b: color(xyz none none none);
+}

--- a/spec/core_functions/color/to_space/hsl/xyz_d50.hrx
+++ b/spec/core_functions/color/to_space/hsl/xyz_d50.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(hsl(10deg 20% none), xyz-d50)}
 a {
   b: color(xyz-d50 0 0 0);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(10deg none none), xyz-d50)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(xyz-d50 0 0 0);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(none none 50%), xyz-d50)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(xyz-d50 0.2063989463 0.2140411405 0.1766063301);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(hsl(none none none), xyz-d50)}
+
+<===> missing/all/output.css
+a {
+  b: color(xyz-d50 none none none);
+}

--- a/spec/core_functions/color/to_space/hwb/a98_rgb.hrx
+++ b/spec/core_functions/color/to_space/hwb/a98_rgb.hrx
@@ -127,3 +127,25 @@ a {b: color.to-space(hwb(10deg 20% none), a98-rgb)}
 a {
   b: color(a98-rgb 0.8725825543 0.3359890414 0.2191164159);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(hwb(10deg none none), a98-rgb)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(a98-rgb 0.8622606438 0.1822173447 0.0427160821);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(hwb(none none none), a98-rgb)}
+
+<===> missing/all/output.css
+a {
+  b: color(a98-rgb none none none);
+}

--- a/spec/core_functions/color/to_space/hwb/display_p3.hrx
+++ b/spec/core_functions/color/to_space/hwb/display_p3.hrx
@@ -127,3 +127,25 @@ a {b: color.to-space(hwb(10deg 20% none), display-p3)}
 a {
   b: color(display-p3 0.9253883052 0.3826332802 0.2571893552);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(hwb(10deg none none), display-p3)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(display-p3 0.9195533082 0.2625869512 0.1464204035);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(hwb(none none none), display-p3)}
+
+<===> missing/all/output.css
+a {
+  b: color(display-p3 none none none);
+}

--- a/spec/core_functions/color/to_space/hwb/display_p3_linear.hrx
+++ b/spec/core_functions/color/to_space/hwb/display_p3_linear.hrx
@@ -127,3 +127,25 @@ a {b: color.to-space(hwb(10deg 20% none), display-p3-linear)}
 a {
   b: color(display-p3-linear 0.8385898273 0.1210204922 0.0538018878);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(hwb(10deg none none), display-p3-linear)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(display-p3-linear 0.8266611675 0.0560614669 0.0187950032);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(hwb(none none none), display-p3-linear)}
+
+<===> missing/all/output.css
+a {
+  b: color(display-p3-linear none none none);
+}

--- a/spec/core_functions/color/to_space/hwb/hsl.hrx
+++ b/spec/core_functions/color/to_space/hwb/hsl.hrx
@@ -127,3 +127,25 @@ a {b: color.to-space(hwb(10deg 20% none), hsl)}
 a {
   b: hsl(10, 100%, 60%);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(hwb(10deg none none), hsl)}
+
+<===> missing/non_hue/output.css
+a {
+  b: hsl(10, 0%, 0%);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(hwb(none none none), hsl)}
+
+<===> missing/all/output.css
+a {
+  b: hsl(0, 0%, 0%);
+}

--- a/spec/core_functions/color/to_space/hwb/hwb.hrx
+++ b/spec/core_functions/color/to_space/hwb/hwb.hrx
@@ -50,3 +50,25 @@ a {b: color.to-space(hwb(10deg 20% none), hsl)}
 a {
   b: hsl(10, 100%, 60%);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(hwb(10deg none none), hwb)}
+
+<===> missing/non_hue/output.css
+a {
+  b: hwb(10deg none none);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(hwb(none none none), hwb)}
+
+<===> missing/all/output.css
+a {
+  b: hwb(none none none);
+}

--- a/spec/core_functions/color/to_space/hwb/lab.hrx
+++ b/spec/core_functions/color/to_space/hwb/lab.hrx
@@ -127,3 +127,25 @@ a {b: color.to-space(hwb(10deg 20% none), lab)}
 a {
   b: lab(60.7483623827% 64.2863186591 55.7098309346);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(hwb(10deg none none), lab)}
+
+<===> missing/non_hue/output.css
+a {
+  b: lab(56.0326115973% 75.9501054187 70.216785337);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(hwb(none none none), lab)}
+
+<===> missing/all/output.css
+a {
+  b: lab(none none none);
+}

--- a/spec/core_functions/color/to_space/hwb/lch.hrx
+++ b/spec/core_functions/color/to_space/hwb/lch.hrx
@@ -127,3 +127,25 @@ a {b: color.to-space(hwb(10deg 20% none), lch)}
 a {
   b: lch(60.7483623827% 85.0665388358 40.9118491907deg);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(hwb(10deg none none), lch)}
+
+<===> missing/non_hue/output.css
+a {
+  b: lch(none none 42.7537544434deg);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(hwb(none none none), lch)}
+
+<===> missing/all/output.css
+a {
+  b: lch(none none none);
+}

--- a/spec/core_functions/color/to_space/hwb/oklab.hrx
+++ b/spec/core_functions/color/to_space/hwb/oklab.hrx
@@ -127,3 +127,25 @@ a {b: color.to-space(hwb(10deg 20% none), oklab)}
 a {
   b: oklab(67.8200001785% 0.1771510813 0.1158916503);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(hwb(10deg none none), oklab)}
+
+<===> missing/non_hue/output.css
+a {
+  b: oklab(64.1192926423% 0.2089584016 0.1287346815);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(hwb(none none none), oklab)}
+
+<===> missing/all/output.css
+a {
+  b: oklab(none none none);
+}

--- a/spec/core_functions/color/to_space/hwb/oklch.hrx
+++ b/spec/core_functions/color/to_space/hwb/oklch.hrx
@@ -127,3 +127,25 @@ a {b: color.to-space(hwb(10deg 20% none), oklch)}
 a {
   b: oklch(67.8200001785% 0.2116917103 33.1925785987deg);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(hwb(10deg none none), oklch)}
+
+<===> missing/non_hue/output.css
+a {
+  b: oklch(none none 31.63631038deg);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(hwb(none none none), oklch)}
+
+<===> missing/all/output.css
+a {
+  b: oklch(none none none);
+}

--- a/spec/core_functions/color/to_space/hwb/prophoto_rgb.hrx
+++ b/spec/core_functions/color/to_space/hwb/prophoto_rgb.hrx
@@ -127,3 +127,25 @@ a {b: color.to-space(hwb(10deg 20% none), prophoto-rgb)}
 a {
   b: color(prophoto-rgb 0.7274254108 0.3840965619 0.2020562891);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(hwb(10deg none none), prophoto-rgb)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(prophoto-rgb 0.7079854223 0.3065255884 0.1127118493);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(hwb(none none none), prophoto-rgb)}
+
+<===> missing/all/output.css
+a {
+  b: color(prophoto-rgb none none none);
+}

--- a/spec/core_functions/color/to_space/hwb/rec2020.hrx
+++ b/spec/core_functions/color/to_space/hwb/rec2020.hrx
@@ -127,3 +127,25 @@ a {b: color.to-space(hwb(10deg 20% none), rec2020)}
 a {
   b: color(rec2020 0.8403632233 0.4573990543 0.296448064);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(hwb(10deg none none), rec2020)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(rec2020 0.8277080064 0.368096751 0.1895507624);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(hwb(none none none), rec2020)}
+
+<===> missing/all/output.css
+a {
+  b: color(rec2020 none none none);
+}

--- a/spec/core_functions/color/to_space/hwb/rgb.hrx
+++ b/spec/core_functions/color/to_space/hwb/rgb.hrx
@@ -127,3 +127,25 @@ a {b: color.to-space(hwb(10deg 20% none), rgb)}
 a {
   b: #ff5533;
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(hwb(10deg none none), rgb)}
+
+<===> missing/non_hue/output.css
+a {
+  b: rgb(100%, 16.6666666667%, 0%);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(hwb(none none none), rgb)}
+
+<===> missing/all/output.css
+a {
+  b: black;
+}

--- a/spec/core_functions/color/to_space/hwb/srgb.hrx
+++ b/spec/core_functions/color/to_space/hwb/srgb.hrx
@@ -127,3 +127,25 @@ a {b: color.to-space(hwb(10deg 20% none), srgb)}
 a {
   b: color(srgb 1 0.3333333333 0.2);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(hwb(10deg none none), srgb)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(srgb 1 0.1666666667 0);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(hwb(none none none), srgb)}
+
+<===> missing/all/output.css
+a {
+  b: color(srgb none none none);
+}

--- a/spec/core_functions/color/to_space/hwb/srgb_linear.hrx
+++ b/spec/core_functions/color/to_space/hwb/srgb_linear.hrx
@@ -127,3 +127,25 @@ a {b: color.to-space(hwb(10deg 20% none), srgb-linear)}
 a {
   b: color(srgb-linear 1 0.0908417112 0.0331047666);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(hwb(10deg none none), srgb-linear)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(srgb-linear 1 0.0236523902 0);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(hwb(none none none), srgb-linear)}
+
+<===> missing/all/output.css
+a {
+  b: color(srgb-linear none none none);
+}

--- a/spec/core_functions/color/to_space/hwb/xyz.hrx
+++ b/spec/core_functions/color/to_space/hwb/xyz.hrx
@@ -127,3 +127,25 @@ a {b: color.to-space(hwb(10deg 20% none), xyz)}
 a {
   b: color(xyz 0.4508491469 0.2799960622 0.0616258215);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(hwb(10deg none none), xyz)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(xyz 0.4208485236 0.2295544545 0.0221500602);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(hwb(none none none), xyz)}
+
+<===> missing/all/output.css
+a {
+  b: color(xyz none none none);
+}

--- a/spec/core_functions/color/to_space/hwb/xyz_d50.hrx
+++ b/spec/core_functions/color/to_space/hwb/xyz_d50.hrx
@@ -127,3 +127,25 @@ a {b: color.to-space(hwb(10deg 20% none), xyz-d50)}
 a {
   b: color(xyz-d50 0.4757901468 0.2896232248 0.0463830476);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(hwb(10deg none none), xyz-d50)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(xyz-d50 0.4451755006 0.2394492684 0.0162201268);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(hwb(none none none), xyz-d50)}
+
+<===> missing/all/output.css
+a {
+  b: color(xyz-d50 none none none);
+}

--- a/spec/core_functions/color/to_space/lab/a98_rgb.hrx
+++ b/spec/core_functions/color/to_space/lab/a98_rgb.hrx
@@ -116,3 +116,25 @@ a {b: color.to-space(lab(10% 20 none), a98-rgb)}
 a {
   b: color(a98-rgb 0.1862731835 0.0856347366 0.1310611506);
 }
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(lab(10% none none), a98-rgb)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(a98-rgb 0.1300242938 0.1300242938 0.1300242938);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(lab(none none none), a98-rgb)}
+
+<===> missing/all/output.css
+a {
+  b: color(a98-rgb none none none);
+}

--- a/spec/core_functions/color/to_space/lab/display_p3.hrx
+++ b/spec/core_functions/color/to_space/lab/display_p3.hrx
@@ -116,3 +116,25 @@ a {b: color.to-space(lab(10% 20 none), display-p3)}
 a {
   b: color(display-p3 0.1823778479 0.0651398083 0.1096920557);
 }
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(lab(10% none none), display-p3)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(display-p3 0.1077034111 0.1077034111 0.1077034111);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(lab(none none none), display-p3)}
+
+<===> missing/all/output.css
+a {
+  b: color(display-p3 none none none);
+}

--- a/spec/core_functions/color/to_space/lab/display_p3_linear.hrx
+++ b/spec/core_functions/color/to_space/lab/display_p3_linear.hrx
@@ -116,3 +116,25 @@ a {b: color.to-space(lab(10% 20 none), display-p3-linear)}
 a {
   b: color(display-p3-linear 0.0278772897 0.0054380443 0.0115933369);
 }
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(lab(10% none none), display-p3-linear)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(display-p3-linear 0.0112601993 0.0112601993 0.0112601993);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(lab(none none none), display-p3-linear)}
+
+<===> missing/all/output.css
+a {
+  b: color(display-p3-linear none none none);
+}

--- a/spec/core_functions/color/to_space/lab/hsl.hrx
+++ b/spec/core_functions/color/to_space/lab/hsl.hrx
@@ -116,3 +116,25 @@ a {b: color.to-space(lab(10% 20 none), hsl)}
 a {
   b: hsl(337.1245847104, 56.1707811732%, 12.7694440441%);
 }
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(lab(10% none none), hsl)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: hsl(0, 0%, 10.7703411095%);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(lab(none none none), hsl)}
+
+<===> missing/all/output.css
+a {
+  b: hsl(0, 0%, 0%);
+}

--- a/spec/core_functions/color/to_space/lab/hwb.hrx
+++ b/spec/core_functions/color/to_space/lab/hwb.hrx
@@ -116,3 +116,25 @@ a {b: color.to-space(lab(10% 20 none), hwb)}
 a {
   b: hsl(337.1245847104, 56.1707811732%, 12.7694440441%);
 }
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(lab(10% none none), hwb)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: hsl(0, 0%, 10.7703411095%);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(lab(none none none), hwb)}
+
+<===> missing/all/output.css
+a {
+  b: red;
+}

--- a/spec/core_functions/color/to_space/lab/lab.hrx
+++ b/spec/core_functions/color/to_space/lab/lab.hrx
@@ -50,3 +50,25 @@ a {b: color.to-space(lab(10% 20 none), lab)}
 a {
   b: lab(10% 20 none);
 }
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(lab(10% none none), lab)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: lab(10% none none);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(lab(none none none), lab)}
+
+<===> missing/all/output.css
+a {
+  b: lab(none none none);
+}

--- a/spec/core_functions/color/to_space/lab/lch.hrx
+++ b/spec/core_functions/color/to_space/lab/lch.hrx
@@ -116,3 +116,25 @@ a {b: color.to-space(lab(10% 20 none), lch)}
 a {
   b: lch(10% 20 0deg);
 }
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(lab(10% none none), lch)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: lch(10% none none);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(lab(none none none), lch)}
+
+<===> missing/all/output.css
+a {
+  b: lch(none none none);
+}

--- a/spec/core_functions/color/to_space/lab/oklab.hrx
+++ b/spec/core_functions/color/to_space/lab/oklab.hrx
@@ -116,3 +116,25 @@ a {b: color.to-space(lab(10% 20 none), oklab)}
 a {
   b: oklab(23.0834634055% 0.0614345616 none);
 }
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(lab(10% none none), oklab)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: oklab(22.4137931034% none none);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(lab(none none none), oklab)}
+
+<===> missing/all/output.css
+a {
+  b: oklab(none none none);
+}

--- a/spec/core_functions/color/to_space/lab/oklch.hrx
+++ b/spec/core_functions/color/to_space/lab/oklch.hrx
@@ -116,3 +116,25 @@ a {b: color.to-space(lab(10% 20 none), oklch)}
 a {
   b: oklch(23.0834634055% 0.0614385679 359.3456789541deg);
 }
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(lab(10% none none), oklch)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: oklch(22.4137931034% none none);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(lab(none none none), oklch)}
+
+<===> missing/all/output.css
+a {
+  b: oklch(none none none);
+}

--- a/spec/core_functions/color/to_space/lab/prophoto_rgb.hrx
+++ b/spec/core_functions/color/to_space/lab/prophoto_rgb.hrx
@@ -116,3 +116,25 @@ a {b: color.to-space(lab(10% 20 none), prophoto-rgb)}
 a {
   b: color(prophoto-rgb 0.1155645311 0.0659678734 0.0827038254);
 }
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(lab(10% none none), prophoto-rgb)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(prophoto-rgb 0.0827038254 0.0827038254 0.0827038254);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(lab(none none none), prophoto-rgb)}
+
+<===> missing/all/output.css
+a {
+  b: color(prophoto-rgb none none none);
+}

--- a/spec/core_functions/color/to_space/lab/rec2020.hrx
+++ b/spec/core_functions/color/to_space/lab/rec2020.hrx
@@ -116,3 +116,25 @@ a {b: color.to-space(lab(10% 20 none), rec2020)}
 a {
   b: color(rec2020 0.2063393882 0.1229873357 0.1553854471);
 }
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(lab(10% none none), rec2020)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(rec2020 0.1542212427 0.1542212427 0.1542212427);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(lab(none none none), rec2020)}
+
+<===> missing/all/output.css
+a {
+  b: color(rec2020 none none none);
+}

--- a/spec/core_functions/color/to_space/lab/rgb.hrx
+++ b/spec/core_functions/color/to_space/lab/rgb.hrx
@@ -116,3 +116,25 @@ a {b: color.to-space(lab(10% 20 none), rgb)}
 a {
   b: rgb(19.9421405152%, 5.5967475731%, 11.0660279238%);
 }
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(lab(10% none none), rgb)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: rgb(10.7703411095%, 10.7703411095%, 10.7703411095%);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(lab(none none none), rgb)}
+
+<===> missing/all/output.css
+a {
+  b: black;
+}

--- a/spec/core_functions/color/to_space/lab/srgb.hrx
+++ b/spec/core_functions/color/to_space/lab/srgb.hrx
@@ -116,3 +116,25 @@ a {b: color.to-space(lab(10% 20 none), srgb)}
 a {
   b: color(srgb 0.1994214052 0.0559674757 0.1106602792);
 }
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(lab(10% none none), srgb)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(srgb 0.1077034111 0.1077034111 0.1077034111);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(lab(none none none), srgb)}
+
+<===> missing/all/output.css
+a {
+  b: color(srgb none none none);
+}

--- a/spec/core_functions/color/to_space/lab/srgb_linear.hrx
+++ b/spec/core_functions/color/to_space/lab/srgb_linear.hrx
@@ -116,3 +116,25 @@ a {b: color.to-space(lab(10% 20 none), srgb-linear)}
 a {
   b: color(srgb-linear 0.0329247775 0.004494318 0.0117575878);
 }
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(lab(10% none none), srgb-linear)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(srgb-linear 0.0112601993 0.0112601993 0.0112601993);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(lab(none none none), srgb-linear)}
+
+<===> missing/all/output.css
+a {
+  b: color(srgb-linear none none none);
+}

--- a/spec/core_functions/color/to_space/lab/xyz.hrx
+++ b/spec/core_functions/color/to_space/lab/xyz.hrx
@@ -116,3 +116,25 @@ a {b: color.to-space(lab(10% 20 none), xyz)}
 a {
   b: color(xyz 0.0173069918 0.0110640949 0.0123481274);
 }
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(lab(10% none none), xyz)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(xyz 0.0107023231 0.0112601993 0.0122630073);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(lab(none none none), xyz)}
+
+<===> missing/all/output.css
+a {
+  b: color(xyz none none none);
+}

--- a/spec/core_functions/color/to_space/lab/xyz_d50.hrx
+++ b/spec/core_functions/color/to_space/lab/xyz_d50.hrx
@@ -116,3 +116,25 @@ a {b: color.to-space(lab(10% 20 none), xyz-d50)}
 a {
   b: color(xyz-d50 0.0177706181 0.0112601993 0.0092908422);
 }
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(lab(10% none none), xyz-d50)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(xyz-d50 0.0108581615 0.0112601993 0.0092908422);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(lab(none none none), xyz-d50)}
+
+<===> missing/all/output.css
+a {
+  b: color(xyz-d50 none none none);
+}

--- a/spec/core_functions/color/to_space/lch/a98_rgb.hrx
+++ b/spec/core_functions/color/to_space/lch/a98_rgb.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(lch(10% 20 none), a98-rgb)}
 a {
   b: color(a98-rgb 0.1862731835 0.0856347366 0.1310611506);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(none none 10deg), a98-rgb)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(a98-rgb 0 0 0);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(50% none none), a98-rgb)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(a98-rgb 0.4633483808 0.4633483808 0.4633483808);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(none none none), a98-rgb)}
+
+<===> missing/all/output.css
+a {
+  b: color(a98-rgb none none none);
+}

--- a/spec/core_functions/color/to_space/lch/display_p3.hrx
+++ b/spec/core_functions/color/to_space/lch/display_p3.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(lch(10% 20 none), display-p3)}
 a {
   b: color(display-p3 0.1823778479 0.0651398083 0.1096920557);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(none none 10deg), display-p3)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(display-p3 0 0 0);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(50% none none), display-p3)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(display-p3 0.4663266093 0.4663266093 0.4663266093);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(none none none), display-p3)}
+
+<===> missing/all/output.css
+a {
+  b: color(display-p3 none none none);
+}

--- a/spec/core_functions/color/to_space/lch/display_p3_linear.hrx
+++ b/spec/core_functions/color/to_space/lch/display_p3_linear.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(lch(10% 20 none), display-p3-linear)}
 a {
   b: color(display-p3-linear 0.0278772897 0.0054380443 0.0115933369);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(none none 10deg), display-p3-linear)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(display-p3-linear 0 0 0);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(50% none none), display-p3-linear)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(display-p3-linear 0.1841865185 0.1841865185 0.1841865185);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(none none none), display-p3-linear)}
+
+<===> missing/all/output.css
+a {
+  b: color(display-p3-linear none none none);
+}

--- a/spec/core_functions/color/to_space/lch/hsl.hrx
+++ b/spec/core_functions/color/to_space/lch/hsl.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(lch(10% 20 none), hsl)}
 a {
   b: hsl(0, 56.1707811732%, 12.7694440441%);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(none none 10deg), hsl)}
+
+<===> missing/non_hue/output.css
+a {
+  b: hsl(0, 0%, 0%);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(50% none none), hsl)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: hsl(0, 0%, 46.6326609284%);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(none none none), hsl)}
+
+<===> missing/all/output.css
+a {
+  b: hsl(0, 0%, 0%);
+}

--- a/spec/core_functions/color/to_space/lch/hwb.hrx
+++ b/spec/core_functions/color/to_space/lch/hwb.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(lch(10% 20 none), hwb)}
 a {
   b: hsl(0, 56.1707811732%, 12.7694440441%);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(none none 10deg), hwb)}
+
+<===> missing/non_hue/output.css
+a {
+  b: red;
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(50% none none), hwb)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: hsl(0, 0%, 46.6326609284%);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(none none none), hwb)}
+
+<===> missing/all/output.css
+a {
+  b: red;
+}

--- a/spec/core_functions/color/to_space/lch/lab.hrx
+++ b/spec/core_functions/color/to_space/lch/lab.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(lch(10% 20 none), lab)}
 a {
   b: lab(10% 20 0);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(none none 10deg), lab)}
+
+<===> missing/non_hue/output.css
+a {
+  b: lab(none none none);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(50% none none), lab)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: lab(50% none none);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(none none none), lab)}
+
+<===> missing/all/output.css
+a {
+  b: lab(none none none);
+}

--- a/spec/core_functions/color/to_space/lch/lch.hrx
+++ b/spec/core_functions/color/to_space/lch/lch.hrx
@@ -50,3 +50,36 @@ a {b: color.to-space(lch(10% 20 none), lch)}
 a {
   b: lch(10% 20 none);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(none none 10deg), lch)}
+
+<===> missing/non_hue/output.css
+a {
+  b: lch(none none 10deg);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(50% none none), lch)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: lch(50% none none);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(none none none), lch)}
+
+<===> missing/all/output.css
+a {
+  b: lch(none none none);
+}

--- a/spec/core_functions/color/to_space/lch/oklab.hrx
+++ b/spec/core_functions/color/to_space/lch/oklab.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(lch(10% 20 none), oklab)}
 a {
   b: oklab(23.0834634055% 0.0614345616 -0.0007016167);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(none none 10deg), oklab)}
+
+<===> missing/non_hue/output.css
+a {
+  b: oklab(none 0 0);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(50% none none), oklab)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: oklab(56.8965517241% none none);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(none none none), oklab)}
+
+<===> missing/all/output.css
+a {
+  b: oklab(none none none);
+}

--- a/spec/core_functions/color/to_space/lch/oklch.hrx
+++ b/spec/core_functions/color/to_space/lch/oklch.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(lch(10% 20 none), oklch)}
 a {
   b: oklch(23.0834634055% 0.0614385679 none);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(none none 10deg), oklch)}
+
+<===> missing/non_hue/output.css
+a {
+  b: oklch(none none none);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(50% none none), oklch)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: oklch(56.8965517241% none none);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(none none none), oklch)}
+
+<===> missing/all/output.css
+a {
+  b: oklch(none none none);
+}

--- a/spec/core_functions/color/to_space/lch/prophoto_rgb.hrx
+++ b/spec/core_functions/color/to_space/lch/prophoto_rgb.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(lch(10% 20 none), prophoto-rgb)}
 a {
   b: color(prophoto-rgb 0.1155645311 0.0659678734 0.0827038254);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(none none 10deg), prophoto-rgb)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(prophoto-rgb 0 0 0);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(50% none none), prophoto-rgb)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(prophoto-rgb 0.3906698633 0.3906698633 0.3906698633);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(none none none), prophoto-rgb)}
+
+<===> missing/all/output.css
+a {
+  b: color(prophoto-rgb none none none);
+}

--- a/spec/core_functions/color/to_space/lch/rec2020.hrx
+++ b/spec/core_functions/color/to_space/lch/rec2020.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(lch(10% 20 none), rec2020)}
 a {
   b: color(rec2020 0.2063393882 0.1229873357 0.1553854471);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(none none 10deg), rec2020)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(rec2020 0 0 0);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(50% none none), rec2020)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(rec2020 0.4941484448 0.4941484448 0.4941484448);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(none none none), rec2020)}
+
+<===> missing/all/output.css
+a {
+  b: color(rec2020 none none none);
+}

--- a/spec/core_functions/color/to_space/lch/rgb.hrx
+++ b/spec/core_functions/color/to_space/lch/rgb.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(lch(10% 20 none), rgb)}
 a {
   b: rgb(19.9421405152%, 5.5967475731%, 11.0660279238%);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(none none 10deg), rgb)}
+
+<===> missing/non_hue/output.css
+a {
+  b: black;
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(50% none none), rgb)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: rgb(46.6326609284%, 46.6326609284%, 46.6326609284%);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(none none none), rgb)}
+
+<===> missing/all/output.css
+a {
+  b: black;
+}

--- a/spec/core_functions/color/to_space/lch/srgb.hrx
+++ b/spec/core_functions/color/to_space/lch/srgb.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(lch(10% 20 none), srgb)}
 a {
   b: color(srgb 0.1994214052 0.0559674757 0.1106602792);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(none none 10deg), srgb)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(srgb 0 0 0);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(50% none none), srgb)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(srgb 0.4663266093 0.4663266093 0.4663266093);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(none none none), srgb)}
+
+<===> missing/all/output.css
+a {
+  b: color(srgb none none none);
+}

--- a/spec/core_functions/color/to_space/lch/srgb_linear.hrx
+++ b/spec/core_functions/color/to_space/lch/srgb_linear.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(lch(10% 20 none), srgb-linear)}
 a {
   b: color(srgb-linear 0.0329247775 0.004494318 0.0117575878);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(none none 10deg), srgb-linear)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(srgb-linear 0 0 0);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(50% none none), srgb-linear)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(srgb-linear 0.1841865185 0.1841865185 0.1841865185);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(none none none), srgb-linear)}
+
+<===> missing/all/output.css
+a {
+  b: color(srgb-linear none none none);
+}

--- a/spec/core_functions/color/to_space/lch/xyz.hrx
+++ b/spec/core_functions/color/to_space/lch/xyz.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(lch(10% 20 none), xyz)}
 a {
   b: color(xyz 0.0173069918 0.0110640949 0.0123481274);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(none none 10deg), xyz)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(xyz 0 0 0);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(50% none none), xyz)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(xyz 0.1750611682 0.1841865185 0.2005897556);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(none none none), xyz)}
+
+<===> missing/all/output.css
+a {
+  b: color(xyz none none none);
+}

--- a/spec/core_functions/color/to_space/lch/xyz_d50.hrx
+++ b/spec/core_functions/color/to_space/lch/xyz_d50.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(lch(10% 20 none), xyz-d50)}
 a {
   b: color(xyz-d50 0.0177706181 0.0112601993 0.0092908422);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(none none 10deg), xyz-d50)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(xyz-d50 0 0 0);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(50% none none), xyz-d50)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(xyz-d50 0.1776102635 0.1841865185 0.1519731441);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(lch(none none none), xyz-d50)}
+
+<===> missing/all/output.css
+a {
+  b: color(xyz-d50 none none none);
+}

--- a/spec/core_functions/color/to_space/oklab/a98_rgb.hrx
+++ b/spec/core_functions/color/to_space/oklab/a98_rgb.hrx
@@ -116,3 +116,25 @@ a {b: color.to-space(oklab(10% 0.2 none), a98-rgb)}
 a {
   b: color(a98-rgb 0.1433510521 -0.0992363373 0.0248601563);
 }
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(oklab(10% none none), a98-rgb)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(a98-rgb 0.0432393561 0.0432393561 0.0432393561);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(oklab(none none none), a98-rgb)}
+
+<===> missing/all/output.css
+a {
+  b: color(a98-rgb none none none);
+}

--- a/spec/core_functions/color/to_space/oklab/display_p3.hrx
+++ b/spec/core_functions/color/to_space/oklab/display_p3.hrx
@@ -116,3 +116,25 @@ a {b: color.to-space(oklab(10% 0.2 none), display-p3)}
 a {
   b: color(display-p3 0.1380887336 -0.0636630559 0.0058108369);
 }
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(oklab(10% none none), display-p3)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(display-p3 0.01292 0.01292 0.01292);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(oklab(none none none), display-p3)}
+
+<===> missing/all/output.css
+a {
+  b: color(display-p3 none none none);
+}

--- a/spec/core_functions/color/to_space/oklab/display_p3_linear.hrx
+++ b/spec/core_functions/color/to_space/oklab/display_p3_linear.hrx
@@ -116,3 +116,25 @@ a {b: color.to-space(oklab(10% 0.2 none), display-p3-linear)}
 a {
   b: color(display-p3-linear 0.0169828565 -0.0052789964 0.0004497552);
 }
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(oklab(10% none none), display-p3-linear)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(display-p3-linear 0.001 0.001 0.001);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(oklab(none none none), display-p3-linear)}
+
+<===> missing/all/output.css
+a {
+  b: color(display-p3-linear none none none);
+}

--- a/spec/core_functions/color/to_space/oklab/hsl.hrx
+++ b/spec/core_functions/color/to_space/oklab/hsl.hrx
@@ -116,3 +116,25 @@ a {b: color.to-space(oklab(10% 0.2 none), hsl)}
 a {
   b: hsl(339.4567051743, 263.6331125505%, 4.4011033198%);
 }
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(oklab(10% none none), hsl)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: hsl(0, 0%, 1.292%);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(oklab(none none none), hsl)}
+
+<===> missing/all/output.css
+a {
+  b: hsl(0, 0%, 0%);
+}

--- a/spec/core_functions/color/to_space/oklab/hwb.hrx
+++ b/spec/core_functions/color/to_space/oklab/hwb.hrx
@@ -116,3 +116,25 @@ a {b: color.to-space(oklab(10% 0.2 none), hwb)}
 a {
   b: hsl(339.4567051743, 263.6331125505%, 4.4011033198%);
 }
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(oklab(10% none none), hwb)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: hsl(0, 0%, 1.292%);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(oklab(none none none), hwb)}
+
+<===> missing/all/output.css
+a {
+  b: red;
+}

--- a/spec/core_functions/color/to_space/oklab/lab.hrx
+++ b/spec/core_functions/color/to_space/oklab/lab.hrx
@@ -116,3 +116,25 @@ a {b: color.to-space(oklab(10% 0.2 none), lab)}
 a {
   b: lab(0.4263319735% 27.5478494427 none);
 }
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(oklab(10% none none), lab)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: lab(0.9032962963% none none);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(oklab(none none none), lab)}
+
+<===> missing/all/output.css
+a {
+  b: lab(none none none);
+}

--- a/spec/core_functions/color/to_space/oklab/lch.hrx
+++ b/spec/core_functions/color/to_space/oklab/lch.hrx
@@ -116,3 +116,25 @@ a {b: color.to-space(oklab(10% 0.2 none), lch)}
 a {
   b: lch(0.4263319735% 27.552760822 1.0818405487deg);
 }
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(oklab(10% none none), lch)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: lch(0.9032962963% none none);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(oklab(none none none), lch)}
+
+<===> missing/all/output.css
+a {
+  b: lch(none none none);
+}

--- a/spec/core_functions/color/to_space/oklab/oklab.hrx
+++ b/spec/core_functions/color/to_space/oklab/oklab.hrx
@@ -50,3 +50,25 @@ a {b: color.to-space(oklab(10% 0.2 none), oklab)}
 a {
   b: oklab(10% 0.2 none);
 }
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(oklab(10% none none), oklab)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: oklab(10% none none);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(oklab(none none none), oklab)}
+
+<===> missing/all/output.css
+a {
+  b: oklab(none none none);
+}

--- a/spec/core_functions/color/to_space/oklab/oklch.hrx
+++ b/spec/core_functions/color/to_space/oklab/oklch.hrx
@@ -116,3 +116,25 @@ a {b: color.to-space(oklab(10% 0.2 none), oklch)}
 a {
   b: oklch(10% 0.2 0deg);
 }
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(oklab(10% none none), oklch)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: oklch(10% none none);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(oklab(none none none), oklch)}
+
+<===> missing/all/output.css
+a {
+  b: oklch(none none none);
+}

--- a/spec/core_functions/color/to_space/oklab/prophoto_rgb.hrx
+++ b/spec/core_functions/color/to_space/oklab/prophoto_rgb.hrx
@@ -116,3 +116,25 @@ a {b: color.to-space(oklab(10% 0.2 none), prophoto-rgb)}
 a {
   b: color(prophoto-rgb 0.0759873336 -0.0414646624 0.0022071927);
 }
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(oklab(10% none none), prophoto-rgb)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(prophoto-rgb 0.016 0.016 0.016);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(oklab(none none none), prophoto-rgb)}
+
+<===> missing/all/output.css
+a {
+  b: color(prophoto-rgb none none none);
+}

--- a/spec/core_functions/color/to_space/oklab/rec2020.hrx
+++ b/spec/core_functions/color/to_space/oklab/rec2020.hrx
@@ -116,3 +116,25 @@ a {b: color.to-space(oklab(10% 0.2 none), rec2020)}
 a {
   b: color(rec2020 0.1571221358 -0.1021456253 0.0353819172);
 }
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(oklab(10% none none), rec2020)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(rec2020 0.0562341325 0.0562341325 0.0562341325);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(oklab(none none none), rec2020)}
+
+<===> missing/all/output.css
+a {
+  b: color(rec2020 none none none);
+}

--- a/spec/core_functions/color/to_space/oklab/rgb.hrx
+++ b/spec/core_functions/color/to_space/oklab/rgb.hrx
@@ -116,3 +116,25 @@ a {b: color.to-space(oklab(10% 0.2 none), rgb)}
 a {
   b: hsl(339.4567051743, 263.6331125505%, 4.4011033198%);
 }
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(oklab(10% none none), rgb)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: rgb(1.292%, 1.292%, 1.292%);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(oklab(none none none), rgb)}
+
+<===> missing/all/output.css
+a {
+  b: black;
+}

--- a/spec/core_functions/color/to_space/oklab/srgb.hrx
+++ b/spec/core_functions/color/to_space/oklab/srgb.hrx
@@ -116,3 +116,25 @@ a {b: color.to-space(oklab(10% 0.2 none), srgb)}
 a {
   b: color(srgb 0.1600386899 -0.0720166235 0.0074363885);
 }
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(oklab(10% none none), srgb)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(srgb 0.01292 0.01292 0.01292);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(oklab(none none none), srgb)}
+
+<===> missing/all/output.css
+a {
+  b: color(srgb none none none);
+}

--- a/spec/core_functions/color/to_space/oklab/srgb_linear.hrx
+++ b/spec/core_functions/color/to_space/oklab/srgb_linear.hrx
@@ -116,3 +116,25 @@ a {b: color.to-space(oklab(10% 0.2 none), srgb-linear)}
 a {
   b: color(srgb-linear 0.0219904416 -0.0062152621 0.0005755719);
 }
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(oklab(10% none none), srgb-linear)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(srgb-linear 0.001 0.001 0.001);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(oklab(none none none), srgb-linear)}
+
+<===> missing/all/output.css
+a {
+  b: color(srgb-linear none none none);
+}

--- a/spec/core_functions/color/to_space/oklab/xyz.hrx
+++ b/spec/core_functions/color/to_space/oklab/xyz.hrx
@@ -116,3 +116,25 @@ a {b: color.to-space(oklab(10% 0.2 none), xyz)}
 a {
   b: color(xyz 0.006950055 0.0002726167 0.000231366);
 }
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(oklab(10% none none), xyz)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(xyz 0.0009504559 0.001 0.0010890578);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(oklab(none none none), xyz)}
+
+<===> missing/all/output.css
+a {
+  b: color(xyz none none none);
+}

--- a/spec/core_functions/color/to_space/oklab/xyz_d50.hrx
+++ b/spec/core_functions/color/to_space/oklab/xyz_d50.hrx
@@ -116,3 +116,25 @@ a {b: color.to-space(oklab(10% 0.2 none), xyz-d50)}
 a {
   b: color(xyz-d50 0.0072778126 0.0004719736 0.0001138228);
 }
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(oklab(10% none none), xyz-d50)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(xyz-d50 0.0009642957 0.001 0.0008251046);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(oklab(none none none), xyz-d50)}
+
+<===> missing/all/output.css
+a {
+  b: color(xyz-d50 none none none);
+}

--- a/spec/core_functions/color/to_space/oklch/a98_rgb.hrx
+++ b/spec/core_functions/color/to_space/oklch/a98_rgb.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(oklch(10% 0.1 none), a98-rgb)}
 a {
   b: color(a98-rgb 0.0964961623 -0.0571048125 0.0359544994);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(none none 10deg), a98-rgb)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(a98-rgb 0 0 0);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(50% none none), a98-rgb)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(a98-rgb 0.3884711105 0.3884711105 0.3884711105);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(none none none), a98-rgb)}
+
+<===> missing/all/output.css
+a {
+  b: color(a98-rgb none none none);
+}

--- a/spec/core_functions/color/to_space/oklch/display_p3.hrx
+++ b/spec/core_functions/color/to_space/oklch/display_p3.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(oklch(10% 0.1 none), display-p3)}
 a {
   b: color(display-p3 0.078451453 -0.0192081229 0.0093493046);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(none none 10deg), display-p3)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(display-p3 0 0 0);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(50% none none), display-p3)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(display-p3 0.388572859 0.388572859 0.388572859);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(none none none), display-p3)}
+
+<===> missing/all/output.css
+a {
+  b: color(display-p3 none none none);
+}

--- a/spec/core_functions/color/to_space/oklch/display_p3_linear.hrx
+++ b/spec/core_functions/color/to_space/oklch/display_p3_linear.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(oklch(10% 0.1 none), display-p3-linear)}
 a {
   b: color(display-p3-linear 0.0069979371 -0.0014866968 0.0007236304);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(none none 10deg), display-p3-linear)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(display-p3-linear 0 0 0);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(50% none none), display-p3-linear)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(display-p3-linear 0.125 0.125 0.125);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(none none none), display-p3-linear)}
+
+<===> missing/all/output.css
+a {
+  b: color(display-p3-linear none none none);
+}

--- a/spec/core_functions/color/to_space/oklch/hsl.hrx
+++ b/spec/core_functions/color/to_space/oklch/hsl.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(oklch(10% 0.1 none), hsl)}
 a {
   b: hsl(0, 169.3004993061%, 3.4369836159%);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(none none 10deg), hsl)}
+
+<===> missing/non_hue/output.css
+a {
+  b: hsl(0, 0%, 0%);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(50% none none), hsl)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: hsl(0, 0%, 38.8572859046%);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(none none none), hsl)}
+
+<===> missing/all/output.css
+a {
+  b: hsl(0, 0%, 0%);
+}

--- a/spec/core_functions/color/to_space/oklch/hwb.hrx
+++ b/spec/core_functions/color/to_space/oklch/hwb.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(oklch(10% 0.1 none), hwb)}
 a {
   b: hsl(0, 169.3004993061%, 3.4369836159%);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(none none 10deg), hwb)}
+
+<===> missing/non_hue/output.css
+a {
+  b: red;
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(50% none none), hwb)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: hsl(0, 0%, 38.8572859046%);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(none none none), hwb)}
+
+<===> missing/all/output.css
+a {
+  b: red;
+}

--- a/spec/core_functions/color/to_space/oklch/lab.hrx
+++ b/spec/core_functions/color/to_space/oklch/lab.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(oklch(10% 0.1 none), lab)}
 a {
   b: lab(0.6385915209% 10.50938712 0.1611876153);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(none none 10deg), lab)}
+
+<===> missing/non_hue/output.css
+a {
+  b: lab(none 0 0);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(50% none none), lab)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: lab(42% none none);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(none none none), lab)}
+
+<===> missing/all/output.css
+a {
+  b: lab(none none none);
+}

--- a/spec/core_functions/color/to_space/oklch/lch.hrx
+++ b/spec/core_functions/color/to_space/oklch/lch.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(oklch(10% 0.1 none), lch)}
 a {
   b: lch(0.6385915209% 10.510623154 none);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(none none 10deg), lch)}
+
+<===> missing/non_hue/output.css
+a {
+  b: lch(none none none);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(50% none none), lch)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: lch(42% none none);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(none none none), lch)}
+
+<===> missing/all/output.css
+a {
+  b: lch(none none none);
+}

--- a/spec/core_functions/color/to_space/oklch/oklab.hrx
+++ b/spec/core_functions/color/to_space/oklch/oklab.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(oklch(10% 0.1 none), oklab)}
 a {
   b: oklab(10% 0.1 0);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(none none 10deg), oklab)}
+
+<===> missing/non_hue/output.css
+a {
+  b: oklab(none 0 0);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(50% none none), oklab)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: oklab(50% none none);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(none none none), oklab)}
+
+<===> missing/all/output.css
+a {
+  b: oklab(none none none);
+}

--- a/spec/core_functions/color/to_space/oklch/oklch.hrx
+++ b/spec/core_functions/color/to_space/oklch/oklch.hrx
@@ -50,3 +50,36 @@ a {b: color.to-space(oklch(10% 0.1 none), oklch)}
 a {
   b: oklch(10% 0.1 none);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(none none 10deg), oklch)}
+
+<===> missing/non_hue/output.css
+a {
+  b: oklch(none none 10deg);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(50% none none), oklch)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: oklch(50% none none);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(none none none), oklch)}
+
+<===> missing/all/output.css
+a {
+  b: oklch(none none none);
+}

--- a/spec/core_functions/color/to_space/oklch/prophoto_rgb.hrx
+++ b/spec/core_functions/color/to_space/oklch/prophoto_rgb.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(oklch(10% 0.1 none), prophoto-rgb)}
 a {
   b: color(prophoto-rgb 0.0479066366 -0.0113980128 0.0096553515);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(none none 10deg), prophoto-rgb)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(prophoto-rgb 0 0 0);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(50% none none), prophoto-rgb)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(prophoto-rgb 0.3149802625 0.3149802625 0.3149802625);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(none none none), prophoto-rgb)}
+
+<===> missing/all/output.css
+a {
+  b: color(prophoto-rgb none none none);
+}

--- a/spec/core_functions/color/to_space/oklch/rec2020.hrx
+++ b/spec/core_functions/color/to_space/oklch/rec2020.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(oklch(10% 0.1 none), rec2020)}
 a {
   b: color(rec2020 0.1100929542 -0.0578643858 0.0478020915);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(none none 10deg), rec2020)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(rec2020 0 0 0);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(50% none none), rec2020)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(rec2020 0.4204482076 0.4204482076 0.4204482076);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(none none none), rec2020)}
+
+<===> missing/all/output.css
+a {
+  b: color(rec2020 none none none);
+}

--- a/spec/core_functions/color/to_space/oklch/rgb.hrx
+++ b/spec/core_functions/color/to_space/oklch/rgb.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(oklch(10% 0.1 none), rgb)}
 a {
   b: hsl(342.5627245765, 169.3004993061%, 3.4369836159%);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(none none 10deg), rgb)}
+
+<===> missing/non_hue/output.css
+a {
+  b: black;
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(50% none none), rgb)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: rgb(38.8572859046%, 38.8572859046%, 38.8572859046%);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(none none none), rgb)}
+
+<===> missing/all/output.css
+a {
+  b: black;
+}

--- a/spec/core_functions/color/to_space/oklch/srgb.hrx
+++ b/spec/core_functions/color/to_space/oklch/srgb.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(oklch(10% 0.1 none), srgb)}
 a {
   b: color(srgb 0.0925581404 -0.0238184681 0.0100030482);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(none none 10deg), srgb)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(srgb 0 0 0);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(50% none none), srgb)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(srgb 0.388572859 0.388572859 0.388572859);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(none none none), srgb)}
+
+<===> missing/all/output.css
+a {
+  b: color(srgb none none none);
+}

--- a/spec/core_functions/color/to_space/oklch/srgb_linear.hrx
+++ b/spec/core_functions/color/to_space/oklch/srgb_linear.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(oklch(10% 0.1 none), srgb-linear)}
 a {
   b: color(srgb-linear 0.0089064721 -0.0018435347 0.0007742297);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(none none 10deg), srgb-linear)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(srgb-linear 0 0 0);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(50% none none), srgb-linear)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(srgb-linear 0.125 0.125 0.125);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(none none none), srgb-linear)}
+
+<===> missing/all/output.css
+a {
+  b: color(srgb-linear none none none);
+}

--- a/spec/core_functions/color/to_space/oklch/xyz.hrx
+++ b/spec/core_functions/color/to_space/oklch/xyz.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(oklch(10% 0.1 none), xyz)}
 a {
   b: color(xyz 0.0031534616 0.0006313186 0.0006883599);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(none none 10deg), xyz)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(xyz 0 0 0);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(50% none none), xyz)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(xyz 0.1188069909 0.125 0.1361322188);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(none none none), xyz)}
+
+<===> missing/all/output.css
+a {
+  b: color(xyz none none none);
+}

--- a/spec/core_functions/color/to_space/oklch/xyz_d50.hrx
+++ b/spec/core_functions/color/to_space/oklch/xyz_d50.hrx
@@ -127,3 +127,36 @@ a {b: color.to-space(oklch(10% 0.1 none), xyz-d50)}
 a {
   b: color(xyz-d50 0.0032845428 0.0007069569 0.0004979172);
 }
+
+<===>
+================================================================================
+<===> missing/non_hue/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(none none 10deg), xyz-d50)}
+
+<===> missing/non_hue/output.css
+a {
+  b: color(xyz-d50 0 0 0);
+}
+
+<===>
+================================================================================
+<===> missing/non_lightness/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(50% none none), xyz-d50)}
+
+<===> missing/non_lightness/output.css
+a {
+  b: color(xyz-d50 0.1205369596 0.125 0.1031380753);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(oklch(none none none), xyz-d50)}
+
+<===> missing/all/output.css
+a {
+  b: color(xyz-d50 none none none);
+}

--- a/spec/core_functions/color/to_space/prophoto_rgb/hsl.hrx
+++ b/spec/core_functions/color/to_space/prophoto_rgb/hsl.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(prophoto-rgb 0.1 0.2 none), hsl)}
 a {
   b: hsl(119.2084673976, 194.643672602%, 9.5495891256%);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(prophoto-rgb none none none), hsl)}
+
+<===> missing/all/output.css
+a {
+  b: hsl(0, 0%, 0%);
+}

--- a/spec/core_functions/color/to_space/prophoto_rgb/hwb.hrx
+++ b/spec/core_functions/color/to_space/prophoto_rgb/hwb.hrx
@@ -147,3 +147,14 @@ a {b: color.to-space(color(prophoto-rgb 0.1 0.2 none), hwb)}
 a {
   b: hsl(119.2084673976, 194.643672602%, 9.5495891256%);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(prophoto-rgb none none none), hwb)}
+
+<===> missing/all/output.css
+a {
+  b: red;
+}

--- a/spec/core_functions/color/to_space/prophoto_rgb/lab.hrx
+++ b/spec/core_functions/color/to_space/prophoto_rgb/lab.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(prophoto-rgb 0.1 0.2 none), lab)}
 a {
   b: lab(24.9058511193% -38.7042406064 42.9411226195);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(prophoto-rgb none none none), lab)}
+
+<===> missing/all/output.css
+a {
+  b: lab(none none none);
+}

--- a/spec/core_functions/color/to_space/prophoto_rgb/lch.hrx
+++ b/spec/core_functions/color/to_space/prophoto_rgb/lch.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(prophoto-rgb 0.1 0.2 none), lch)}
 a {
   b: lch(24.9058511193% 57.8096726572 132.0293732633deg);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(prophoto-rgb none none none), lch)}
+
+<===> missing/all/output.css
+a {
+  b: lch(none none none);
+}

--- a/spec/core_functions/color/to_space/prophoto_rgb/oklab.hrx
+++ b/spec/core_functions/color/to_space/prophoto_rgb/oklab.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(prophoto-rgb 0.1 0.2 none), oklab)}
 a {
   b: oklab(33.9153746566% -0.1155256052 0.0932618107);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(prophoto-rgb none none none), oklab)}
+
+<===> missing/all/output.css
+a {
+  b: oklab(none none none);
+}

--- a/spec/core_functions/color/to_space/prophoto_rgb/oklch.hrx
+++ b/spec/core_functions/color/to_space/prophoto_rgb/oklch.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(prophoto-rgb 0.1 0.2 none), oklch)}
 a {
   b: oklch(33.9153746566% 0.1484719865 141.086665946deg);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(prophoto-rgb none none none), oklch)}
+
+<===> missing/all/output.css
+a {
+  b: oklch(none none none);
+}

--- a/spec/core_functions/color/to_space/rec2020/hsl.hrx
+++ b/spec/core_functions/color/to_space/rec2020/hsl.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(rec2020 0.1 0.2 none), hsl)}
 a {
   b: hsl(130.1929265324, 239.2223908609%, 4.873488282%);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(rec2020 none none none), hsl)}
+
+<===> missing/all/output.css
+a {
+  b: hsl(0, 0%, 0%);
+}

--- a/spec/core_functions/color/to_space/rec2020/hwb.hrx
+++ b/spec/core_functions/color/to_space/rec2020/hwb.hrx
@@ -147,3 +147,14 @@ a {b: color.to-space(color(rec2020 0.1 0.2 none), hwb)}
 a {
   b: hsl(130.1929265324, 239.2223908609%, 4.873488282%);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(rec2020 none none none), hwb)}
+
+<===> missing/all/output.css
+a {
+  b: red;
+}

--- a/spec/core_functions/color/to_space/rec2020/lab.hrx
+++ b/spec/core_functions/color/to_space/rec2020/lab.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(rec2020 0.1 0.2 none), lab)}
 a {
   b: lab(12.7980788363% -30.2799799635 20.8912193128);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(rec2020 none none none), lab)}
+
+<===> missing/all/output.css
+a {
+  b: lab(none none none);
+}

--- a/spec/core_functions/color/to_space/rec2020/lch.hrx
+++ b/spec/core_functions/color/to_space/rec2020/lch.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(rec2020 0.1 0.2 none), lch)}
 a {
   b: lch(12.7980788363% 36.7875010155 145.3968458287deg);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(rec2020 none none none), lch)}
+
+<===> missing/all/output.css
+a {
+  b: lch(none none none);
+}

--- a/spec/core_functions/color/to_space/rec2020/oklab.hrx
+++ b/spec/core_functions/color/to_space/rec2020/oklab.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(rec2020 0.1 0.2 none), oklab)}
 a {
   b: oklab(23.7844679127% -0.0891920746 0.0607987891);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(rec2020 none none none), oklab)}
+
+<===> missing/all/output.css
+a {
+  b: oklab(none none none);
+}

--- a/spec/core_functions/color/to_space/rec2020/oklch.hrx
+++ b/spec/core_functions/color/to_space/rec2020/oklch.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(rec2020 0.1 0.2 none), oklch)}
 a {
   b: oklch(23.7844679127% 0.1079431282 145.7192580256deg);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(rec2020 none none none), oklch)}
+
+<===> missing/all/output.css
+a {
+  b: oklch(none none none);
+}

--- a/spec/core_functions/color/to_space/rgb/hsl.hrx
+++ b/spec/core_functions/color/to_space/rgb/hsl.hrx
@@ -127,3 +127,14 @@ a {b: color.to-space(rgb(10 20 none), hsl)}
 a {
   b: hsl(90, 100%, 3.9215686275%);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(rgb(none none none), hsl)}
+
+<===> missing/all/output.css
+a {
+  b: hsl(0, 0%, 0%);
+}

--- a/spec/core_functions/color/to_space/rgb/hwb.hrx
+++ b/spec/core_functions/color/to_space/rgb/hwb.hrx
@@ -163,3 +163,14 @@ a {b: color.to-space(rgb(10 20 none), hwb)}
 a {
   b: #0a1400;
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(rgb(none none none), hwb)}
+
+<===> missing/all/output.css
+a {
+  b: red;
+}

--- a/spec/core_functions/color/to_space/rgb/lab.hrx
+++ b/spec/core_functions/color/to_space/rgb/lab.hrx
@@ -127,3 +127,14 @@ a {b: color.to-space(rgb(10 20 none), lab)}
 a {
   b: lab(5.1399777246% -5.9321982521 7.5003938134);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(rgb(none none none), lab)}
+
+<===> missing/all/output.css
+a {
+  b: lab(none none none);
+}

--- a/spec/core_functions/color/to_space/rgb/lch.hrx
+++ b/spec/core_functions/color/to_space/rgb/lch.hrx
@@ -127,3 +127,14 @@ a {b: color.to-space(rgb(10 20 none), lch)}
 a {
   b: lch(5.1399777246% 9.5627863857 128.3411151091deg);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(rgb(none none none), lch)}
+
+<===> missing/all/output.css
+a {
+  b: lch(none none none);
+}

--- a/spec/core_functions/color/to_space/rgb/oklab.hrx
+++ b/spec/core_functions/color/to_space/rgb/oklab.hrx
@@ -127,3 +127,14 @@ a {b: color.to-space(rgb(10 20 none), oklab)}
 a {
   b: oklab(17.4737574106% -0.0289569465 0.0360129822);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(rgb(none none none), oklab)}
+
+<===> missing/all/output.css
+a {
+  b: oklab(none none none);
+}

--- a/spec/core_functions/color/to_space/rgb/oklch.hrx
+++ b/spec/core_functions/color/to_space/rgb/oklch.hrx
@@ -127,3 +127,14 @@ a {b: color.to-space(rgb(10 20 none), oklch)}
 a {
   b: oklch(17.4737574106% 0.0462108173 128.8017058762deg);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(rgb(none none none), oklch)}
+
+<===> missing/all/output.css
+a {
+  b: oklch(none none none);
+}

--- a/spec/core_functions/color/to_space/srgb/hsl.hrx
+++ b/spec/core_functions/color/to_space/srgb/hsl.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(srgb 0.1 0.2 none), hsl)}
 a {
   b: hsl(90, 100%, 10%);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(srgb none none none), hsl)}
+
+<===> missing/all/output.css
+a {
+  b: hsl(0, 0%, 0%);
+}

--- a/spec/core_functions/color/to_space/srgb/hwb.hrx
+++ b/spec/core_functions/color/to_space/srgb/hwb.hrx
@@ -147,3 +147,14 @@ a {b: color.to-space(color(srgb 0.1 0.2 none), hwb)}
 a {
   b: hsl(90, 100%, 10%);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(srgb none none none), hwb)}
+
+<===> missing/all/output.css
+a {
+  b: red;
+}

--- a/spec/core_functions/color/to_space/srgb/lab.hrx
+++ b/spec/core_functions/color/to_space/srgb/lab.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(srgb 0.1 0.2 none), lab)}
 a {
   b: lab(18.3483752329% -17.6137840535 25.305473968);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(srgb none none none), lab)}
+
+<===> missing/all/output.css
+a {
+  b: lab(none none none);
+}

--- a/spec/core_functions/color/to_space/srgb/lch.hrx
+++ b/spec/core_functions/color/to_space/srgb/lch.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(srgb 0.1 0.2 none), lch)}
 a {
   b: lch(18.3483752329% 30.8320028773 124.8397077198deg);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(srgb none none none), lch)}
+
+<===> missing/all/output.css
+a {
+  b: lch(none none none);
+}

--- a/spec/core_functions/color/to_space/srgb/oklab.hrx
+++ b/spec/core_functions/color/to_space/srgb/oklab.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(srgb 0.1 0.2 none), oklab)}
 a {
   b: oklab(28.8978413919% -0.0558272242 0.05963976);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(srgb none none none), oklab)}
+
+<===> missing/all/output.css
+a {
+  b: oklab(none none none);
+}

--- a/spec/core_functions/color/to_space/srgb/oklch.hrx
+++ b/spec/core_functions/color/to_space/srgb/oklch.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(srgb 0.1 0.2 none), oklch)}
 a {
   b: oklch(28.8978413919% 0.0816919821 133.1088717005deg);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(srgb none none none), oklch)}
+
+<===> missing/all/output.css
+a {
+  b: oklch(none none none);
+}

--- a/spec/core_functions/color/to_space/srgb_linear/hsl.hrx
+++ b/spec/core_functions/color/to_space/srgb_linear/hsl.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(srgb-linear 0.1 0.2 none), hsl)}
 a {
   b: hsl(76.7592364631, 100%, 24.2264602241%);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(srgb-linear none none none), hsl)}
+
+<===> missing/all/output.css
+a {
+  b: hsl(0, 0%, 0%);
+}

--- a/spec/core_functions/color/to_space/srgb_linear/hwb.hrx
+++ b/spec/core_functions/color/to_space/srgb_linear/hwb.hrx
@@ -147,3 +147,14 @@ a {b: color.to-space(color(srgb-linear 0.1 0.2 none), hwb)}
 a {
   b: hsl(76.7592364631, 100%, 24.2264602241%);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(srgb-linear none none none), hwb)}
+
+<===> missing/all/output.css
+a {
+  b: red;
+}

--- a/spec/core_functions/color/to_space/srgb_linear/lab.hrx
+++ b/spec/core_functions/color/to_space/srgb_linear/lab.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(srgb-linear 0.1 0.2 none), lab)}
 a {
   b: lab(47.7042083773% -24.5180464109 51.183897624);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(srgb-linear none none none), lab)}
+
+<===> missing/all/output.css
+a {
+  b: lab(none none none);
+}

--- a/spec/core_functions/color/to_space/srgb_linear/lch.hrx
+++ b/spec/core_functions/color/to_space/srgb_linear/lch.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(srgb-linear 0.1 0.2 none), lch)}
 a {
   b: lch(47.7042083773% 56.7532023396 115.5952944453deg);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(srgb-linear none none none), lch)}
+
+<===> missing/all/output.css
+a {
+  b: lch(none none none);
+}

--- a/spec/core_functions/color/to_space/srgb_linear/oklab.hrx
+++ b/spec/core_functions/color/to_space/srgb_linear/oklab.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(srgb-linear 0.1 0.2 none), oklab)}
 a {
   b: oklab(53.8237211404% -0.0823086195 0.1108579758);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(srgb-linear none none none), oklab)}
+
+<===> missing/all/output.css
+a {
+  b: oklab(none none none);
+}

--- a/spec/core_functions/color/to_space/srgb_linear/oklch.hrx
+++ b/spec/core_functions/color/to_space/srgb_linear/oklch.hrx
@@ -116,3 +116,14 @@ a {b: color.to-space(color(srgb-linear 0.1 0.2 none), oklch)}
 a {
   b: oklch(53.8237211404% 0.1380731677 126.5927444559deg);
 }
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(srgb-linear none none none), oklch)}
+
+<===> missing/all/output.css
+a {
+  b: oklch(none none none);
+}

--- a/spec/core_functions/color/to_space/xyz/a98_rgb.hrx
+++ b/spec/core_functions/color/to_space/xyz/a98_rgb.hrx
@@ -86,33 +86,33 @@ a {
 
 <===>
 ================================================================================
-<===> missing/red/input.scss
+<===> missing/x/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz none 0.2 0.3), a98-rgb)}
 
-<===> missing/red/output.css
+<===> missing/x/output.css
 a {
   b: color(a98-rgb none 0.6499288625 0.5613563103);
 }
 
 <===>
 ================================================================================
-<===> missing/green/input.scss
+<===> missing/y/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz 0.1 none 0.3), a98-rgb)}
 
-<===> missing/green/output.css
+<===> missing/y/output.css
 a {
   b: color(a98-rgb 0.3521663165 none 0.5835625865);
 }
 
 <===>
 ================================================================================
-<===> missing/blue/input.scss
+<===> missing/z/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz 0.1 0.2 none), a98-rgb)}
 
-<===> missing/blue/output.css
+<===> missing/z/output.css
 a {
   b: color(a98-rgb 0.3365194536 0.5589776013 none);
 }

--- a/spec/core_functions/color/to_space/xyz/display_p3.hrx
+++ b/spec/core_functions/color/to_space/xyz/display_p3.hrx
@@ -86,33 +86,33 @@ a {
 
 <===>
 ================================================================================
-<===> missing/red/input.scss
+<===> missing/x/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz none 0.2 0.3), display-p3)}
 
-<===> missing/red/output.css
+<===> missing/x/output.css
 a {
   b: color(display-p3 none 0.6339496775 0.5581173728);
 }
 
 <===>
 ================================================================================
-<===> missing/green/input.scss
+<===> missing/y/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz 0.1 none 0.3), display-p3)}
 
-<===> missing/green/output.css
+<===> missing/y/output.css
 a {
   b: color(display-p3 0.3937592636 none 0.575458821);
 }
 
 <===>
 ================================================================================
-<===> missing/blue/input.scss
+<===> missing/z/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz 0.1 0.2 none), display-p3)}
 
-<===> missing/blue/output.css
+<===> missing/z/output.css
 a {
   b: color(display-p3 0.2785701294 0.5560005714 none);
 }

--- a/spec/core_functions/color/to_space/xyz/display_p3_linear.hrx
+++ b/spec/core_functions/color/to_space/xyz/display_p3_linear.hrx
@@ -86,33 +86,33 @@ a {
 
 <===>
 ================================================================================
-<===> missing/red/input.scss
+<===> missing/x/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz none 0.2 0.3), display-p3-linear)}
 
-<===> missing/red/output.css
+<===> missing/x/output.css
 a {
   b: color(display-p3-linear none 0.3596202178 0.2718308793);
 }
 
 <===>
 ================================================================================
-<===> missing/green/input.scss
+<===> missing/y/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz 0.1 none 0.3), display-p3-linear)}
 
-<===> missing/green/output.css
+<===> missing/y/output.css
 a {
   b: color(display-p3-linear 0.1285364559 none 0.2906499402);
 }
 
 <===>
 ================================================================================
-<===> missing/blue/input.scss
+<===> missing/z/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz 0.1 0.2 none), display-p3-linear)}
 
-<===> missing/blue/output.css
+<===> missing/z/output.css
 a {
   b: color(display-p3-linear 0.0630729676 0.2695839151 none);
 }

--- a/spec/core_functions/color/to_space/xyz/hsl.hrx
+++ b/spec/core_functions/color/to_space/xyz/hsl.hrx
@@ -86,33 +86,44 @@ a {
 
 <===>
 ================================================================================
-<===> missing/red/input.scss
+<===> missing/x/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz none 0.2 0.3), hsl)}
 
-<===> missing/red/output.css
+<===> missing/x/output.css
 a {
   b: hsl(355.8794204538, 2697.9214173204%, -2.5244914397%);
 }
 
 <===>
 ================================================================================
-<===> missing/green/input.scss
+<===> missing/y/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz 0.1 none 0.3), hsl)}
 
-<===> missing/green/output.css
+<===> missing/y/output.css
 a {
   b: hsl(290.3526254976, 328.3439800543%, 14.0892871543%);
 }
 
 <===>
 ================================================================================
-<===> missing/blue/input.scss
+<===> missing/z/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz 0.1 0.2 none), hsl)}
 
-<===> missing/blue/output.css
+<===> missing/z/output.css
 a {
   b: hsl(93.2964667331, 215.664278299%, 17.8710983929%);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(xyz none none none), hsl)}
+
+<===> missing/all/output.css
+a {
+  b: hsl(0, 0%, 0%);
 }

--- a/spec/core_functions/color/to_space/xyz/hwb.hrx
+++ b/spec/core_functions/color/to_space/xyz/hwb.hrx
@@ -110,12 +110,12 @@ a {
 
 <===>
 ================================================================================
-<===> missing/red/input.scss
+<===> missing/x/input.scss
 @use "sass:color";
 @use 'core_functions/color/utils';
 @include utils.inspect(color.to-space(color(xyz none 0.2 0.3), hwb));
 
-<===> missing/red/output.css
+<===> missing/x/output.css
 a {
   value: hsl(355.8794204538, 2697.9214173204%, -2.5244914397%);
   space: hwb;
@@ -124,12 +124,12 @@ a {
 
 <===>
 ================================================================================
-<===> missing/green/input.scss
+<===> missing/y/input.scss
 @use "sass:color";
 @use 'core_functions/color/utils';
 @include utils.inspect(color.to-space(color(xyz 0.1 none 0.3), hwb));
 
-<===> missing/green/output.css
+<===> missing/y/output.css
 a {
   value: hsl(290.3526254976, 328.3439800543%, 14.0892871543%);
   space: hwb;
@@ -138,12 +138,23 @@ a {
 
 <===>
 ================================================================================
-<===> missing/blue/input.scss
+<===> missing/z/input.scss
 @use "sass:color";
 @use 'core_functions/color/utils';
 a {b: color.to-space(color(xyz 0.1 0.2 none), hwb)}
 
-<===> missing/blue/output.css
+<===> missing/z/output.css
 a {
   b: hsl(93.2964667331, 215.664278299%, 17.8710983929%);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(xyz none none none), hwb)}
+
+<===> missing/all/output.css
+a {
+  b: red;
 }

--- a/spec/core_functions/color/to_space/xyz/lab.hrx
+++ b/spec/core_functions/color/to_space/xyz/lab.hrx
@@ -86,33 +86,44 @@ a {
 
 <===>
 ================================================================================
-<===> missing/red/input.scss
+<===> missing/x/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz none 0.2 0.3), lab)}
 
-<===> missing/red/output.css
+<===> missing/x/output.css
 a {
   b: lab(51.0322781723% -262.2343975897 -14.80446365);
 }
 
 <===>
 ================================================================================
-<===> missing/green/input.scss
+<===> missing/y/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz 0.1 none 0.3), lab)}
 
-<===> missing/green/output.css
+<===> missing/y/output.css
 a {
   b: color-mix(in lab, color(xyz 0.1 0 0.3) 100%, black);
 }
 
 <===>
 ================================================================================
-<===> missing/blue/input.scss
+<===> missing/z/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz 0.1 0.2 none), lab)}
 
-<===> missing/blue/output.css
+<===> missing/z/output.css
 a {
   b: lab(51.9556818936% -50.8750926576 85.6399941916);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(xyz none none none), lab)}
+
+<===> missing/all/output.css
+a {
+  b: lab(none none none);
 }

--- a/spec/core_functions/color/to_space/xyz/lch.hrx
+++ b/spec/core_functions/color/to_space/xyz/lch.hrx
@@ -86,33 +86,44 @@ a {
 
 <===>
 ================================================================================
-<===> missing/red/input.scss
+<===> missing/x/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz none 0.2 0.3), lch)}
 
-<===> missing/red/output.css
+<===> missing/x/output.css
 a {
   b: lch(51.0322781723% 262.6519587272 183.231207866deg);
 }
 
 <===>
 ================================================================================
-<===> missing/green/input.scss
+<===> missing/y/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz 0.1 none 0.3), lch)}
 
-<===> missing/green/output.css
+<===> missing/y/output.css
 a {
   b: color-mix(in lch, color(xyz 0.1 0 0.3) 100%, black);
 }
 
 <===>
 ================================================================================
-<===> missing/blue/input.scss
+<===> missing/z/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz 0.1 0.2 none), lch)}
 
-<===> missing/blue/output.css
+<===> missing/z/output.css
 a {
   b: lch(51.9556818936% 99.6116642671 120.7127528375deg);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(xyz none none none), lch)}
+
+<===> missing/all/output.css
+a {
+  b: lch(none none none);
 }

--- a/spec/core_functions/color/to_space/xyz/oklab.hrx
+++ b/spec/core_functions/color/to_space/xyz/oklab.hrx
@@ -86,33 +86,44 @@ a {
 
 <===>
 ================================================================================
-<===> missing/red/input.scss
+<===> missing/x/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz none 0.2 0.3), oklab)}
 
-<===> missing/red/output.css
+<===> missing/x/output.css
 a {
   b: oklab(52.6994311398% -0.4922232483 -0.0409679567);
 }
 
 <===>
 ================================================================================
-<===> missing/green/input.scss
+<===> missing/y/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz 0.1 none 0.3), oklab)}
 
-<===> missing/green/output.css
+<===> missing/y/output.css
 a {
   b: oklab(26.3423255262% 0.3682063802 -0.2704617674);
 }
 
 <===>
 ================================================================================
-<===> missing/blue/input.scss
+<===> missing/z/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz 0.1 0.2 none), oklab)}
 
-<===> missing/blue/output.css
+<===> missing/z/output.css
 a {
   b: oklab(56.6867662885% -0.1591393729 0.1508075356);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(xyz none none none), oklab)}
+
+<===> missing/all/output.css
+a {
+  b: oklab(none none none);
 }

--- a/spec/core_functions/color/to_space/xyz/oklch.hrx
+++ b/spec/core_functions/color/to_space/xyz/oklch.hrx
@@ -86,33 +86,44 @@ a {
 
 <===>
 ================================================================================
-<===> missing/red/input.scss
+<===> missing/x/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz none 0.2 0.3), oklch)}
 
-<===> missing/red/output.css
+<===> missing/x/output.css
 a {
   b: oklch(52.6994311398% 0.4939251964 184.7577868469deg);
 }
 
 <===>
 ================================================================================
-<===> missing/green/input.scss
+<===> missing/y/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz 0.1 none 0.3), oklch)}
 
-<===> missing/green/output.css
+<===> missing/y/output.css
 a {
   b: oklch(26.3423255262% 0.4568648662 323.7012844561deg);
 }
 
 <===>
 ================================================================================
-<===> missing/blue/input.scss
+<===> missing/z/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz 0.1 0.2 none), oklch)}
 
-<===> missing/blue/output.css
+<===> missing/z/output.css
 a {
   b: oklch(56.6867662885% 0.2192447326 136.5398255702deg);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(xyz none none none), oklch)}
+
+<===> missing/all/output.css
+a {
+  b: oklch(none none none);
 }

--- a/spec/core_functions/color/to_space/xyz/prophoto_rgb.hrx
+++ b/spec/core_functions/color/to_space/xyz/prophoto_rgb.hrx
@@ -86,33 +86,33 @@ a {
 
 <===>
 ================================================================================
-<===> missing/red/input.scss
+<===> missing/x/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz none 0.2 0.3), prophoto-rgb)}
 
-<===> missing/red/output.css
+<===> missing/x/output.css
 a {
   b: color(prophoto-rgb none 0.5136422936 0.49010255);
 }
 
 <===>
 ================================================================================
-<===> missing/green/input.scss
+<===> missing/y/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz 0.1 none 0.3), prophoto-rgb)}
 
-<===> missing/green/output.css
+<===> missing/y/output.css
 a {
   b: color(prophoto-rgb 0.2931451274 none 0.4853966387);
 }
 
 <===>
 ================================================================================
-<===> missing/blue/input.scss
+<===> missing/z/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz 0.1 0.2 none), prophoto-rgb)}
 
-<===> missing/blue/output.css
+<===> missing/z/output.css
 a {
   b: color(prophoto-rgb 0.2715690946 0.4564221473 none);
 }

--- a/spec/core_functions/color/to_space/xyz/rec2020.hrx
+++ b/spec/core_functions/color/to_space/xyz/rec2020.hrx
@@ -86,33 +86,33 @@ a {
 
 <===>
 ================================================================================
-<===> missing/red/input.scss
+<===> missing/x/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz none 0.2 0.3), rec2020)}
 
-<===> missing/red/output.css
+<===> missing/x/output.css
 a {
   b: color(rec2020 none 0.6284859295 0.5831497901);
 }
 
 <===>
 ================================================================================
-<===> missing/green/input.scss
+<===> missing/y/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz 0.1 none 0.3), rec2020)}
 
-<===> missing/green/output.css
+<===> missing/y/output.css
 a {
   b: color(rec2020 0.3760930504 none 0.5921986764);
 }
 
 <===>
 ================================================================================
-<===> missing/blue/input.scss
+<===> missing/z/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz 0.1 0.2 none), rec2020)}
 
-<===> missing/blue/output.css
+<===> missing/z/output.css
 a {
   b: color(rec2020 0.3839649655 0.5673833022 none);
 }

--- a/spec/core_functions/color/to_space/xyz/rgb.hrx
+++ b/spec/core_functions/color/to_space/xyz/rgb.hrx
@@ -86,33 +86,33 @@ a {
 
 <===>
 ================================================================================
-<===> missing/red/input.scss
+<===> missing/x/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz none 0.2 0.3), rgb)}
 
-<===> missing/red/output.css
+<===> missing/x/output.css
 a {
   b: rgb(0%, 65.5843037912%, 56.2293801732%);
 }
 
 <===>
 ================================================================================
-<===> missing/green/input.scss
+<===> missing/y/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz 0.1 none 0.3), rgb)}
 
-<===> missing/green/output.css
+<===> missing/y/output.css
 a {
   b: rgb(45.4739353957%, 0%, 60.3506133579%);
 }
 
 <===>
 ================================================================================
-<===> missing/blue/input.scss
+<===> missing/z/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz 0.1 0.2 none), rgb)}
 
-<===> missing/blue/output.css
+<===> missing/z/output.css
 a {
   b: rgb(13.6360643575%, 56.4126737659%, 0%);
 }

--- a/spec/core_functions/color/to_space/xyz/srgb.hrx
+++ b/spec/core_functions/color/to_space/xyz/srgb.hrx
@@ -86,33 +86,33 @@ a {
 
 <===>
 ================================================================================
-<===> missing/red/input.scss
+<===> missing/x/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz none 0.2 0.3), srgb)}
 
-<===> missing/red/output.css
+<===> missing/x/output.css
 a {
   b: color(srgb none 0.6558430379 0.5622938017);
 }
 
 <===>
 ================================================================================
-<===> missing/green/input.scss
+<===> missing/y/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz 0.1 none 0.3), srgb)}
 
-<===> missing/green/output.css
+<===> missing/y/output.css
 a {
   b: color(srgb 0.454739354 none 0.6035061336);
 }
 
 <===>
 ================================================================================
-<===> missing/blue/input.scss
+<===> missing/z/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz 0.1 0.2 none), srgb)}
 
-<===> missing/blue/output.css
+<===> missing/z/output.css
 a {
   b: color(srgb 0.1363606436 0.5641267377 none);
 }

--- a/spec/core_functions/color/to_space/xyz/srgb_linear.hrx
+++ b/spec/core_functions/color/to_space/xyz/srgb_linear.hrx
@@ -86,33 +86,33 @@ a {
 
 <===>
 ================================================================================
-<===> missing/red/input.scss
+<===> missing/x/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz none 0.2 0.3), srgb-linear)}
 
-<===> missing/red/output.css
+<===> missing/x/output.css
 a {
   b: color(srgb-linear none 0.3876600175 0.2762960625);
 }
 
 <===>
 ================================================================================
-<===> missing/green/input.scss
+<===> missing/y/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz 0.1 none 0.3), srgb-linear)}
 
-<===> missing/green/output.css
+<===> missing/y/output.css
 a {
   b: color(srgb-linear 0.1745137661 none 0.3226544622);
 }
 
 <===>
 ================================================================================
-<===> missing/blue/input.scss
+<===> missing/z/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz 0.1 0.2 none), srgb-linear)}
 
-<===> missing/blue/output.css
+<===> missing/z/output.css
 a {
   b: color(srgb-linear 0.0166203587 0.2782691367 none);
 }

--- a/spec/core_functions/color/to_space/xyz/xyz.hrx
+++ b/spec/core_functions/color/to_space/xyz/xyz.hrx
@@ -20,33 +20,33 @@ a {
 
 <===>
 ================================================================================
-<===> missing/red/input.scss
+<===> missing/x/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz none 0.2 0.3), xyz)}
 
-<===> missing/red/output.css
+<===> missing/x/output.css
 a {
   b: color(xyz none 0.2 0.3);
 }
 
 <===>
 ================================================================================
-<===> missing/green/input.scss
+<===> missing/y/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz 0.1 none 0.3), xyz)}
 
-<===> missing/green/output.css
+<===> missing/y/output.css
 a {
   b: color(xyz 0.1 none 0.3);
 }
 
 <===>
 ================================================================================
-<===> missing/blue/input.scss
+<===> missing/z/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz 0.1 0.2 none), xyz)}
 
-<===> missing/blue/output.css
+<===> missing/z/output.css
 a {
   b: color(xyz 0.1 0.2 none);
 }

--- a/spec/core_functions/color/to_space/xyz/xyz_d50.hrx
+++ b/spec/core_functions/color/to_space/xyz/xyz_d50.hrx
@@ -86,33 +86,33 @@ a {
 
 <===>
 ================================================================================
-<===> missing/red/input.scss
+<===> missing/x/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz none 0.2 0.3), xyz-d50)}
 
-<===> missing/red/output.css
+<===> missing/x/output.css
 a {
   b: color(xyz-d50 none 0.1929647456 0.2285733227);
 }
 
 <===>
 ================================================================================
-<===> missing/green/input.scss
+<===> missing/y/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz 0.1 none 0.3), xyz-d50)}
 
-<===> missing/green/output.css
+<===> missing/y/output.css
 a {
   b: color(xyz-d50 0.0897352994 none 0.2246379804);
 }
 
 <===>
 ================================================================================
-<===> missing/blue/input.scss
+<===> missing/z/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz 0.1 0.2 none), xyz-d50)}
 
-<===> missing/blue/output.css
+<===> missing/z/output.css
 a {
   b: color(xyz-d50 0.1093823534 0.2010496662 none);
 }

--- a/spec/core_functions/color/to_space/xyz_d50/a98_rgb.hrx
+++ b/spec/core_functions/color/to_space/xyz_d50/a98_rgb.hrx
@@ -20,33 +20,33 @@ a {
 
 <===>
 ================================================================================
-<===> missing/red/input.scss
+<===> missing/x/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 none 0.2 0.3), xyz-d50)}
 
-<===> missing/red/output.css
+<===> missing/x/output.css
 a {
   b: color(xyz-d50 none 0.2 0.3);
 }
 
 <===>
 ================================================================================
-<===> missing/green/input.scss
+<===> missing/y/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 0.1 none 0.3), xyz-d50)}
 
-<===> missing/green/output.css
+<===> missing/y/output.css
 a {
   b: color(xyz-d50 0.1 none 0.3);
 }
 
 <===>
 ================================================================================
-<===> missing/blue/input.scss
+<===> missing/z/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 0.1 0.2 none), xyz-d50)}
 
-<===> missing/blue/output.css
+<===> missing/z/output.css
 a {
   b: color(xyz-d50 0.1 0.2 none);
 }

--- a/spec/core_functions/color/to_space/xyz_d50/display_p3.hrx
+++ b/spec/core_functions/color/to_space/xyz_d50/display_p3.hrx
@@ -86,33 +86,33 @@ a {
 
 <===>
 ================================================================================
-<===> missing/red/input.scss
+<===> missing/x/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 none 0.2 0.3), display-p3)}
 
-<===> missing/red/output.css
+<===> missing/x/output.css
 a {
   b: color(display-p3 none 0.637912978 0.6363418884);
 }
 
 <===>
 ================================================================================
-<===> missing/green/input.scss
+<===> missing/y/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 0.1 none 0.3), display-p3)}
 
-<===> missing/green/output.css
+<===> missing/y/output.css
 a {
   b: color(display-p3 0.3827670965 none 0.655277932);
 }
 
 <===>
 ================================================================================
-<===> missing/blue/input.scss
+<===> missing/z/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 0.1 0.2 none), display-p3)}
 
-<===> missing/blue/output.css
+<===> missing/z/output.css
 a {
   b: color(display-p3 0.2276620199 0.5616123537 none);
 }

--- a/spec/core_functions/color/to_space/xyz_d50/display_p3_linear.hrx
+++ b/spec/core_functions/color/to_space/xyz_d50/display_p3_linear.hrx
@@ -86,33 +86,33 @@ a {
 
 <===>
 ================================================================================
-<===> missing/red/input.scss
+<===> missing/x/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 none 0.2 0.3), display-p3-linear)}
 
-<===> missing/red/output.css
+<===> missing/x/output.css
 a {
   b: color(display-p3-linear none 0.3646052907 0.3626243712);
 }
 
 <===>
 ================================================================================
-<===> missing/green/input.scss
+<===> missing/y/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 0.1 none 0.3), display-p3-linear)}
 
-<===> missing/green/output.css
+<===> missing/y/output.css
 a {
   b: color(display-p3-linear 0.1211093226 none 0.3869207925);
 }
 
 <===>
 ================================================================================
-<===> missing/blue/input.scss
+<===> missing/z/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 0.1 0.2 none), display-p3-linear)}
 
-<===> missing/blue/output.css
+<===> missing/z/output.css
 a {
   b: color(display-p3-linear 0.0423873237 0.2755646016 none);
 }

--- a/spec/core_functions/color/to_space/xyz_d50/hsl.hrx
+++ b/spec/core_functions/color/to_space/xyz_d50/hsl.hrx
@@ -86,33 +86,44 @@ a {
 
 <===>
 ================================================================================
-<===> missing/red/input.scss
+<===> missing/x/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 none 0.2 0.3), hsl)}
 
-<===> missing/red/output.css
+<===> missing/x/output.css
 a {
   b: hsl(359.4153454139, 2475.3715741602%, -2.7790249918%);
 }
 
 <===>
 ================================================================================
-<===> missing/green/input.scss
+<===> missing/y/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 0.1 none 0.3), hsl)}
 
-<===> missing/green/output.css
+<===> missing/y/output.css
 a {
   b: hsl(285.6927471827, 282.9980963007%, 17.9207568387%);
 }
 
 <===>
 ================================================================================
-<===> missing/blue/input.scss
+<===> missing/z/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 0.1 0.2 none), hsl)}
 
-<===> missing/blue/output.css
+<===> missing/z/output.css
 a {
   b: hsl(111.1172729557, 222.5792269318%, 17.6906141138%);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(xyz-d50 none none none), hsl)}
+
+<===> missing/all/output.css
+a {
+  b: hsl(0, 0%, 0%);
 }

--- a/spec/core_functions/color/to_space/xyz_d50/hwb.hrx
+++ b/spec/core_functions/color/to_space/xyz_d50/hwb.hrx
@@ -110,12 +110,12 @@ a {
 
 <===>
 ================================================================================
-<===> missing/red/input.scss
+<===> missing/x/input.scss
 @use "sass:color";
 @use 'core_functions/color/utils';
 @include utils.inspect(color.to-space(color(xyz-d50 none 0.2 0.3), hwb));
 
-<===> missing/red/output.css
+<===> missing/x/output.css
 a {
   value: hsl(359.4153454139, 2475.3715741602%, -2.7790249918%);
   space: hwb;
@@ -124,12 +124,12 @@ a {
 
 <===>
 ================================================================================
-<===> missing/green/input.scss
+<===> missing/y/input.scss
 @use "sass:color";
 @use 'core_functions/color/utils';
 @include utils.inspect(color.to-space(color(xyz-d50 0.1 none 0.3), hwb));
 
-<===> missing/green/output.css
+<===> missing/y/output.css
 a {
   value: hsl(285.6927471827, 282.9980963007%, 17.9207568387%);
   space: hwb;
@@ -138,12 +138,23 @@ a {
 
 <===>
 ================================================================================
-<===> missing/blue/input.scss
+<===> missing/z/input.scss
 @use "sass:color";
 @use 'core_functions/color/utils';
 a {b: color.to-space(color(xyz-d50 0.1 0.2 none), hwb)}
 
-<===> missing/blue/output.css
+<===> missing/z/output.css
 a {
   b: hsl(111.1172729557, 222.5792269318%, 17.6906141138%);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(xyz-d50 none none none), hwb)}
+
+<===> missing/all/output.css
+a {
+  b: red;
 }

--- a/spec/core_functions/color/to_space/xyz_d50/lab.hrx
+++ b/spec/core_functions/color/to_space/xyz_d50/lab.hrx
@@ -86,33 +86,44 @@ a {
 
 <===>
 ================================================================================
-<===> missing/red/input.scss
+<===> missing/x/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 none 0.2 0.3), lab)}
 
-<===> missing/red/output.css
+<===> missing/x/output.css
 a {
   b: lab(51.8372115265% -223.4362565799 -25.7864288134);
 }
 
 <===>
 ================================================================================
-<===> missing/green/input.scss
+<===> missing/y/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 0.1 none 0.3), lab)}
 
-<===> missing/green/output.css
+<===> missing/y/output.css
 a {
   b: lab(0% 165.9436315393 -115.1609314454);
 }
 
 <===>
 ================================================================================
-<===> missing/blue/input.scss
+<===> missing/z/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 0.1 0.2 none), lab)}
 
-<===> missing/blue/output.css
+<===> missing/z/output.css
 a {
   b: lab(51.8372115265% -57.4926250406 89.374502632);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(xyz-d50 none none none), lab)}
+
+<===> missing/all/output.css
+a {
+  b: lab(none none none);
 }

--- a/spec/core_functions/color/to_space/xyz_d50/lch.hrx
+++ b/spec/core_functions/color/to_space/xyz_d50/lch.hrx
@@ -86,33 +86,44 @@ a {
 
 <===>
 ================================================================================
-<===> missing/red/input.scss
+<===> missing/x/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 none 0.2 0.3), lch)}
 
-<===> missing/red/output.css
+<===> missing/x/output.css
 a {
   b: lch(51.8372115265% 224.9193203471 186.5832915139deg);
 }
 
 <===>
 ================================================================================
-<===> missing/green/input.scss
+<===> missing/y/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 0.1 none 0.3), lch)}
 
-<===> missing/green/output.css
+<===> missing/y/output.css
 a {
   b: lch(0% 201.988437738 325.2402722247deg);
 }
 
 <===>
 ================================================================================
-<===> missing/blue/input.scss
+<===> missing/z/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 0.1 0.2 none), lch)}
 
-<===> missing/blue/output.css
+<===> missing/z/output.css
 a {
   b: lch(51.8372115265% 106.2694860003 122.7522732424deg);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(xyz-d50 none none none), lch)}
+
+<===> missing/all/output.css
+a {
+  b: lch(none none none);
 }

--- a/spec/core_functions/color/to_space/xyz_d50/oklab.hrx
+++ b/spec/core_functions/color/to_space/xyz_d50/oklab.hrx
@@ -86,33 +86,44 @@ a {
 
 <===>
 ================================================================================
-<===> missing/red/input.scss
+<===> missing/x/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 none 0.2 0.3), oklab)}
 
-<===> missing/red/output.css
+<===> missing/x/output.css
 a {
   b: oklab(53.7370326457% -0.4814824036 -0.0723240854);
 }
 
 <===>
 ================================================================================
-<===> missing/green/input.scss
+<===> missing/y/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 0.1 none 0.3), oklab)}
 
-<===> missing/green/output.css
+<===> missing/y/output.css
 a {
   b: oklab(29.1994680372% 0.3079984413 -0.28949216);
 }
 
 <===>
 ================================================================================
-<===> missing/blue/input.scss
+<===> missing/z/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 0.1 0.2 none), oklab)}
 
-<===> missing/blue/output.css
+<===> missing/z/output.css
 a {
   b: oklab(56.4114763984% -0.1759135199 0.154183989);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(xyz-d50 none none none), oklab)}
+
+<===> missing/all/output.css
+a {
+  b: oklab(none none none);
 }

--- a/spec/core_functions/color/to_space/xyz_d50/oklch.hrx
+++ b/spec/core_functions/color/to_space/xyz_d50/oklch.hrx
@@ -86,33 +86,44 @@ a {
 
 <===>
 ================================================================================
-<===> missing/red/input.scss
+<===> missing/x/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 none 0.2 0.3), oklch)}
 
-<===> missing/red/output.css
+<===> missing/x/output.css
 a {
   b: oklch(53.7370326457% 0.4868840502 188.5426040002deg);
 }
 
 <===>
 ================================================================================
-<===> missing/green/input.scss
+<===> missing/y/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 0.1 none 0.3), oklch)}
 
-<===> missing/green/output.css
+<===> missing/y/output.css
 a {
   b: oklch(29.1994680372% 0.4226922646 316.7740746587deg);
 }
 
 <===>
 ================================================================================
-<===> missing/blue/input.scss
+<===> missing/z/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 0.1 0.2 none), oklch)}
 
-<===> missing/blue/output.css
+<===> missing/z/output.css
 a {
   b: oklch(56.4114763984% 0.2339193642 138.7662106424deg);
+}
+
+<===>
+================================================================================
+<===> missing/all/input.scss
+@use "sass:color";
+a {b: color.to-space(color(xyz-d50 none none none), oklch)}
+
+<===> missing/all/output.css
+a {
+  b: oklch(none none none);
 }

--- a/spec/core_functions/color/to_space/xyz_d50/prophoto_rgb.hrx
+++ b/spec/core_functions/color/to_space/xyz_d50/prophoto_rgb.hrx
@@ -86,33 +86,33 @@ a {
 
 <===>
 ================================================================================
-<===> missing/red/input.scss
+<===> missing/x/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 none 0.2 0.3), prophoto-rgb)}
 
-<===> missing/red/output.css
+<===> missing/x/output.css
 a {
   b: color(prophoto-rgb none 0.5196499466 0.5700273474);
 }
 
 <===>
 ================================================================================
-<===> missing/green/input.scss
+<===> missing/y/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 0.1 none 0.3), prophoto-rgb)}
 
-<===> missing/green/output.css
+<===> missing/y/output.css
 a {
   b: color(prophoto-rgb 0.3068439327 none 0.5700273474);
 }
 
 <===>
 ================================================================================
-<===> missing/blue/input.scss
+<===> missing/z/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 0.1 0.2 none), prophoto-rgb)}
 
-<===> missing/blue/output.css
+<===> missing/z/output.css
 a {
   b: color(prophoto-rgb 0.251671286 0.4600356682 none);
 }

--- a/spec/core_functions/color/to_space/xyz_d50/rec2020.hrx
+++ b/spec/core_functions/color/to_space/xyz_d50/rec2020.hrx
@@ -86,33 +86,33 @@ a {
 
 <===>
 ================================================================================
-<===> missing/red/input.scss
+<===> missing/x/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 none 0.2 0.3), rec2020)}
 
-<===> missing/red/output.css
+<===> missing/x/output.css
 a {
   b: color(rec2020 none 0.6327456634 0.6559458093);
 }
 
 <===>
 ================================================================================
-<===> missing/green/input.scss
+<===> missing/y/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 0.1 none 0.3), rec2020)}
 
-<===> missing/green/output.css
+<===> missing/y/output.css
 a {
   b: color(rec2020 0.3732526973 none 0.6674970467);
 }
 
 <===>
 ================================================================================
-<===> missing/blue/input.scss
+<===> missing/z/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 0.1 0.2 none), rec2020)}
 
-<===> missing/blue/output.css
+<===> missing/z/output.css
 a {
   b: color(rec2020 0.3597521318 0.5716433477 none);
 }

--- a/spec/core_functions/color/to_space/xyz_d50/rgb.hrx
+++ b/spec/core_functions/color/to_space/xyz_d50/rgb.hrx
@@ -86,33 +86,33 @@ a {
 
 <===>
 ================================================================================
-<===> missing/red/input.scss
+<===> missing/x/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 none 0.2 0.3), rgb)}
 
-<===> missing/red/output.css
+<===> missing/x/output.css
 a {
   b: rgb(0%, 66.0121696941%, 64.6715334456%);
 }
 
 <===>
 ================================================================================
-<===> missing/green/input.scss
+<===> missing/y/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 0.1 none 0.3), rgb)}
 
-<===> missing/green/output.css
+<===> missing/y/output.css
 a {
   b: rgb(44.4495555519%, 0%, 68.636157535%);
 }
 
 <===>
 ================================================================================
-<===> missing/blue/input.scss
+<===> missing/z/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 0.1 0.2 none), rgb)}
 
-<===> missing/blue/output.css
+<===> missing/z/output.css
 a {
   b: hsl(128.9663541465, 142.6286256266%, 23.5199973212%);
 }

--- a/spec/core_functions/color/to_space/xyz_d50/srgb.hrx
+++ b/spec/core_functions/color/to_space/xyz_d50/srgb.hrx
@@ -86,33 +86,33 @@ a {
 
 <===>
 ================================================================================
-<===> missing/red/input.scss
+<===> missing/x/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 none 0.2 0.3), srgb)}
 
-<===> missing/red/output.css
+<===> missing/x/output.css
 a {
   b: color(srgb none 0.6601216969 0.6467153345);
 }
 
 <===>
 ================================================================================
-<===> missing/green/input.scss
+<===> missing/y/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 0.1 none 0.3), srgb)}
 
-<===> missing/green/output.css
+<===> missing/y/output.css
 a {
   b: color(srgb 0.4444955555 none 0.6863615754);
 }
 
 <===>
 ================================================================================
-<===> missing/blue/input.scss
+<===> missing/z/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 0.1 0.2 none), srgb)}
 
-<===> missing/blue/output.css
+<===> missing/z/output.css
 a {
   b: color(srgb -0.1002625161 0.5706624625 none);
 }

--- a/spec/core_functions/color/to_space/xyz_d50/srgb_linear.hrx
+++ b/spec/core_functions/color/to_space/xyz_d50/srgb_linear.hrx
@@ -86,33 +86,33 @@ a {
 
 <===>
 ================================================================================
-<===> missing/red/input.scss
+<===> missing/x/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 none 0.2 0.3), srgb-linear)}
 
-<===> missing/red/output.css
+<===> missing/x/output.css
 a {
   b: color(srgb-linear none 0.3932837375 0.3758204586);
 }
 
 <===>
 ================================================================================
-<===> missing/green/input.scss
+<===> missing/y/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 0.1 none 0.3), srgb-linear)}
 
-<===> missing/green/output.css
+<===> missing/y/output.css
 a {
   b: color(srgb-linear 0.1662149199 none 0.4288113498);
 }
 
 <===>
 ================================================================================
-<===> missing/blue/input.scss
+<===> missing/z/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 0.1 0.2 none), srgb-linear)}
 
-<===> missing/blue/output.css
+<===> missing/z/output.css
 a {
   b: color(srgb-linear -0.0100636143 0.2853713278 none);
 }

--- a/spec/core_functions/color/to_space/xyz_d50/xyz.hrx
+++ b/spec/core_functions/color/to_space/xyz_d50/xyz.hrx
@@ -86,33 +86,33 @@ a {
 
 <===>
 ================================================================================
-<===> missing/red/input.scss
+<===> missing/x/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 none 0.2 0.3), xyz)}
 
-<===> missing/red/output.css
+<===> missing/x/output.css
 a {
   b: color(xyz none 0.208311512 0.395008248);
 }
 
 <===>
 ================================================================================
-<===> missing/green/input.scss
+<===> missing/y/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 0.1 none 0.3), xyz)}
 
-<===> missing/green/output.css
+<===> missing/y/output.css
 a {
   b: color(xyz 0.1145251151 none 0.4003411794);
 }
 
 <===>
 ================================================================================
-<===> missing/blue/input.scss
+<===> missing/z/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 0.1 0.2 none), xyz)}
 
-<===> missing/blue/output.css
+<===> missing/z/output.css
 a {
   b: color(xyz 0.0909276512 0.1991621087 none);
 }

--- a/spec/core_functions/color/to_space/xyz_d50/xyz_d50.hrx
+++ b/spec/core_functions/color/to_space/xyz_d50/xyz_d50.hrx
@@ -86,33 +86,33 @@ a {
 
 <===>
 ================================================================================
-<===> missing/red/input.scss
+<===> missing/x/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 none 0.2 0.3), xyz-d50)}
 
-<===> missing/red/output.css
+<===> missing/x/output.css
 a {
   b: color(xyz-d50 none 0.2 0.3);
 }
 
 <===>
 ================================================================================
-<===> missing/green/input.scss
+<===> missing/y/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 0.1 none 0.3), xyz-d50)}
 
-<===> missing/green/output.css
+<===> missing/y/output.css
 a {
   b: color(xyz-d50 0.1 none 0.3);
 }
 
 <===>
 ================================================================================
-<===> missing/blue/input.scss
+<===> missing/z/input.scss
 @use "sass:color";
 a {b: color.to-space(color(xyz-d50 0.1 0.2 none), xyz-d50)}
 
-<===> missing/blue/output.css
+<===> missing/z/output.css
 a {
   b: color(xyz-d50 0.1 0.2 none);
 }


### PR DESCRIPTION
This also fixes channel names in test names for XYZ color spaces.

See https://github.com/sass/sass/issues/4217
[skip dart-sass]