### PR TITLE
Add a regression test for sass/dart-sass#2848

### DIFF
--- a/spec/css/selector/attribute.hrx
+++ b/spec/css/selector/attribute.hrx
@@ -254,3 +254,25 @@ Error: expected "]".
   |      ^
   '
   input.scss 2:6  root stylesheet
+
+<===>
+================================================================================
+<===> error/indented/opening_only/input.sass
+// Regression test for https://github.com/sass/dart-sass/issues/2848
+[
+
+<===> error/indented/opening_only/error
+WARNING: This selector doesn't have any properties and won't be rendered.
+
+  ,
+2 | [
+  | ^
+  '
+    input.sass 2:1  root stylesheet
+
+Error: Expected identifier.
+  ,
+2 | [
+  |  ^
+  '
+  input.sass 2:2  root stylesheet

--- a/spec/directives/extend/whitespace.hrx
+++ b/spec/directives/extend/whitespace.hrx
@@ -123,12 +123,12 @@ a
   !optional
 
 <===> error/before_optional/sass/error
-Error: Expected newline.
+Error: unrecognized syntax
   ,
-2 |   @extend b
-  |            ^
+3 |   !optional
+  |   ^^^^^^^^^
   '
-  input.sass 2:12  root stylesheet
+  input.sass 3:3  root stylesheet
 
 <===>
 ================================================================================

--- a/spec/libsass-closed-issues/issue_1484.hrx
+++ b/spec/libsass-closed-issues/issue_1484.hrx
@@ -2,7 +2,7 @@
 div {
 
 <===> error
-Error: expected "}".
+Error: expected end of rule.
   ,
 1 | div {
   |      ^

--- a/spec/libsass-closed-issues/issue_1720.hrx
+++ b/spec/libsass-closed-issues/issue_1720.hrx
@@ -4,7 +4,7 @@
 }
 
 <===> error
-Error: expected "}".
+Error: expected end of rule.
   ,
 3 | }
   |  ^

--- a/spec/libsass-closed-issues/issue_2307.hrx
+++ b/spec/libsass-closed-issues/issue_2307.hrx
@@ -3,7 +3,7 @@
 {
 
 <===> error
-Error: expected "}".
+Error: expected end of rule.
   ,
 2 | {
   |  ^

--- a/spec/non_conformant/errors/unicode/report/before.hrx
+++ b/spec/non_conformant/errors/unicode/report/before.hrx
@@ -1,7 +1,7 @@
 <===> input.scss
 öüäöüäöü{a:c
 <===> error
-Error: expected "}".
+Error: expected end of rule.
   ,
 1 | öüäöüäöü{a:c
   |             ^


### PR DESCRIPTION
This crashed Dart Sass's parser because it was injecting a phantom newline into the interpolation, which broke the mapping back to the original document.

[skip dart-sass]